### PR TITLE
Work-order integrations + completeness, orchestrator hooks, audit anchoring & tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,27 @@
+name: Backend tests
+
+on:
+  push:
+    branches: [main]
+    paths: ["backend/**", ".github/workflows/backend-tests.yml"]
+  pull_request:
+    paths: ["backend/**", ".github/workflows/backend-tests.yml"]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependencies
+        # The security/integration logic tests are self-contained (no DB); they
+        # need only the crypto + HTTP libraries plus pytest.
+        run: pip install cryptography httpx pytest pytest-asyncio
+      - name: Run tests
+        run: python -m pytest tests/ -q

--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -339,3 +339,43 @@ async def verify_audit_log_integrity(
         "message": "Audit log chain is intact" if is_valid else "WARNING: Tampering detected in audit logs",
         "timestamp": datetime.utcnow().isoformat()
     }
+
+
+@router.get("/anchors")
+async def list_audit_anchors(
+    limit: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+):
+    """Recent append-only anchors of the request-audit hash-chain head, plus
+    whether the live chain head still matches the most recent anchor.
+
+    The anchors (and their matching log lines) let a records officer confirm
+    the audit trail hasn't been rewritten even against a full-DB attacker: the
+    current head must equal the last anchored head, and each anchor is also in
+    the external log stream."""
+    from app.models import AuditAnchor, RequestAuditLog
+
+    anchors = (await db.execute(
+        select(AuditAnchor).order_by(desc(AuditAnchor.id)).limit(limit)
+    )).scalars().all()
+    live_head = (await db.execute(
+        select(RequestAuditLog.entry_hash)
+        .where(RequestAuditLog.entry_hash.isnot(None))
+        .order_by(desc(RequestAuditLog.id)).limit(1)
+    )).scalar()
+    latest = anchors[0] if anchors else None
+    # Head matches the last anchor, or has legitimately advanced since (more
+    # entries added). A shrinking count or a head that predates the anchor is
+    # the suspicious case.
+    matches = bool(latest and live_head and latest.head_hash == live_head)
+    return {
+        "live_head": live_head,
+        "latest_anchor_head": latest.head_hash if latest else None,
+        "head_matches_latest_anchor": matches,
+        "anchors": [
+            {"id": a.id, "created_at": a.created_at.isoformat() if a.created_at else None,
+             "head_hash": a.head_hash, "entry_count": a.entry_count}
+            for a in anchors
+        ],
+    }

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -351,12 +351,39 @@ async def health_check(
 async def quick_health_check():
     """
     Quick health check for monitoring (no auth required).
-    
+
     Just checks if the API is responding.
     """
+    from app.core.config import get_settings
+    settings = get_settings()
     return {
         "status": "ok",
+        "version": settings.app_version,
         "timestamp": __import__("datetime").datetime.now().isoformat()
+    }
+
+
+@router.get("/version")
+async def version_info(db: AsyncSession = Depends(get_db)):
+    """Build + schema version stamp for the orchestrator/control plane.
+
+    Metadata only (no resident data) — the panel polls this fleet-wide to
+    detect version drift and gate canary rollouts on DB-migration compatibility.
+    """
+    from app.core.config import get_settings
+    from sqlalchemy import text
+    settings = get_settings()
+    db_revision = None
+    try:
+        db_revision = (await db.execute(text("SELECT version_num FROM alembic_version LIMIT 1"))).scalar()
+    except Exception:
+        db_revision = None  # alembic table absent (fresh DB) — panel treats as unmigrated
+    return {
+        "version": settings.app_version,
+        "git_sha": settings.git_sha,
+        "app_name": settings.app_name,
+        "managed_mode": settings.managed_mode,
+        "db_revision": db_revision,
     }
 
 

--- a/backend/app/api/integrations.py
+++ b/backend/app/api/integrations.py
@@ -308,6 +308,32 @@ async def trigger_asset_sync(
     return {"message": "Asset sync started", "platform": integration.platform}
 
 
+@router.post("/requests/{request_id}/refresh")
+@limiter.limit("20/minute")
+async def refresh_request_work_order(
+    request: Request,
+    request_id: str,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_staff),
+):
+    """Pull the latest work-order state (assignment, schedule, status,
+    resolution) for a single request from every platform it's linked to.
+    Staff-triggered on-demand refresh — complements the scheduled pull."""
+    sr = (await db.execute(
+        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+    )).scalar_one_or_none()
+    if not sr:
+        raise HTTPException(status_code=404, detail="Request not found")
+    links = (await db.execute(
+        select(IntegrationLink).where(IntegrationLink.service_request_id == sr.id)
+    )).scalars().all()
+    if not links:
+        return {"ok": False, "detail": "This request isn't linked to any external platform."}
+    from app.tasks.integrations import refresh_request_from_integrations
+    refresh_request_from_integrations.delay(sr.id)
+    return {"ok": True, "detail": "Refreshing the latest work-order status — updates appear on the request in a moment."}
+
+
 @router.get("/{integration_id}/logs")
 async def get_sync_logs(
     integration_id: int,

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1441,9 +1441,23 @@ async def get_heatmap_data(
 # ============ System Update ============
 
 
+def _reject_if_managed():
+    """In state-hosted (managed) mode, in-app self-update is disabled — upgrades
+    come only from the orchestrator (publish image → panel rolls out). This also
+    removes the biggest infra risk (git pull + docker compose via a mounted
+    Docker socket) from the hosted fleet."""
+    from app.core.config import get_settings
+    if get_settings().managed_mode:
+        raise HTTPException(
+            status_code=403,
+            detail="Updates are managed by your state's hosting platform and can't be triggered from here.",
+        )
+
+
 @router.post("/update")
 async def update_system(_: User = Depends(get_current_admin)):
     """Pull updates from GitHub (admin only). Code changes reload automatically."""
+    _reject_if_managed()
     try:
         # Get the project root
         project_root = os.environ.get("PROJECT_ROOT", "/project")
@@ -1783,6 +1797,7 @@ async def switch_version(
     6. Health check the new deployment
     7. Automatic rollback on any failure
     """
+    _reject_if_managed()
     import httpx
     from datetime import datetime
     

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -21,6 +21,12 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,
     # Celery Beat Schedule
     beat_schedule={
+        # Daily anchor of the audit hash-chain head (tamper-evidence beyond the DB)
+        "daily-audit-anchor": {
+            "task": "app.tasks.service_requests.anchor_audit_chain",
+            "schedule": 60 * 60 * 24,  # Every 24 hours
+            "options": {"queue": "default"}
+        },
         # Daily retention enforcement at 1:00 AM UTC (before backup)
         "daily-retention-enforcement": {
             "task": "app.tasks.service_requests.enforce_retention_policy",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,9 +38,19 @@ class Settings(BaseSettings):
     # Application
     app_name: str = "Township 311"
     debug: bool = False
-    
+    # Build/version stamp (set by the image build; surfaced on /health for the
+    # orchestrator to detect drift and gate rollouts).
+    app_version: str = "dev"
+    git_sha: str = "unknown"
+
     # Demo mode - single shared demo environment
     demo_mode: bool = False
+
+    # Managed (state-hosted) mode: when true, this instance is run by an
+    # orchestrator/control plane. Platform-owned settings (infra, backups,
+    # domain) and the in-app self-update are locked; the panel manages them.
+    # Off = fully self-contained single-tenant behavior (unchanged default).
+    managed_mode: bool = False
 
     class Config:
         env_file = ".env"

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -167,6 +167,7 @@ async def _run_schema_migrations():
         "CREATE INDEX IF NOT EXISTS ix_request_comments_external_ref ON request_comments (external_ref)",
         "ALTER TABLE integration_links ADD COLUMN IF NOT EXISTS pushed_comment_ids JSON DEFAULT '[]'",
         "ALTER TABLE integration_links ADD COLUMN IF NOT EXISTS documents_pushed BOOLEAN DEFAULT FALSE",
+        "ALTER TABLE integration_links ADD COLUMN IF NOT EXISTS documents_pushed_count INTEGER DEFAULT 0",
         # Immutable/tamper-evident request audit log hash chain (added 2026-07-02)
         "ALTER TABLE request_audit_logs ADD COLUMN IF NOT EXISTS previous_hash VARCHAR(64)",
         "ALTER TABLE request_audit_logs ADD COLUMN IF NOT EXISTS entry_hash VARCHAR(64)",

--- a/backend/app/integrations/base.py
+++ b/backend/app/integrations/base.py
@@ -183,7 +183,8 @@ class ConnectorError(Exception):
 
 @dataclass
 class ExternalRecord:
-    """Normalized view of a service request as it exists on an external platform."""
+    """Normalized view of a service request / work order as it exists on an
+    external platform."""
     external_id: str
     status: Optional[str] = None          # Normalized: open, in_progress, closed
     raw_status: Optional[str] = None      # The platform's native status string
@@ -196,6 +197,18 @@ class ExternalRecord:
     address: Optional[str] = None
     lat: Optional[float] = None
     long: Optional[float] = None
+    # ---- Work-order fields (capability "work_orders") ----
+    # A work-order management system (Accela, Cityworks, Edmunds MCSJ, SDL, …)
+    # owns dispatch: who it's assigned to, when it's scheduled/due, and how it
+    # was resolved. These flow back into Pinpoint as timeline updates so staff
+    # see the full work-order lifecycle without leaving the request.
+    work_order_id: Optional[str] = None       # vendor's WO number (distinct from record id)
+    priority: Optional[str] = None            # vendor priority label/number
+    assigned_to: Optional[str] = None         # crew / technician / user
+    assigned_department: Optional[str] = None # division / department / queue
+    scheduled_datetime: Optional[datetime] = None
+    due_datetime: Optional[datetime] = None
+    resolution: Optional[str] = None          # how the work order was closed out
 
 
 @dataclass
@@ -219,7 +232,12 @@ class BaseConnector:
     """Abstract base for platform connectors."""
 
     platform: str = "base"
-    # What this connector supports: subset of {"push", "push_status", "pull", "test"}
+    # What this connector supports: subset of
+    #   {"push", "push_status", "pull", "comments", "documents", "assets",
+    #    "work_orders", "test"}
+    # "work_orders" means pull_updates / fetch_record populate the work-order
+    # fields on ExternalRecord (assignment, schedule, resolution) and push
+    # carries assignment/priority outbound.
     capabilities = {"test"}
 
     def __init__(self, config: Dict[str, Any], credentials: Dict[str, Any]):

--- a/backend/app/integrations/connectors/accela.py
+++ b/backend/app/integrations/connectors/accela.py
@@ -32,7 +32,7 @@ DEFAULT_AUTH_BASE = "https://auth.accela.com"
 
 class AccelaConnector(BaseConnector):
     platform = "accela"
-    capabilities = {"test", "push", "push_status", "pull", "comments", "documents", "assets"}
+    capabilities = {"test", "push", "push_status", "pull", "comments", "documents", "assets", "work_orders"}
 
     DEFAULT_STATUS_MAP_OUT = {"open": "Open", "in_progress": "In Progress", "closed": "Closed"}
     DEFAULT_STATUS_MAP_IN = {
@@ -91,12 +91,32 @@ class AccelaConnector(BaseConnector):
                 updated_dt = datetime.fromisoformat(str(updated).replace("Z", "+00:00"))
             except ValueError:
                 pass  # unparseable vendor timestamp — leave as None
+
+        def _text(v):
+            return v.get("text") if isinstance(v, dict) else (str(v) if v is not None else None)
+
+        def _accela_dt(v):
+            if not v:
+                return None
+            try:
+                return datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+            except ValueError:
+                return None
+
         return ExternalRecord(
             external_id=str(item.get("id") or item.get("customId") or ""),
             status=self.map_status_in(raw_status),
             raw_status=raw_status,
             status_notes=item.get("statusReason", {}).get("text") if isinstance(item.get("statusReason"), dict) else None,
             updated_at=updated_dt,
+            # Work-order fields from the Accela record
+            work_order_id=str(item.get("customId")) if item.get("customId") else None,
+            priority=_text(item.get("priority")),
+            assigned_to=_text(item.get("assignedUser")) or _text(item.get("assignedTo")),
+            assigned_department=_text(item.get("assignedToDepartment")) or _text(item.get("assignedDepartment")),
+            scheduled_datetime=_accela_dt(item.get("scheduledDate") or item.get("assignedDate")),
+            due_datetime=_accela_dt(item.get("dueDate") or item.get("estimatedDueDate")),
+            resolution=_text(item.get("statusReason")) if self.map_status_in(raw_status) == "closed" else None,
             raw=item,
         )
 

--- a/backend/app/integrations/connectors/generic_rest.py
+++ b/backend/app/integrations/connectors/generic_rest.py
@@ -49,19 +49,30 @@ DEFAULT_FIELD_MAP = {
     "phone": "phone",
     "media_urls": "attachments",
     "requested_datetime": "submitted_at",
+    # Work-order fields carried outbound so a WOMS can open a proper work order
+    "priority": "priority",
+    "assigned_to": "assigned_to",
+    "assigned_department": "department",
+    "due_date": "due_date",
 }
 
 
 class GenericRestConnector(BaseConnector):
     platform = "generic_rest"
-    capabilities = {"test", "push", "push_status", "pull", "comments", "documents", "assets"}
+    capabilities = {"test", "push", "push_status", "pull", "comments", "documents", "assets", "work_orders"}
 
     DEFAULT_STATUS_MAP_OUT = {"open": "open", "in_progress": "in_progress", "closed": "closed"}
     DEFAULT_STATUS_MAP_IN = {
-        "open": "open", "new": "open", "submitted": "open", "received": "open",
+        "open": "open", "new": "open", "submitted": "open", "received": "open", "created": "open",
+        # Work-order lifecycle states → in progress
         "in_progress": "in_progress", "in progress": "in_progress",
         "assigned": "in_progress", "acknowledged": "in_progress", "pending": "in_progress",
+        "scheduled": "in_progress", "dispatched": "in_progress", "en_route": "in_progress",
+        "en route": "in_progress", "on_hold": "in_progress", "on hold": "in_progress",
+        "active": "in_progress", "started": "in_progress", "working": "in_progress",
+        # Terminal states → closed
         "closed": "closed", "resolved": "closed", "complete": "closed", "completed": "closed",
+        "cancelled": "closed", "canceled": "closed", "done": "closed", "finished": "closed",
     }
 
     @property
@@ -114,6 +125,22 @@ class GenericRestConnector(BaseConnector):
             return item.get(field_map.get(ours) or fallback)
         lat = theirs("lat", "latitude")
         lng = theirs("long", "longitude")
+
+        # Work-order fields are read from dedicated, per-vendor field-name keys
+        # (distinct from the outbound field_map) so a WOMS's own column names map cleanly.
+        def _wo_str(cfg_key: str, default_field: str):
+            v = item.get(self.config.get(cfg_key, default_field))
+            return str(v) if v is not None else None
+
+        def _wo_dt(cfg_key: str, default_field: str):
+            v = item.get(self.config.get(cfg_key, default_field))
+            if not v:
+                return None
+            try:
+                return datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+            except ValueError:
+                return None
+
         return ExternalRecord(
             external_id=str(item.get(id_field) or ""),
             status=self.map_status_in(raw_status) if raw_status is not None else None,
@@ -124,6 +151,14 @@ class GenericRestConnector(BaseConnector):
             address=theirs("address", "address"),
             lat=float(lat) if lat is not None else None,
             long=float(lng) if lng is not None else None,
+            # Work-order fields (configurable vendor field names)
+            work_order_id=_wo_str("work_order_id_field", "work_order_id"),
+            priority=_wo_str("priority_field", "priority"),
+            assigned_to=_wo_str("assigned_to_field", "assigned_to"),
+            assigned_department=_wo_str("assigned_department_field", "department"),
+            scheduled_datetime=_wo_dt("scheduled_date_field", "scheduled_date"),
+            due_datetime=_wo_dt("due_date_field", "due_date"),
+            resolution=_wo_str("resolution_field", "resolution"),
             raw=item,
         )
 

--- a/backend/app/integrations/connectors/vendors.py
+++ b/backend/app/integrations/connectors/vendors.py
@@ -107,3 +107,41 @@ class PolimorphicConnector(GenericRestConnector):
     def __init__(self, config, credentials):
         config = {"auth_style": "bearer", **(config or {})}
         super().__init__(config, credentials)
+
+
+class CityworksConnector(GenericRestConnector):
+    """Trimble Cityworks — the dominant public-works work-order & asset
+    management system (AMS/PLL).
+
+    Cityworks exposes a token-based REST API. Reports become Cityworks work
+    orders; the connector maps the work-order lifecycle (assignment, schedule,
+    status, resolution) back into Pinpoint. Ships with Cityworks-oriented field
+    defaults that remain configurable to your instance — run the connection
+    check to confirm your endpoints.
+    """
+    platform = "cityworks"
+
+    def __init__(self, config, credentials):
+        config = {
+            "auth_style": "bearer",
+            "field_map": {
+                "service_request_id": "SourceId",
+                "description": "Description",
+                "address": "Address",
+                "priority": "Priority",
+                "assigned_to": "AssignedTo",
+                "assigned_department": "WorkOrderCategory",
+                "due_date": "ProjectedFinishDate",
+            },
+            "id_field": "WorkOrderId",
+            "status_field": "Status",
+            "work_order_id_field": "WorkOrderId",
+            "priority_field": "Priority",
+            "assigned_to_field": "AssignedTo",
+            "assigned_department_field": "WorkOrderCategory",
+            "scheduled_date_field": "ScheduledDate",
+            "due_date_field": "ProjectedFinishDate",
+            "resolution_field": "ClosedComments",
+            **(config or {}),
+        }
+        super().__init__(config, credentials)

--- a/backend/app/integrations/registry.py
+++ b/backend/app/integrations/registry.py
@@ -12,6 +12,7 @@ from app.integrations.connectors.accela import AccelaConnector
 from app.integrations.connectors.open311 import Open311Connector
 from app.integrations.connectors.seeclickfix import SeeClickFixConnector
 from app.integrations.connectors.vendors import (
+    CityworksConnector,
     EdmundsConnector,
     FastTrackGovConnector,
     GovPilotConnector,
@@ -33,7 +34,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "sandbox",
         "docs_url": "https://github.com/Pinpoint-311/Pinpoint-311/blob/main/docs/INTEGRATIONS.md",
         "description": "A pretend town system built into Pinpoint. Connect it to watch reports, photos, comments, status changes, and assets flow both ways — then disconnect when you're done.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [],
         "config_fields": [
             # NOTE: no base_url field — the sandbox address is pinned server-side
@@ -50,7 +51,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "public_api",
         "docs_url": "https://developer.accela.com",
         "description": "Full two-way sync with Accela Civic Platform via the Construct API v4: records, status, comments, photo attachments, and asset inventory sync into Pinpoint map layers.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [
             {"key": "client_id", "label": "Client ID", "secret": False},
             {"key": "client_secret", "label": "Client Secret", "secret": True},
@@ -110,7 +111,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "partner_api",
         "docs_url": "https://www.spatialdatalogic.com",
         "description": "Prebuilt two-way connector for SDL's customer REST API: requests, status, comments, photo attachments, and asset sync. Ships with sensible endpoint defaults that are configurable to your tenant — run the connection check to confirm your endpoints.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [
             {"key": "api_key", "label": "SDL API Key", "secret": True},
         ],
@@ -126,7 +127,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "partner_api",
         "docs_url": "https://edmundsgovtech.com",
         "description": "Prebuilt two-way connector for MCSJ work orders via the Edmunds web-service interface: requests, status, comments, attachments, and asset sync. Endpoint paths are configurable to your tenant — run the connection check to confirm.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [
             {"key": "username", "label": "Service Username", "secret": False},
             {"key": "password", "label": "Service Password", "secret": True},
@@ -143,7 +144,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "partner_api",
         "docs_url": "https://www.govpilot.com",
         "description": "Prebuilt two-way connector for GovPilot's report-a-concern and records modules: requests, status, comments, attachments, and GIS asset sync. Endpoint paths are configurable to your account — run the connection check to confirm.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [
             {"key": "api_key", "label": "GovPilot API Key", "secret": True},
         ],
@@ -159,7 +160,7 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
         "integration_mode": "partner_api",
         "docs_url": "https://www.fasttrackgov.com",
         "description": "Prebuilt two-way connector for FastTrackGov cases through the customer API gateway: requests, status, comments, attachments, and asset sync. Endpoint paths are configurable to your gateway — run the connection check to confirm.",
-        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "test"],
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
         "credential_fields": [
             {"key": "api_key", "label": "Subscription Key", "secret": True},
         ],
@@ -183,6 +184,22 @@ PLATFORM_CATALOG: Dict[str, Dict[str, Any]] = {
             {"key": "base_url", "label": "Workspace API URL", "placeholder": "https://api.polimorphic.com/workspaces/yourtown", "required": True},
         ],
         "setup_notes": "Give Polimorphic your Pinpoint inbound webhook URL (shown after connecting) so their AI intake can create requests here, and paste their workspace endpoint + token for outbound sync.",
+    },
+    "cityworks": {
+        "name": "Trimble Cityworks",
+        "vendor": "Trimble (Cityworks AMS / PLL)",
+        "category": "Public works — work order & asset management",
+        "integration_mode": "partner_api",
+        "docs_url": "https://www.cityworks.com",
+        "description": "Prebuilt work-order connector for Trimble Cityworks: resident reports become Cityworks work orders, and the full work-order lifecycle — crew assignment, scheduled/due dates, status, and closeout resolution — syncs back onto the request. Ships with Cityworks field defaults that are configurable to your instance; run the connection check to confirm your endpoints.",
+        "capabilities": ["push", "push_status", "pull", "comments", "documents", "assets", "work_orders", "test"],
+        "credential_fields": [
+            {"key": "api_key", "label": "Cityworks API Token", "secret": True},
+        ],
+        "config_fields": [
+            {"key": "base_url", "label": "Cityworks API Base URL", "placeholder": "https://cityworks.yourtown.gov/api", "required": True},
+        ],
+        "setup_notes": "Request a Cityworks REST API token from your Cityworks administrator. The connector maps Cityworks work-order fields (WorkOrderId, AssignedTo, Status, ScheduledDate) by default; these are configurable if your instance differs.",
     },
     "open311": {
         "name": "Generic Open311",
@@ -376,6 +393,22 @@ CLERK_GUIDES: Dict[str, Dict[str, Any]] = {
         },
         "recommended_sync_direction": "bidirectional",
     },
+    "cityworks": {
+        "plain_summary": "Reports here become Cityworks work orders. When your crews assign, schedule, and complete the work order in Cityworks, that progress shows up right on the request here.",
+        "what_you_need": [
+            "A Cityworks API token and your Cityworks web address — your Cityworks administrator can provide both",
+        ],
+        "vendor_ask": {
+            "to_hint": "Your Cityworks administrator or Trimble support",
+            "subject": "API access for our 311 system (Pinpoint 311)",
+            "body": "Hello,\n\nWe use Cityworks and are connecting our resident request system (Pinpoint 311) so resident reports become Cityworks work orders automatically and the work-order status flows back.\n\nCould you please send us:\n1. Our Cityworks REST API base URL\n2. An API token with permission to create and read work orders\n3. Any notes if our work-order field names differ from the Cityworks defaults\n\nThank you!",
+        },
+        "field_help": {
+            "api_key": "The Cityworks API token from your administrator.",
+            "base_url": "Paste your Cityworks web address exactly, e.g. https://cityworks.yourtown.gov/api.",
+        },
+        "recommended_sync_direction": "bidirectional",
+    },
     "open311": {
         "plain_summary": "Connects to any system that speaks the Open311 standard — a fallback for vendors not listed above.",
         "what_you_need": [
@@ -411,6 +444,7 @@ _CONNECTOR_CLASSES = {
     "govpilot": GovPilotConnector,
     "fasttrackgov": FastTrackGovConnector,
     "polimorphic": PolimorphicConnector,
+    "cityworks": CityworksConnector,
     "open311": Open311Connector,
 }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -351,6 +351,23 @@ class RequestAuditLog(Base):
     service_request = relationship("ServiceRequest", backref="audit_logs")
 
 
+class AuditAnchor(Base):
+    """Append-only anchor of the request-audit hash-chain head.
+
+    The HMAC chain detects tampering *within* the DB, but an attacker with full
+    DB write access could rewrite the chain and re-anchor it. Periodically
+    recording the chain head here AND emitting it to the application log (which
+    ships to external aggregation in hosted mode) means the head at each point
+    in time also lives outside this table — so a silent full-history rewrite
+    would have to defeat the external log too. Never updated or deleted."""
+    __tablename__ = "audit_anchors"
+
+    id = Column(Integer, primary_key=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), default=datetime.utcnow)
+    head_hash = Column(String(64))   # latest RequestAuditLog.entry_hash at anchor time
+    entry_count = Column(Integer)    # number of hashed entries at anchor time
+
+
 def _canonical_request_audit(action, old_value, new_value, actor_type,
                              actor_name, created_at, extra_data, previous_hash) -> str:
     """Deterministic serialization of a request-audit row for hashing."""
@@ -725,6 +742,9 @@ class IntegrationLink(Base):
     pushed_comment_ids = Column(JSON, default=list)
     # Whether local media/documents were uploaded to the external record
     documents_pushed = Column(Boolean, default=False)
+    # How many media items have been pushed — lets photos added after the
+    # initial push sync on a later run (push only media beyond this count).
+    documents_pushed_count = Column(Integer, default=0)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/tasks/integrations.py
+++ b/backend/app/tasks/integrations.py
@@ -149,42 +149,77 @@ async def _apply_work_order_fields(db, sr, record, integration) -> bool:
     return True
 
 
-def _decode_media(sr: ServiceRequest, max_items: int = 3):
-    """Extract embedded base64 photos as (filename, bytes, content_type) tuples."""
+_MAX_MEDIA = 3
+_MAX_MEDIA_BYTES = 15 * 1024 * 1024  # 15 MB per photo
+
+
+async def _decode_media(sr: ServiceRequest, max_items: int = _MAX_MEDIA):
+    """Resolve a request's photos to (filename, bytes, content_type) tuples.
+
+    Handles both embedded base64 data-URIs and http(s)-hosted images — the
+    latter are downloaded (SSRF-guarded, size-capped) so an externally-hosted
+    photo actually attaches to the work order instead of being skipped."""
+    from app.integrations.base import _assert_public_url, HTTP_TIMEOUT
+    import httpx
+
     documents = []
     for i, url in enumerate((sr.media_urls or [])[:max_items]):
         if not isinstance(url, str):
             continue
         match = _DATA_URI_RE.match(url)
-        if not match:
+        if match:
+            mime, b64 = match.groups()
+            try:
+                content = base64.b64decode(b64)
+            except Exception:
+                continue
+            ext = _EXT_BY_MIME.get(mime, "bin")
+            documents.append((f"{sr.service_request_id}-photo-{i + 1}.{ext}", content, mime))
             continue
-        mime, b64 = match.groups()
-        try:
-            content = base64.b64decode(b64)
-        except Exception:
-            continue
-        ext = _EXT_BY_MIME.get(mime, "bin")
-        documents.append((f"{sr.service_request_id}-photo-{i + 1}.{ext}", content, mime))
+        if url.startswith(("http://", "https://")):
+            try:
+                _assert_public_url(url)
+                async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, follow_redirects=False) as client:
+                    resp = await client.get(url)
+                    resp.raise_for_status()
+                    content = resp.content
+                    if not content or len(content) > _MAX_MEDIA_BYTES:
+                        continue
+                    mime = (resp.headers.get("content-type") or "application/octet-stream").split(";")[0].strip()
+                    if not mime.startswith("image/"):
+                        continue
+                    ext = _EXT_BY_MIME.get(mime, "bin")
+                    documents.append((f"{sr.service_request_id}-photo-{i + 1}.{ext}", content, mime))
+            except Exception as e:
+                logger.debug(f"[Integrations] Could not fetch hosted photo for {sr.service_request_id}: {e}")
+                continue
     return documents
 
 
 async def _push_documents(db, connector, integration, link, sr):
-    """Upload the request's embedded photos to the linked external record."""
-    if "documents" not in connector.capabilities or link.documents_pushed:
+    """Upload any not-yet-pushed photos to the linked external record. Tracks a
+    per-link count so photos added after the initial push sync on a later run
+    (e.g. on the next status change)."""
+    if "documents" not in connector.capabilities:
         return
-    documents = _decode_media(sr)
-    if not documents:
+    already = link.documents_pushed_count or 0
+    documents = await _decode_media(sr)
+    new_docs = documents[already:]
+    if not new_docs:
         link.documents_pushed = True
         return
     pushed = 0
     try:
-        for filename, content, mime in documents:
+        for filename, content, mime in new_docs:
             await connector.push_document(link.external_id, filename, content, mime)
             pushed += 1
+        link.documents_pushed_count = already + pushed
         link.documents_pushed = True
         await _log(db, integration.id, "push_documents", "success",
                    f"{sr.service_request_id}: {pushed} photo(s) attached", pushed)
     except Exception as e:
+        # Persist however many succeeded so a retry doesn't re-upload them.
+        link.documents_pushed_count = already + pushed
         await _log(db, integration.id, "push_documents", "error",
                    f"{sr.service_request_id}: {e} ({pushed} uploaded before failure)")
         logger.warning(f"[Integrations] Document push to {integration.platform} failed: {e}")
@@ -360,6 +395,8 @@ def push_status_to_integrations(self, request_id: int, notes: str = None):
                     link.sync_error = None
                     await _log(db, integration.id, "push_status", "success",
                                f"{sr.service_request_id} -> {sr.status}", 1)
+                    # Attach any photos added since the last push (idempotent).
+                    await _push_documents(db, connector, integration, link, sr)
                 except Exception as e:
                     link.sync_error = str(e)[:1000]
                     await _log(db, integration.id, "push_status", "error",

--- a/backend/app/tasks/integrations.py
+++ b/backend/app/tasks/integrations.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 import re
 from datetime import datetime
+from typing import Optional
 
 from sqlalchemy import select
 
@@ -54,9 +55,11 @@ _DATA_URI_RE = re.compile(r"^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$", re.DOTA
 _EXT_BY_MIME = {"image/jpeg": "jpg", "image/png": "png", "image/webp": "webp", "image/gif": "gif"}
 
 
-def _build_payload(sr: ServiceRequest, config: dict) -> dict:
+def _build_payload(sr: ServiceRequest, config: dict, dept_name: Optional[str] = None) -> dict:
     """Normalized outbound payload. PII is only included when the integration
-    is explicitly configured to share it (config.share_pii)."""
+    is explicitly configured to share it (config.share_pii). Work-order fields
+    (priority, assignment, due date) are carried so a work-order management
+    system can open a properly-routed work order."""
     payload = {
         "service_request_id": sr.service_request_id,
         "service_code": sr.service_code,
@@ -72,7 +75,11 @@ def _build_payload(sr: ServiceRequest, config: dict) -> dict:
         "media_urls": [u for u in (sr.media_urls or []) if isinstance(u, str) and u.startswith("http")],
         "matched_asset": sr.matched_asset,
         "custom_fields": sr.custom_fields,
-        "priority": sr.manual_priority_score,
+        # Work-order routing fields
+        "priority": sr.manual_priority_score if sr.manual_priority_score is not None else sr.priority,
+        "assigned_to": sr.assigned_to,
+        "assigned_department": dept_name,
+        "due_date": sr.due_datetime.isoformat() if getattr(sr, "due_datetime", None) else None,
     }
     if _flag(config, "share_pii"):
         payload.update({
@@ -82,6 +89,64 @@ def _build_payload(sr: ServiceRequest, config: dict) -> dict:
             "phone": sr.phone,
         })
     return payload
+
+
+async def _dept_name(db, sr: ServiceRequest) -> Optional[str]:
+    """Resolve the assigned department's name for the outbound payload without
+    relying on a lazy relationship load (which errors under the async engine)."""
+    if not sr.assigned_department_id:
+        return None
+    from app.models import Department
+    dept = (await db.execute(
+        select(Department).where(Department.id == sr.assigned_department_id)
+    )).scalar_one_or_none()
+    return dept.name if dept else None
+
+
+async def _apply_work_order_fields(db, sr, record, integration) -> bool:
+    """Reflect a work-order update from the vendor into Pinpoint as an internal
+    timeline comment (and fill assignment if we don't have one locally), without
+    clobbering staff-owned fields. Returns True if anything was recorded."""
+    bits = []
+    if record.work_order_id:
+        bits.append(f"work order {record.work_order_id}")
+    if record.assigned_department:
+        bits.append(f"dept: {record.assigned_department}")
+    if record.assigned_to:
+        bits.append(f"assigned to: {record.assigned_to}")
+    if record.scheduled_datetime:
+        bits.append(f"scheduled: {record.scheduled_datetime.date().isoformat()}")
+    if record.due_datetime:
+        bits.append(f"due: {record.due_datetime.date().isoformat()}")
+    if record.priority:
+        bits.append(f"priority: {record.priority}")
+    if record.resolution:
+        bits.append(f"resolution: {record.resolution}")
+    if not bits:
+        return False
+
+    # Fill local assignment only if empty — never overwrite a staff assignment.
+    if record.assigned_to and not sr.assigned_to:
+        sr.assigned_to = record.assigned_to[:100]
+
+    from app.models import RequestComment
+    summary = f"[{integration.display_name}] Work order update — " + "; ".join(bits)
+    # De-dupe: skip if the most recent integration note is identical.
+    last = (await db.execute(
+        select(RequestComment).where(
+            RequestComment.service_request_id == sr.id,
+            RequestComment.username == integration.display_name,
+        ).order_by(RequestComment.id.desc()).limit(1)
+    )).scalar_one_or_none()
+    if last and last.content == summary:
+        return False
+    db.add(RequestComment(
+        service_request_id=sr.id,
+        username=integration.display_name,
+        content=summary,
+        visibility="internal",
+    ))
+    return True
 
 
 def _decode_media(sr: ServiceRequest, max_items: int = 3):
@@ -234,7 +299,9 @@ def push_request_to_integrations(self, request_id: int):
                     )
                     if "push" not in connector.capabilities:
                         continue
-                    record = await connector.push_request(_build_payload(sr, integration.config or {}))
+                    record = await connector.push_request(
+                        _build_payload(sr, integration.config or {}, await _dept_name(db, sr))
+                    )
                     link = IntegrationLink(
                         integration_id=integration.id,
                         service_request_id=sr.id,
@@ -345,20 +412,32 @@ def pull_integration_updates():
                         link.last_pulled_at = datetime.utcnow()
                         if record.raw_status and record.raw_status != link.external_status:
                             link.external_status = record.raw_status
-                        if not record.status:
-                            continue
                         sr = (await db.execute(
                             select(ServiceRequest).where(ServiceRequest.id == link.service_request_id)
                         )).scalar_one_or_none()
-                        if not sr or sr.status == record.status:
+                        if not sr:
+                            continue
+
+                        # Reflect work-order fields (assignment/schedule/
+                        # resolution) as an internal timeline note — these often
+                        # change without a status change, so do it first.
+                        if await _apply_work_order_fields(db, sr, record, integration):
+                            updated += 1
+
+                        # Status change (if any)
+                        if not record.status or sr.status == record.status:
                             continue
                         old_status = sr.status
                         sr.status = record.status
                         sr.updated_datetime = datetime.utcnow()
                         if record.status == "closed":
                             sr.closed_datetime = datetime.utcnow()
-                            if record.status_notes:
+                            if record.resolution and not sr.completion_message:
+                                sr.completion_message = record.resolution
+                            elif record.status_notes:
                                 sr.completion_message = record.status_notes
+                            if not sr.closed_substatus:
+                                sr.closed_substatus = "resolved"
                         db.add(RequestAuditLog(
                             service_request_id=sr.id,
                             action="status_change",
@@ -388,6 +467,71 @@ def pull_integration_updates():
             await db.commit()
 
     run_async(_pull())
+
+
+@celery_app.task(bind=True, max_retries=3, default_retry_delay=60)
+def refresh_request_from_integrations(self, request_id: int):
+    """On-demand: pull the latest work-order state for ONE request from each
+    platform it's linked to (uses the connector's fetch_record). Lets staff hit
+    "Refresh work order" and see current assignment/schedule/status without
+    waiting for the scheduled pull. Returns a small summary dict."""
+    from app.integrations import build_connector
+
+    async def _refresh():
+        applied = 0
+        async with SessionLocal() as db:
+            sr = (await db.execute(
+                select(ServiceRequest).where(ServiceRequest.id == request_id)
+            )).scalar_one_or_none()
+            if not sr:
+                return {"ok": False, "detail": "Request not found"}
+
+            links = (await db.execute(
+                select(IntegrationLink).where(IntegrationLink.service_request_id == sr.id)
+            )).scalars().all()
+            for link in links:
+                integration = (await db.execute(
+                    select(IntegrationConfig).where(
+                        IntegrationConfig.id == link.integration_id,
+                        IntegrationConfig.enabled == True,  # noqa: E712
+                    )
+                )).scalar_one_or_none()
+                if not integration:
+                    continue
+                try:
+                    connector = build_connector(
+                        integration.platform, integration.config or {}, integration.credentials
+                    )
+                    record = await connector.fetch_record(link.external_id)
+                    if not record:
+                        continue
+                    if record.raw_status and record.raw_status != link.external_status:
+                        link.external_status = record.raw_status
+                    link.last_pulled_at = datetime.utcnow()
+                    if await _apply_work_order_fields(db, sr, record, integration):
+                        applied += 1
+                    if record.status and record.status != sr.status:
+                        old = sr.status
+                        sr.status = record.status
+                        sr.updated_datetime = datetime.utcnow()
+                        if record.status == "closed":
+                            sr.closed_datetime = datetime.utcnow()
+                            if record.resolution and not sr.completion_message:
+                                sr.completion_message = record.resolution
+                            if not sr.closed_substatus:
+                                sr.closed_substatus = "resolved"
+                        db.add(RequestAuditLog(
+                            service_request_id=sr.id, action="status_change",
+                            old_value=old, new_value=record.status,
+                            actor_type="integration", actor_name=integration.display_name,
+                        ))
+                        applied += 1
+                except Exception as e:
+                    logger.warning(f"[Integrations] Refresh from {integration.platform} failed: {e}")
+            await db.commit()
+        return {"ok": True, "applied": applied}
+
+    return run_async(_refresh())
 
 
 @celery_app.task(bind=True, max_retries=3, default_retry_delay=60)

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -1078,3 +1078,46 @@ def send_weekly_digest():
         logger.error(f"[Weekly Digest] Task failed: {e}")
         return {"status": "error", "error": str(e)}
 
+
+
+@celery_app.task(bind=True)
+def anchor_audit_chain(self):
+    """Record the request-audit hash-chain head to the append-only AuditAnchor
+    table AND emit it to the application log. Runs daily via Celery Beat.
+
+    This puts the chain head outside the mutable audit table (and, in hosted
+    mode, outside the instance entirely via log shipping), so a full-history
+    rewrite can't pass silently — the anchors and external logs would disagree.
+    """
+    from app.models import RequestAuditLog, AuditAnchor
+    from sqlalchemy import func as _func
+
+    async def _anchor():
+        async with SessionLocal() as db:
+            head = (await db.execute(
+                select(RequestAuditLog.entry_hash)
+                .where(RequestAuditLog.entry_hash.isnot(None))
+                .order_by(RequestAuditLog.id.desc()).limit(1)
+            )).scalar()
+            if not head:
+                return {"status": "skipped", "reason": "no hashed audit entries yet"}
+            count = (await db.execute(
+                select(_func.count()).select_from(RequestAuditLog)
+                .where(RequestAuditLog.entry_hash.isnot(None))
+            )).scalar() or 0
+            last = (await db.execute(
+                select(AuditAnchor).order_by(AuditAnchor.id.desc()).limit(1)
+            )).scalar_one_or_none()
+            if last and last.head_hash == head:
+                return {"status": "unchanged", "head": head, "count": count}
+            db.add(AuditAnchor(head_hash=head, entry_count=count))
+            await db.commit()
+            # External-visible line (shipped to central log aggregation in hosted mode)
+            logger.info(f"[AUDIT ANCHOR] head={head} count={count}")
+            return {"status": "anchored", "head": head, "count": count}
+
+    try:
+        return run_async(_anchor())
+    except Exception as e:
+        logger.error(f"[AUDIT ANCHOR] task failed: {e}")
+        return {"status": "error", "error": str(e)}

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+filterwarnings =
+    ignore::DeprecationWarning

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Lightweight test bootstrap.
+
+These tests exercise the security- and integration-critical *logic* (envelope
+encryption, secret-manager caching/merge, connector retry/pagination, work-order
+mapping) without needing a database or the full app stack. conftest makes `app`
+importable and provides a minimal app.core.config stub if pydantic-settings
+isn't installed, so the suite runs fast in CI.
+"""
+import os
+import sys
+import types
+
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+os.environ.setdefault("PII_DECRYPT_CACHE", "on")
+
+try:
+    import app.core.config  # noqa: F401
+except Exception:
+    cfg = types.ModuleType("app.core.config")
+
+    class _Settings:
+        secret_key = "test-secret-key-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    cfg.get_settings = lambda: _Settings()
+    sys.modules["app.core.config"] = cfg

--- a/backend/tests/test_connector_retry.py
+++ b/backend/tests/test_connector_retry.py
@@ -1,0 +1,85 @@
+"""RetryTransport: safe, method-aware retries; generic connector pagination."""
+import httpx
+import pytest
+
+import app.integrations.base as base
+from app.integrations.base import RetryTransport
+from app.integrations.registry import build_connector
+
+
+def _fake(script, calls):
+    async def fake(self, request):
+        i = calls["n"]; calls["n"] += 1
+        item = script[min(i, len(script) - 1)]
+        if isinstance(item, Exception):
+            raise item
+        status, headers = item if isinstance(item, tuple) else (item, {})
+        return httpx.Response(status, headers=headers, request=request)
+    return fake
+
+
+async def _run(method, script, monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(base.httpx.AsyncHTTPTransport, "handle_async_request", _fake(script, calls))
+    t = RetryTransport(max_retries=3, backoff_base=0.001, backoff_cap=0.002)
+    req = httpx.Request(method, "https://vendor.test/requests")
+    try:
+        r = await t.handle_async_request(req)
+        return r.status_code, calls["n"], None
+    except Exception as e:  # noqa: BLE001
+        return None, calls["n"], type(e).__name__
+
+
+@pytest.mark.asyncio
+async def test_get_429_then_200_retries(monkeypatch):
+    status, n, _ = await _run("GET", [(429, {"Retry-After": "0"}), 200], monkeypatch)
+    assert status == 200 and n == 2
+
+
+@pytest.mark.asyncio
+async def test_get_503_exhausts(monkeypatch):
+    status, n, _ = await _run("GET", [503], monkeypatch)
+    assert status == 503 and n == 4  # 1 + 3 retries
+
+
+@pytest.mark.asyncio
+async def test_post_500_not_retried(monkeypatch):
+    status, n, _ = await _run("POST", [500, 200], monkeypatch)
+    assert status == 500 and n == 1
+
+
+@pytest.mark.asyncio
+async def test_post_429_is_retried(monkeypatch):
+    status, n, _ = await _run("POST", [(429, {"Retry-After": "0"}), 200], monkeypatch)
+    assert status == 200 and n == 2
+
+
+@pytest.mark.asyncio
+async def test_post_read_error_not_retried(monkeypatch):
+    err = httpx.ReadError("boom", request=httpx.Request("POST", "https://vendor.test/requests"))
+    _, n, exc = await _run("POST", [err, 200], monkeypatch)
+    assert exc == "ReadError" and n == 1
+
+
+def test_retry_after_parsing():
+    assert RetryTransport._parse_retry_after("5") == 5.0
+    assert RetryTransport._parse_retry_after(None) is None
+    assert RetryTransport._parse_retry_after("garbage") is None
+
+
+@pytest.mark.asyncio
+async def test_pagination_follows_next_and_dedupes(monkeypatch):
+    monkeypatch.setattr(base, "_assert_public_url", lambda url: None)
+    pages = {
+        "p1": {"results": [{"id": "1"}, {"id": "2"}], "next": "https://api.test/v1/requests?page=2"},
+        "p2": {"results": [{"id": "2"}, {"id": "3"}], "next": None},
+    }
+
+    async def paged(self, request):
+        key = "p2" if "page=2" in str(request.url) else "p1"
+        return httpx.Response(200, json=pages[key], request=request)
+
+    monkeypatch.setattr(base.httpx.AsyncHTTPTransport, "handle_async_request", paged)
+    conn = build_connector("sdl", {"base_url": "https://api.test/v1"}, {"api_key": "k"})
+    recs = await conn.pull_updates()
+    assert sorted(r.external_id for r in recs) == ["1", "2", "3"]

--- a/backend/tests/test_pii_crypto.py
+++ b/backend/tests/test_pii_crypto.py
@@ -1,0 +1,68 @@
+"""Envelope PII encryption: round-trip, tamper detection, DEK amortization,
+REQUIRE_KMS enforcement, and backward-compatible legacy decryption."""
+import base64
+import os
+
+import pytest
+
+from app.core import pii_crypto
+from app.core import encryption as enc
+
+
+def setup_function(_):
+    os.environ.pop("REQUIRE_KMS", None)
+    os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+    os.environ.pop("KMS_PROVIDER", None)
+    pii_crypto.clear_caches()
+
+
+def test_round_trip():
+    tok = pii_crypto.encrypt("Jane Q. Resident")
+    assert tok.startswith("pii2:")
+    assert pii_crypto.decrypt(tok) == "Jane Q. Resident"
+
+
+def test_tamper_detected():
+    tok = pii_crypto.encrypt("resident@example.com")
+    p, w, n, c = tok.split(":", 3)
+    raw = bytearray(base64.b64decode(c))
+    raw[0] ^= 0x01
+    bad = f"{p}:{w}:{n}:{base64.b64encode(bytes(raw)).decode()}"
+    with pytest.raises(Exception):
+        pii_crypto.decrypt(bad)
+
+
+def test_single_dek_amortized_across_many_encrypts():
+    toks = [pii_crypto.encrypt(f"v{i}") for i in range(50)]
+    wraps = {t.split(":", 3)[1] for t in toks}
+    assert len(wraps) == 1
+    assert len(pii_crypto._unwrap_cache) == 1
+
+
+def test_encrypt_pii_helpers_and_is_encrypted():
+    e = enc.encrypt_pii("resident@example.com")
+    assert e.startswith("pii2:")
+    assert enc.is_encrypted(e)
+    assert enc.decrypt_pii(e) == "resident@example.com"
+    assert enc.decrypt_safe(e) == "resident@example.com"
+
+
+def test_legacy_fernet_still_decrypts():
+    legacy = enc.encrypt("legacy-value")
+    assert legacy.startswith("gAAAA")
+    assert enc.decrypt_safe(legacy) == "legacy-value"
+    assert enc.is_encrypted(legacy)
+
+
+def test_empty_passthrough():
+    assert enc.encrypt_pii("") == ""
+    assert enc.decrypt_pii("") == ""
+
+
+def test_require_kms_refuses_local_fallback():
+    os.environ["REQUIRE_KMS"] = "1"
+    pii_crypto.clear_caches()
+    with pytest.raises(Exception):
+        enc.encrypt_pii("must-be-hsm")
+    os.environ.pop("REQUIRE_KMS", None)
+    pii_crypto.clear_caches()

--- a/backend/tests/test_secret_manager.py
+++ b/backend/tests/test_secret_manager.py
@@ -1,0 +1,72 @@
+"""Secret manager: TTL cache expiry and no-clobber bundle merge."""
+import json
+import os
+import sys
+import types
+
+# Stub DB / tracking / sanitize so the merge path needs no real database.
+_san = types.ModuleType("app.core.sanitize"); _san.sanitize_for_log = lambda s: s
+sys.modules.setdefault("app.core.sanitize", _san)
+
+
+class _Sess:
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+
+
+_dbs = types.ModuleType("app.db.session"); _dbs.SessionLocal = _Sess; _dbs.sync_engine = None
+sys.modules.setdefault("app.db.session", _dbs)
+_au = types.ModuleType("app.services.api_usage")
+async def _track(*a, **k): return None
+_au.track_api_usage = _track
+sys.modules.setdefault("app.services.api_usage", _au)
+
+import app.services.secret_manager as sm  # noqa: E402
+
+
+class FakeSM:
+    def __init__(self): self.data = {}
+    def access_secret_version(self, request):
+        sid = request["name"].split("/secrets/")[1].split("/")[0]
+        payload = self.data.get(sid)
+        if payload is None:
+            raise Exception("no version")
+        return types.SimpleNamespace(payload=types.SimpleNamespace(data=payload))
+    def get_secret(self, request):
+        sid = request["name"].split("/secrets/")[1]
+        if sid in self.data:
+            return object()
+        raise Exception("not found")
+    def create_secret(self, request): self.data[request["secret_id"]] = None
+    def add_secret_version(self, request):
+        sid = request["parent"].split("/secrets/")[1]
+        self.data[sid] = request["payload"]["data"]
+
+
+def test_cache_ttl():
+    os.environ["SECRET_CACHE_TTL_SECONDS"] = "100"
+    sm._cache_put("secret-config", {"A": "1"})
+    assert sm._cache_get("secret-config") == {"A": "1"}
+    os.environ["SECRET_CACHE_TTL_SECONDS"] = "0"
+    sm._cache_put("secret-config", {"A": "1"})
+    assert sm._cache_get("secret-config") is None
+    os.environ["SECRET_CACHE_TTL_SECONDS"] = "300"
+    sm.clear_cache()
+
+
+def test_no_clobber_merge(monkeypatch):
+    fake = FakeSM()
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-proj")
+    sm._config["use_gcp"] = True
+    sm._sm_client = fake
+    assert sm.set_secret_sync("TOWNSHIP_NAME", "Springfield") is True
+    assert sm.set_secret_sync("SUPPORT_EMAIL", "help@town.gov") is True
+    final = json.loads(fake.data["secret-config"].decode())
+    assert final == {"TOWNSHIP_NAME": "Springfield", "SUPPORT_EMAIL": "help@town.gov"}
+    # A stale cache must not cause a lost key on the next write.
+    sm._cache_put("secret-config", {"TOWNSHIP_NAME": "STALE"})
+    assert sm.set_secret_sync("PRIMARY_COLOR", "#111") is True
+    final2 = json.loads(fake.data["secret-config"].decode())
+    assert final2.get("SUPPORT_EMAIL") == "help@town.gov"
+    assert final2.get("PRIMARY_COLOR") == "#111"
+    sm.clear_cache()

--- a/backend/tests/test_workorders.py
+++ b/backend/tests/test_workorders.py
@@ -1,0 +1,54 @@
+"""Work-order sync: inbound mapping, closeout, outbound body, status lifecycle."""
+from app.integrations.registry import build_connector, PLATFORM_CATALOG
+
+
+def test_cityworks_work_order_maps_to_record():
+    cw = build_connector("cityworks", {"base_url": "https://cw/api"}, {"api_key": "k"})
+    rec = cw._record_from_response({
+        "WorkOrderId": "WO-5567", "Status": "Assigned", "Description": "Pothole",
+        "AssignedTo": "Streets Crew A", "WorkOrderCategory": "Streets",
+        "ScheduledDate": "2026-07-10T08:00:00Z", "ProjectedFinishDate": "2026-07-12T00:00:00Z",
+        "Priority": "High",
+    })
+    assert rec.external_id == "WO-5567"
+    assert rec.status == "in_progress"
+    assert rec.assigned_to == "Streets Crew A"
+    assert rec.assigned_department == "Streets"
+    assert rec.work_order_id == "WO-5567"
+    assert rec.priority == "High"
+    assert rec.scheduled_datetime.date().isoformat() == "2026-07-10"
+    assert rec.due_datetime.date().isoformat() == "2026-07-12"
+
+
+def test_completed_maps_to_closed_with_resolution():
+    cw = build_connector("cityworks", {"base_url": "https://cw/api"}, {"api_key": "k"})
+    rec = cw._record_from_response({"WorkOrderId": "WO-9", "Status": "Completed", "ClosedComments": "Patched"})
+    assert rec.status == "closed"
+    assert rec.resolution == "Patched"
+
+
+def test_outbound_body_carries_work_order_fields():
+    gr = build_connector("sdl", {"base_url": "https://sdl"}, {"api_key": "k"})
+    body = gr._build_create_body({
+        "description": "Leak", "priority": 8, "assigned_to": "Water Div",
+        "assigned_department": "Public Works", "due_date": "2026-07-15",
+    })
+    assert body["priority"] == 8
+    assert body["assigned_to"] == "Water Div"
+    assert body["department"] == "Public Works"
+    assert body["due_date"] == "2026-07-15"
+
+
+def test_work_order_status_lifecycle():
+    gr = build_connector("sdl", {"base_url": "https://sdl"}, {"api_key": "k"})
+    assert gr.map_status_in("Dispatched") == "in_progress"
+    assert gr.map_status_in("On Hold") == "in_progress"
+    assert gr.map_status_in("Scheduled") == "in_progress"
+    assert gr.map_status_in("Cancelled") == "closed"
+
+
+def test_catalog_work_orders_capability_consistent():
+    for key, meta in PLATFORM_CATALOG.items():
+        if "work_orders" in meta["capabilities"]:
+            conn = build_connector(key, {"base_url": "https://x"}, {})
+            assert "work_orders" in conn.capabilities, f"{key} catalog claims work_orders but connector lacks it"

--- a/frontend/src/components/GovtechIntegrations.tsx
+++ b/frontend/src/components/GovtechIntegrations.tsx
@@ -4,7 +4,7 @@ import {
     Landmark, CheckCircle, AlertCircle, ExternalLink, RefreshCw,
     Plug, Trash2, Copy, Check, Mail, ClipboardList, Loader2, ArrowLeft,
     ChevronDown, ChevronUp, PartyPopper, Sparkles, Search,
-    ArrowUpRight, ArrowDownLeft, MessageSquare, Image as ImageIcon, MapPin,
+    ArrowUpRight, ArrowDownLeft, MessageSquare, Image as ImageIcon, MapPin, ClipboardCheck,
 } from 'lucide-react';
 
 import { Button, Modal } from './ui';
@@ -28,6 +28,7 @@ const CAPABILITY_CHIPS: { key: string; label: string; icon: typeof Sparkles }[] 
     { key: 'comments', label: 'Comments', icon: MessageSquare },
     { key: 'documents', label: 'Photos & files', icon: ImageIcon },
     { key: 'assets', label: 'Assets → map', icon: MapPin },
+    { key: 'work_orders', label: 'Work orders', icon: ClipboardCheck },
 ];
 
 const SYNC_CHOICES = (name: string) => [

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback, FormEvent } f
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+    RefreshCw,
     Menu,
     X,
     Search,
@@ -157,6 +158,7 @@ export default function StaffDashboard() {
 
     // Closed substatus state
     const [showClosedModal, setShowClosedModal] = useState(false);
+    const [woRefresh, setWoRefresh] = useState<{ busy: boolean; msg: string | null }>({ busy: false, msg: null });
     const [closedSubstatus, setClosedSubstatus] = useState<ClosedSubstatus>('resolved');
     const [completionMessage, setCompletionMessage] = useState('');
     const [completionPhotoUrl, setCompletionPhotoUrl] = useState('');
@@ -530,6 +532,26 @@ export default function StaffDashboard() {
         } catch (err) {
             console.error('Failed to load request detail:', err);
         }
+    };
+
+    const handleRefreshWorkOrder = async () => {
+        if (!selectedRequest) return;
+        setWoRefresh({ busy: true, msg: null });
+        try {
+            const res = await api.refreshRequestWorkOrder(selectedRequest.service_request_id);
+            setWoRefresh({ busy: false, msg: res.detail });
+            // Synced work-order updates land as status/assignment/timeline notes;
+            // reload the detail + comments shortly so they show up.
+            if (res.ok) {
+                setTimeout(() => {
+                    loadRequestDetail(selectedRequest.service_request_id);
+                    if (selectedRequest.id) loadComments(selectedRequest.id);
+                }, 2500);
+            }
+        } catch (err: any) {
+            setWoRefresh({ busy: false, msg: err?.message || 'Could not refresh the work order.' });
+        }
+        setTimeout(() => setWoRefresh(s => ({ ...s, msg: null })), 6000);
     };
 
     const handleStatusChange = async (status: string) => {
@@ -1774,15 +1796,31 @@ export default function StaffDashboard() {
                                                 </div>
                                                 <h1 className="text-base sm:text-lg font-semibold text-white truncate">{selectedRequest.service_name}</h1>
                                             </div>
-                                            <PrintWorkOrder
-                                                request={selectedRequest}
-                                                auditLog={auditLog}
-                                                comments={comments}
-                                                townshipName={settings?.township_name}
-                                                logoUrl={settings?.logo_url || undefined}
-                                                mapsApiKey={mapsConfig?.google_maps_api_key}
-                                            />
+                                            <div className="flex items-center gap-1.5 shrink-0">
+                                                <button
+                                                    onClick={handleRefreshWorkOrder}
+                                                    disabled={woRefresh.busy}
+                                                    title="Pull the latest work-order status (assignment, schedule, resolution) from any connected system"
+                                                    className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-white/70 hover:text-white bg-white/5 hover:bg-white/10 border border-white/10 transition-colors disabled:opacity-50"
+                                                >
+                                                    <RefreshCw className={`w-3.5 h-3.5 ${woRefresh.busy ? 'animate-spin' : ''}`} aria-hidden="true" />
+                                                    <span className="hidden sm:inline">{woRefresh.busy ? 'Refreshing…' : 'Refresh work order'}</span>
+                                                </button>
+                                                <PrintWorkOrder
+                                                    request={selectedRequest}
+                                                    auditLog={auditLog}
+                                                    comments={comments}
+                                                    townshipName={settings?.township_name}
+                                                    logoUrl={settings?.logo_url || undefined}
+                                                    mapsApiKey={mapsConfig?.google_maps_api_key}
+                                                />
+                                            </div>
                                         </div>
+                                        {woRefresh.msg && (
+                                            <div className="mt-1.5 text-[11px] text-white/60 bg-white/5 border border-white/10 rounded-lg px-2.5 py-1.5">
+                                                {woRefresh.msg}
+                                            </div>
+                                        )}
 
                                         {/* Row 2: Status Actions - Compact on mobile */}
                                         <div className="flex gap-1.5 sm:gap-2">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -494,6 +494,13 @@ class ApiClient {
         return this.request<IntegrationSyncLog[]>(`/integrations/${id}/logs`);
     }
 
+    // Pull the latest work-order state for one request from its linked platforms
+    async refreshRequestWorkOrder(requestId: string): Promise<{ ok: boolean; detail: string }> {
+        return this.request<{ ok: boolean; detail: string }>(
+            `/integrations/requests/${requestId}/refresh`, { method: 'POST' }
+        );
+    }
+
     // Service providers (AI / translation / identity)
     async getProviderCatalog(capability: 'ai' | 'translation' | 'identity'): Promise<ProviderCatalog> {
         return this.request<ProviderCatalog>(`/system/${capability}/catalog`);


### PR DESCRIPTION
## Summary

Turns the govtech connectors into complete work-order integrations and adds the surrounding platform hardening. Branches from `main`; frontend builds, backend compiles, and a new 21-test suite passes.

## 1. Full work-order management sync
A resident report becomes a work order in the vendor WOMS, and the whole lifecycle syncs back.
- `ExternalRecord` work-order fields (work_order_id, priority, assigned_to, assigned_department, scheduled/due dates, resolution).
- Outbound push carries priority + assignment + due date so a WOMS opens a properly-routed work order.
- Inbound pull applies updates **non-destructively** (internal timeline note, de-duped; fills assignment only when empty; closeout → completion_message + `closed_substatus=resolved`) — and applies **even when status is unchanged** (the common dispatch case).
- Richer status lifecycle (assigned/scheduled/dispatched/en route/on hold → in progress; cancelled/completed → closed).
- On-demand refresh wires the previously-dead `fetch_record`: `POST /integrations/requests/{id}/refresh` + a **"Refresh work order"** button on the staff request view.
- New **Trimble Cityworks** connector; Accela maps its native fields; `work_orders` capability chip in the UI, kept in lockstep with connector capabilities.

## 2. Integration completeness (photo sync)
- Downloads **http(s)-hosted** photos (not just base64) with SSRF guard + size cap.
- Tracks a per-link pushed count so photos added **after** creation sync on the next status push (was one-shot).

## 3. Orchestrator hooks (state-hosted model — all flag-gated, no-op by default)
- `MANAGED_MODE` config flag.
- In-app self-update (`/system/update`, `/switch-version`) **403s in managed mode** — closes the Docker-socket infra risk; upgrades come from the control plane.
- Version/schema stamping: `GET /health/version` returns app version, git sha, and DB revision for drift detection + rollout gating.

## 4. Audit-chain external anchoring
- Append-only `AuditAnchor` table + daily task records the audit hash-chain head and emits it to the log (shipped externally in hosted mode), so a full-DB rewrite can't pass silently. `GET /audit/anchors` confirms the live head matches the latest anchor.

## 5. Tests + CI
- `backend/tests/` pytest suite (21 tests): envelope crypto, secret-manager TTL/no-clobber merge, connector retry/pagination, work-order mapping — plus a `backend-tests` GitHub Actions workflow so none of this silently regresses.

## Notes
- Partner-WOMS connectors ship configurable field defaults ("run the connection check to confirm your endpoints"); Accela/Cityworks target their documented API shapes.
- The single PR to add — supersedes the earlier work-order-only scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)