### PR TITLE
Make the corridor map's zoom tracking actually fire

### DIFF
--- a/frontend/src/components/RoadCorridorMap.tsx
+++ b/frontend/src/components/RoadCorridorMap.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Loader2, MapPin, RotateCcw, X } from 'lucide-react';
 
 import { api } from '../services/api';
 import {
+    CanvasOverlayHandle,
     GeoFeature,
     GeoJsonLayerHandle,
     LatLng,
@@ -90,6 +91,7 @@ export default function RoadCorridorMap({
 
     useEffect(() => {
         let cancelled = false;
+        let unsubscribeIdle: (() => void) | undefined;
         const container = containerRef.current;
         const config = legacyMapProviderConfig(apiKey);
         if (!container || !config) return;
@@ -103,7 +105,12 @@ export default function RoadCorridorMap({
                 if (cancelled) { renderer.destroy(); return; }
                 rendererRef.current = renderer;
 
-                renderer.onBoundsChange?.(() => {
+                // `idle` is the renderer-agnostic "camera has settled" event, and
+                // every provider implements it. The previous call was to
+                // onBoundsChange, which nothing implements -- so with optional
+                // chaining it silently never fired and zoomLevel stayed at its
+                // initial 13 for the life of the map.
+                unsubscribeIdle = renderer.on('idle', () => {
                     const z = renderer.getZoom();
                     if (typeof z === "number") setZoomLevel(z);
                 });
@@ -134,6 +141,7 @@ export default function RoadCorridorMap({
 
         return () => {
             cancelled = true;
+            unsubscribeIdle?.();
             rendererRef.current?.destroy();
             rendererRef.current = null;
             bufferLayerRef.current = null;
@@ -151,7 +159,6 @@ export default function RoadCorridorMap({
             strokeColor: off ? "#64748b" : "#ef4444",
             strokeWidth: off ? 4 : bufferPx,
             strokeOpacity: 0.0,
-            strokeDasharray: off ? "4,4" : "6,6",
         };
     }, [corridorMetres, zoomLevel]);
 


### PR DESCRIPTION
One commit on top of #410. Fixes the three type errors in `RoadCorridorMap`, one of which was a silent dead call rather than a cosmetic complaint.

## The dead call

`renderer.onBoundsChange?.(...)` is implemented by no renderer — that call site is the only occurrence of the name anywhere in the codebase. Optional chaining meant it never threw and never ran, so `setZoomLevel` was never called and `zoomLevel` stayed at its initial `13` for the life of the map.

It now subscribes to `idle`, the renderer-agnostic "camera has settled" event that every provider implements and that `types.ts` documents as *"the moment to read bounds/zoom"*, and unsubscribes on teardown.

**What that was actually costing is narrower than it looks.** The visible corridor is drawn by the canvas overlay, which reads `view.zoom` itself and was always correct. What went stale is `bufferStyleFor`'s `strokeWidth` — and since both vector styles are `strokeOpacity: 0`, those layers exist only as click targets. So the symptom was that a road's *clickable* width stopped matching its *drawn* width as you zoomed, making segments progressively harder to select the further you got from zoom 13.

## The other two

- `CanvasOverlayHandle` is exported from `../maps` (via `./types`) and was simply never imported.
- `strokeDasharray` was set on a `strokeOpacity: 0` layer, so it drew nothing. The stripes come from the canvas overlay's own `ctx.setLineDash`. Removed, rather than added to `VectorStyle` — adding it would have implied renderers honour it, and none do.

## Verification

`RoadCorridorMap` is now type-clean. Repo-wide `tsc --noEmit` goes from 14 errors to 11: 9 in the Azure renderer's null handling and 2 in `AdminConsole`, all pre-existing and untouched here. 80 frontend tests pass; the production build succeeds.

## Two things found and deliberately left alone

**There is no frontend typecheck in CI** — only pytest, CodeQL and the WCAG audit. That is exactly why a call to a nonexistent method survived in the tree. Turning it on needs the remaining 11 errors cleared first, so it belongs in its own change.

**The Service Categories search and filters are dead UI.** `searchQuery` and `filterMode` are declared and do filter `filteredServices`, but no input is ever rendered that can set them — the "live search, filters" described in `69b32e0` are not on the page. Where they go and how they look is a design decision, so this flags it rather than inventing a search bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_