### PR TITLE
Redirect a resident to the right agency, and make the inverted default work

### DIFF
--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -698,6 +698,7 @@ async def create_request(
                 "error": "redirected",
                 "jurisdiction": decision.jurisdiction,
                 "message": decision.message,
+                "message_is_default": decision.message_is_default,
                 "contacts": decision.contacts,
                 "road": decision.road_name,
             },

--- a/backend/app/api/roads.py
+++ b/backend/app/api/roads.py
@@ -63,6 +63,7 @@ async def road_check(payload: RoadCheckRequest, db: AsyncSession = Depends(get_d
         "block_type": decision.block_type,
         "jurisdiction": decision.jurisdiction,
         "message": decision.message,
+        "message_is_default": decision.message_is_default,
         "contacts": decision.contacts,
         "road": decision.road_name,
         "detected_road": detected,

--- a/backend/app/services/road_blocking.py
+++ b/backend/app/services/road_blocking.py
@@ -37,6 +37,12 @@ class BlockDecision:
     message: str = ""
     contacts: List[Dict[str, str]] = None
     road_name: Optional[str] = None
+    # True when `message` is our generated sentence rather than something the
+    # clerk wrote. The string is still filled in, because API clients of the 409
+    # get only that field and a blank one explains nothing -- but the portal has
+    # a heading that already says the same thing, so it uses this to avoid
+    # printing "Cranbury Rd is maintained by County DPW" twice in a row.
+    message_is_default: bool = False
 
     def __post_init__(self) -> None:
         if self.contacts is None:
@@ -96,6 +102,7 @@ async def evaluate(
                 # Never empty: API clients of the 409 get only this string, and a
                 # blank one tells a resident nothing about why they were stopped.
                 message=config.get("message") or f"This service is handled by {name}.",
+                message_is_default=not (config.get("message") or "").strip(),
                 contacts=contacts,
             )
 
@@ -112,6 +119,7 @@ async def evaluate(
             block_type="road_based",
             jurisdiction=match.name,
             message=match.message or f"This road is maintained by {match.name}.",
+            message_is_default=not (match.message or "").strip(),
             contacts=match.contacts or [],
             road_name=match.matched_road,
         )

--- a/backend/app/services/road_blocking.py
+++ b/backend/app/services/road_blocking.py
@@ -79,12 +79,24 @@ async def evaluate(
         config: Dict[str, Any] = service.routing_config or {}
 
         if mode == "third_party":
+            contacts = config.get("contacts") or []
+            # There is no separate agency-name field on this mode, only contacts,
+            # so fall back to the first contact's name. "Another agency" reads as
+            # the system not knowing, when the clerk did in fact say who.
+            first = contacts[0] if contacts and isinstance(contacts[0], dict) else {}
+            name = (
+                config.get("third_party_name")
+                or (first.get("name") or "").strip()
+                or "Another agency"
+            )
             return BlockDecision(
                 blocked=True,
                 block_type="category",
-                jurisdiction=config.get("third_party_name") or "Another agency",
-                message=config.get("message") or "This service is handled by another agency.",
-                contacts=config.get("contacts") or [],
+                jurisdiction=name,
+                # Never empty: API clients of the 409 get only this string, and a
+                # blank one tells a resident nothing about why they were stopped.
+                message=config.get("message") or f"This service is handled by {name}.",
+                contacts=contacts,
             )
 
         if mode != "road_based":

--- a/backend/app/services/road_geometry.py
+++ b/backend/app/services/road_geometry.py
@@ -38,7 +38,12 @@ from sqlalchemy import cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import RoadSegment
-from app.services.road_matching import JurisdictionMatch, road_matches, _as_list
+from app.services.road_matching import (
+    JurisdictionMatch,
+    jurisdictions_from_config,
+    road_matches,
+    _as_list,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -149,19 +154,10 @@ def _municipal_entries(config: Dict[str, Any]) -> List[str]:
 
 
 def _jurisdictions(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    jurisdictions = config.get("jurisdictions")
-    if isinstance(jurisdictions, list) and jurisdictions:
-        return [j for j in jurisdictions if isinstance(j, dict)]
-    # Pre-multi-jurisdiction config: one unnamed third party.
-    roads = _as_list(config.get("exclusion_list"))
-    if not roads:
-        return []
-    return [{
-        "name": config.get("third_party_name") or "Another agency",
-        "roads": roads,
-        "message": config.get("third_party_message") or "",
-        "contacts": config.get("third_party_contacts") or [],
-    }]
+    """Delegated so the spatial and address resolvers read one config the same
+    way. They had separate copies of this, and only one of them would have been
+    fixed."""
+    return jurisdictions_from_config(config)
 
 
 def _matching_jurisdiction(

--- a/backend/app/services/road_geometry.py
+++ b/backend/app/services/road_geometry.py
@@ -39,7 +39,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import RoadSegment
 from app.services.road_matching import (
+    GENERIC_THIRD_PARTY,
     JurisdictionMatch,
+    MUNICIPAL_DEFAULTS,
+    default_jurisdiction,
     jurisdictions_from_config,
     road_matches,
     _as_list,
@@ -214,6 +217,28 @@ def choose_road(
     municipal = _municipal_entries(config)
     jurisdictions = _jurisdictions(config)
 
+    # Who gets a road no rule names. Usually nobody -- the town. Under a
+    # third-party default it is that agency, which this resolver used to ignore
+    # entirely: the setting was only ever read on the address path, so the
+    # portal, which resolves by geometry, kept everything with the town.
+    fallback = default_jurisdiction(config, jurisdictions)
+    default_claim = (
+        (fallback, "(default -- road not listed as municipal)") if fallback else None
+    )
+
+    def claim_for(road: RoadMatch) -> Optional[Tuple[Dict[str, Any], str]]:
+        claim = _matching_jurisdiction(jurisdictions, road, excluded, trims)
+        if claim is not None:
+            return claim
+        # Switched off or trimmed back in the coverage map: the clerk did that
+        # deliberately, so the stretch stays with the town even when an agency
+        # is the default. Otherwise turning a stretch off would hand it away.
+        if road.source_feature_id in excluded:
+            return None
+        if trims and not within_trim(road.fraction_along, trims.get(road.source_feature_id)):
+            return None
+        return default_claim
+
     # A road the town explicitly claims wins even if it is not the nearest --
     # this is the town-maintained stretch of a county road.
     for road in ordered:
@@ -229,11 +254,11 @@ def choose_road(
         # Being wrong this way costs a reassignment; being wrong the other way
         # turns a resident away with no recourse.
         for road in tied:
-            if _matching_jurisdiction(jurisdictions, road, excluded, trims) is None:
+            if claim_for(road) is None:
                 return road, None
 
     for road in tied:
-        claim = _matching_jurisdiction(jurisdictions, road, excluded, trims)
+        claim = claim_for(road)
         if claim is not None:
             return road, claim
 
@@ -356,6 +381,36 @@ def check_config(config: Dict[str, Any], known_road_names: Sequence[str]) -> Lis
                     ),
                     roads=[entry],
                 ))
+
+    # A third-party default that cannot be resolved to an agency is the quietest
+    # possible failure: every road stays with the town, which is exactly what
+    # the setting was meant to stop, and nothing anywhere says so.
+    raw_default = config.get("default_handler")
+    handler = (raw_default or "").strip() if isinstance(raw_default, str) else ""
+    if handler and handler.lower() not in MUNICIPAL_DEFAULTS:
+        if default_jurisdiction(config, jurisdictions) is None:
+            if handler.lower() in GENERIC_THIRD_PARTY:
+                detail = (
+                    f"{len(jurisdictions)} agencies are configured, so \"a third party\" "
+                    "does not say which one handles a road none of them list. "
+                    "Choose the agency by name."
+                    if jurisdictions
+                    else "No agency is configured to hand those roads to. Add one."
+                )
+            else:
+                detail = (
+                    f"No configured agency is called \"{handler}\" -- it may have been "
+                    "renamed or removed. Choose the agency again."
+                )
+            issues.append(ConfigIssue(
+                severity="warning",
+                kind="default_handler_unresolved",
+                message=(
+                    "This service is set to send unlisted roads to another agency, but "
+                    f"that cannot be resolved, so every road stays with the town. {detail}"
+                ),
+                roads=[],
+            ))
 
     return issues
 

--- a/backend/app/services/road_matching.py
+++ b/backend/app/services/road_matching.py
@@ -178,6 +178,72 @@ def _as_list(value: Any) -> List[str]:
     return []
 
 
+def _agency_contacts(agency: Dict[str, Any]) -> List[Dict[str, str]]:
+    """One agency card becomes one contact block.
+
+    The routing modal collects the contact details flat on the agency itself --
+    name, phone, email, url -- rather than as a nested list, so build the list
+    the rest of the pipeline expects. An explicit `contacts` list, if a config
+    has one, wins.
+    """
+    explicit = agency.get("contacts")
+    if isinstance(explicit, list) and explicit:
+        return [c for c in explicit if isinstance(c, dict)]
+    entry = {
+        key: str(agency.get(key) or "").strip()
+        for key in ("name", "phone", "email", "url")
+    }
+    return [entry] if any(entry.values()) else []
+
+
+def jurisdictions_from_config(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Every agency in a routing config, each owning only its own roads.
+
+    Three shapes, newest first. This is the single reader for all of them, so
+    that the spatial resolver and the address resolver cannot disagree about
+    who owns a road -- they did diverge before, and a resident reporting through
+    the portal could be told something different from one phoned in.
+
+      1. `jurisdictions`  -- the explicit multi-agency shape.
+      2. `third_party_contacts` where the entries carry roads -- what the
+         routing modal writes: one card per agency, each with its own road
+         list, message and contact details.
+      3. the pre-multi-jurisdiction shape -- one unnamed third party owning
+         `exclusion_list`.
+
+    Shape 2 previously fell through to shape 3, which read the *combined*
+    exclusion_list as one nameless agency's roads and handed back every
+    agency's contacts at once. A resident on a state highway was shown the
+    county's phone number alongside the state's, under the heading "Another
+    agency".
+    """
+    jurisdictions = config.get("jurisdictions")
+    if isinstance(jurisdictions, list) and jurisdictions:
+        return [j for j in jurisdictions if isinstance(j, dict)]
+
+    agencies = config.get("third_party_contacts")
+    if isinstance(agencies, list):
+        built: List[Dict[str, Any]] = []
+        for agency in agencies:
+            if not isinstance(agency, dict):
+                continue
+            # `roads` is the normalised array; `road_list` is the raw
+            # comma-separated string the input writes as the clerk types.
+            roads = _as_list(agency.get("roads")) or _as_list(agency.get("road_list"))
+            if not roads:
+                continue
+            built.append({
+                "name": agency.get("name") or "Another agency",
+                "roads": roads,
+                "message": agency.get("message") or "",
+                "contacts": _agency_contacts(agency),
+            })
+        if built:
+            return built
+
+    return _legacy_jurisdictions(config)
+
+
 def _legacy_jurisdictions(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Read the older single-third-party shape as one unnamed jurisdiction.
 
@@ -222,9 +288,7 @@ def resolve_jurisdiction(
         if road_matches(entry, detected_road):
             return None
 
-    jurisdictions = config.get("jurisdictions")
-    if not isinstance(jurisdictions, list) or not jurisdictions:
-        jurisdictions = _legacy_jurisdictions(config)
+    jurisdictions = jurisdictions_from_config(config)
 
     for jurisdiction in jurisdictions:
         if not isinstance(jurisdiction, dict):

--- a/backend/app/services/road_matching.py
+++ b/backend/app/services/road_matching.py
@@ -262,6 +262,48 @@ def _legacy_jurisdictions(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
 
+# Values meaning "the town keeps anything nobody else claimed".
+MUNICIPAL_DEFAULTS = {"", "municipality", "township", "town", "municipal"}
+# The generic literal the routing UI used to write, before it named the agency.
+GENERIC_THIRD_PARTY = {"third_party", "thirdparty", "third party", "3rd_party"}
+
+
+def default_jurisdiction(
+    config: Dict[str, Any], jurisdictions: Sequence[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Who owns a road that no rule claims -- None meaning the municipality.
+
+    Normally the town is the default and the listed roads are the exceptions.
+    A town can invert that: an agency maintains everything and the town keeps
+    only the roads on its own list. That setting existed in the UI and did
+    nothing, because it was stored as the literal "third_party" and looked up
+    against the configured agencies' names, which never matched. Every road
+    fell back to the municipality.
+
+    It is resolved here, once, for both resolvers.
+
+    Ambiguity fails open. "third_party" does not say *which* agency when more
+    than one is configured, and guessing would redirect a resident to a phone
+    number for a road that agency does not maintain. Naming the agency in the
+    setting resolves it; check_config says so.
+    """
+    raw = config.get("default_handler")
+    handler = (raw or "").strip() if isinstance(raw, str) else ""
+    if handler.lower() in MUNICIPAL_DEFAULTS:
+        return None
+
+    real = [j for j in jurisdictions if isinstance(j, dict)]
+    for jurisdiction in real:
+        if handler in (jurisdiction.get("id"), jurisdiction.get("name")):
+            return jurisdiction
+
+    if handler.lower() in GENERIC_THIRD_PARTY:
+        return real[0] if len(real) == 1 else None
+
+    # Named something that is not configured -- a renamed or deleted agency.
+    return None
+
+
 def resolve_jurisdiction(
     config: Optional[Dict[str, Any]], detected_road: str
 ) -> Optional[JurisdictionMatch]:
@@ -303,23 +345,15 @@ def resolve_jurisdiction(
                     matched_entry=entry,
                 )
 
-    default_handler = config.get("default_handler") or "municipality"
-    if default_handler in ("municipality", "township", "", None):
+    # Nobody claimed this road by name. Under a third-party default that means
+    # it belongs to the default agency; normally it means the town.
+    fallback = default_jurisdiction(config, jurisdictions)
+    if fallback is None:
         return None
-
-    # Everything unlisted belongs to a named jurisdiction. Find it by name or id.
-    for jurisdiction in jurisdictions:
-        if not isinstance(jurisdiction, dict):
-            continue
-        if default_handler in (jurisdiction.get("id"), jurisdiction.get("name")):
-            return JurisdictionMatch(
-                name=jurisdiction.get("name") or "Another agency",
-                message=jurisdiction.get("message") or "",
-                contacts=jurisdiction.get("contacts") or [],
-                matched_road=detected_road,
-                matched_entry="(default -- road not listed as municipal)",
-            )
-
-    # A default handler was named but no such jurisdiction is configured. Treat
-    # the municipality as responsible rather than blocking on a broken config.
-    return None
+    return JurisdictionMatch(
+        name=fallback.get("name") or "Another agency",
+        message=fallback.get("message") or "",
+        contacts=fallback.get("contacts") or [],
+        matched_road=detected_road,
+        matched_entry="(default -- road not listed as municipal)",
+    )

--- a/backend/tests/test_default_handler.py
+++ b/backend/tests/test_default_handler.py
@@ -16,8 +16,18 @@ reports typed in by address.
 
 import pytest
 
-from app.services.road_geometry import RoadMatch, check_config, choose_road
 from app.services.road_matching import default_jurisdiction, resolve_jurisdiction
+
+# road_geometry pulls in geoalchemy2 and SQLAlchemy, which CI does not install.
+# Guarded per-test rather than for the module, so the address-path and
+# config-check tests -- which need neither -- still run there.
+try:
+    from app.services.road_geometry import RoadMatch, check_config, choose_road
+    HAVE_GEO_STACK = True
+except ModuleNotFoundError:  # pragma: no cover - depends on the environment
+    HAVE_GEO_STACK = False
+
+needs_geo = pytest.mark.skipif(not HAVE_GEO_STACK, reason="geoalchemy2 not installed")
 
 
 def _config(default_handler, *, municipal="Elm Street"):
@@ -93,6 +103,7 @@ def test_with_a_municipal_default_an_unlisted_road_is_not_redirected():
 
 # ---- the spatial resolver, which ignored the setting entirely ----------------
 
+@needs_geo
 def test_spatially_an_unlisted_road_goes_to_the_default_agency():
     chosen = choose_road([road("Nowhere Lane")], _config("County DPW"))
     assert chosen is not None
@@ -100,16 +111,19 @@ def test_spatially_an_unlisted_road_goes_to_the_default_agency():
     assert claim is not None and claim[0]["name"] == "County DPW"
 
 
+@needs_geo
 def test_spatially_a_municipal_road_stays_with_the_town():
     chosen = choose_road([road("Elm Street")], _config("County DPW"))
     assert chosen is not None and chosen[1] is None
 
 
+@needs_geo
 def test_spatially_a_municipal_default_redirects_nothing_unlisted():
     chosen = choose_road([road("Nowhere Lane")], _config("township"))
     assert chosen is not None and chosen[1] is None
 
 
+@needs_geo
 def test_a_switched_off_stretch_stays_with_the_town_under_an_agency_default():
     """Turning a stretch off in the coverage map must not hand it away. The
     clerk did that deliberately, and the inverted default would otherwise turn
@@ -119,12 +133,14 @@ def test_a_switched_off_stretch_stays_with_the_town_under_an_agency_default():
     assert chosen is not None and chosen[1] is None
 
 
+@needs_geo
 def test_a_trimmed_stretch_stays_with_the_town_beyond_the_trim():
     cfg = dict(_config("County DPW"), segment_trims={"f1": {"start": 0.0, "end": 0.2}})
     chosen = choose_road([road("Nowhere Lane")], cfg)  # fraction_along = 0.5, past the trim
     assert chosen is not None and chosen[1] is None
 
 
+@needs_geo
 def test_an_off_road_pin_is_never_redirected_by_the_default():
     """No road means no answer, and fail-open beats turning someone away."""
     assert choose_road([], _config("County DPW")) is None
@@ -132,6 +148,7 @@ def test_an_off_road_pin_is_never_redirected_by_the_default():
 
 # ---- the clerk is told when the setting cannot take effect -------------------
 
+@needs_geo
 def test_an_ambiguous_default_is_flagged():
     cfg = _config("third_party")
     cfg["third_party_contacts"].append(
@@ -141,16 +158,19 @@ def test_an_ambiguous_default_is_flagged():
     assert "default_handler_unresolved" in kinds
 
 
+@needs_geo
 def test_a_missing_agency_default_is_flagged():
     kinds = [i.kind for i in check_config(_config("Renamed Authority"), [])]
     assert "default_handler_unresolved" in kinds
 
 
+@needs_geo
 def test_a_resolvable_default_is_not_flagged():
     kinds = [i.kind for i in check_config(_config("County DPW"), [])]
     assert "default_handler_unresolved" not in kinds
 
 
+@needs_geo
 def test_a_municipal_default_is_not_flagged():
     kinds = [i.kind for i in check_config(_config("township"), [])]
     assert "default_handler_unresolved" not in kinds

--- a/backend/tests/test_default_handler.py
+++ b/backend/tests/test_default_handler.py
@@ -1,0 +1,156 @@
+"""Who handles a road that no rule names.
+
+Normally the town does, and the listed roads are the exceptions. A town can
+invert that -- an agency maintains everything and the town keeps only the roads
+on its own list -- and the routing UI has offered that choice all along.
+
+It did nothing. The UI stored the literal "third_party"; the resolver looked that
+value up against the configured agencies' names and ids, where it never matched,
+and fell through to "the municipality handles it". So every road stayed with the
+town, which is precisely what selecting the setting was meant to stop.
+
+The spatial resolver -- the one the resident portal actually uses -- did not read
+the setting at all, so even a correctly named agency only ever took effect for
+reports typed in by address.
+"""
+
+import pytest
+
+from app.services.road_geometry import RoadMatch, check_config, choose_road
+from app.services.road_matching import default_jurisdiction, resolve_jurisdiction
+
+
+def _config(default_handler, *, municipal="Elm Street"):
+    return {
+        "default_handler": default_handler,
+        "inclusion_list": municipal,
+        "third_party_contacts": [
+            {"name": "County DPW", "phone": "555-0200", "road_list": "Cranbury Rd"},
+        ],
+    }
+
+
+def road(name, distance=5.0, fid="f1"):
+    return RoadMatch(name=name, ref=None, distance_m=distance, segment_id=1,
+                     source_feature_id=fid, highway_class="residential",
+                     fraction_along=0.5)
+
+
+# ---- resolving the setting ---------------------------------------------------
+
+def test_the_municipality_is_the_default_default():
+    from app.services.road_matching import jurisdictions_from_config
+    cfg = _config(None)
+    assert default_jurisdiction(cfg, jurisdictions_from_config(cfg)) is None
+
+
+def test_naming_the_agency_resolves_it():
+    from app.services.road_matching import jurisdictions_from_config
+    cfg = _config("County DPW")
+    resolved = default_jurisdiction(cfg, jurisdictions_from_config(cfg))
+    assert resolved and resolved["name"] == "County DPW"
+
+
+def test_the_legacy_literal_resolves_when_there_is_only_one_agency():
+    """Configs saved by the old UI still work, where they are unambiguous."""
+    from app.services.road_matching import jurisdictions_from_config
+    cfg = _config("third_party")
+    resolved = default_jurisdiction(cfg, jurisdictions_from_config(cfg))
+    assert resolved and resolved["name"] == "County DPW"
+
+
+def test_the_legacy_literal_fails_open_with_several_agencies():
+    """"A third party" does not say which one. Guessing would hand a resident a
+    phone number for a road that agency does not maintain."""
+    from app.services.road_matching import jurisdictions_from_config
+    cfg = _config("third_party")
+    cfg["third_party_contacts"].append(
+        {"name": "State DOT", "phone": "555-0100", "road_list": "Route 1"}
+    )
+    assert default_jurisdiction(cfg, jurisdictions_from_config(cfg)) is None
+
+
+def test_an_agency_that_no_longer_exists_fails_open():
+    from app.services.road_matching import jurisdictions_from_config
+    cfg = _config("Renamed Authority")
+    assert default_jurisdiction(cfg, jurisdictions_from_config(cfg)) is None
+
+
+# ---- the address resolver ----------------------------------------------------
+
+def test_an_unlisted_road_goes_to_the_default_agency():
+    match = resolve_jurisdiction(_config("County DPW"), "Nowhere Lane")
+    assert match is not None and match.name == "County DPW"
+
+
+def test_the_towns_own_roads_stay_with_the_town():
+    assert resolve_jurisdiction(_config("County DPW"), "Elm Street") is None
+
+
+def test_with_a_municipal_default_an_unlisted_road_is_not_redirected():
+    assert resolve_jurisdiction(_config("township"), "Nowhere Lane") is None
+
+
+# ---- the spatial resolver, which ignored the setting entirely ----------------
+
+def test_spatially_an_unlisted_road_goes_to_the_default_agency():
+    chosen = choose_road([road("Nowhere Lane")], _config("County DPW"))
+    assert chosen is not None
+    _, claim = chosen
+    assert claim is not None and claim[0]["name"] == "County DPW"
+
+
+def test_spatially_a_municipal_road_stays_with_the_town():
+    chosen = choose_road([road("Elm Street")], _config("County DPW"))
+    assert chosen is not None and chosen[1] is None
+
+
+def test_spatially_a_municipal_default_redirects_nothing_unlisted():
+    chosen = choose_road([road("Nowhere Lane")], _config("township"))
+    assert chosen is not None and chosen[1] is None
+
+
+def test_a_switched_off_stretch_stays_with_the_town_under_an_agency_default():
+    """Turning a stretch off in the coverage map must not hand it away. The
+    clerk did that deliberately, and the inverted default would otherwise turn
+    every exclusion into the opposite of what was intended."""
+    cfg = dict(_config("County DPW"), excluded_segments=["f9"])
+    chosen = choose_road([road("Nowhere Lane", fid="f9")], cfg)
+    assert chosen is not None and chosen[1] is None
+
+
+def test_a_trimmed_stretch_stays_with_the_town_beyond_the_trim():
+    cfg = dict(_config("County DPW"), segment_trims={"f1": {"start": 0.0, "end": 0.2}})
+    chosen = choose_road([road("Nowhere Lane")], cfg)  # fraction_along = 0.5, past the trim
+    assert chosen is not None and chosen[1] is None
+
+
+def test_an_off_road_pin_is_never_redirected_by_the_default():
+    """No road means no answer, and fail-open beats turning someone away."""
+    assert choose_road([], _config("County DPW")) is None
+
+
+# ---- the clerk is told when the setting cannot take effect -------------------
+
+def test_an_ambiguous_default_is_flagged():
+    cfg = _config("third_party")
+    cfg["third_party_contacts"].append(
+        {"name": "State DOT", "phone": "555-0100", "road_list": "Route 1"}
+    )
+    kinds = [i.kind for i in check_config(cfg, [])]
+    assert "default_handler_unresolved" in kinds
+
+
+def test_a_missing_agency_default_is_flagged():
+    kinds = [i.kind for i in check_config(_config("Renamed Authority"), [])]
+    assert "default_handler_unresolved" in kinds
+
+
+def test_a_resolvable_default_is_not_flagged():
+    kinds = [i.kind for i in check_config(_config("County DPW"), [])]
+    assert "default_handler_unresolved" not in kinds
+
+
+def test_a_municipal_default_is_not_flagged():
+    kinds = [i.kind for i in check_config(_config("township"), [])]
+    assert "default_handler_unresolved" not in kinds

--- a/backend/tests/test_per_agency_routing.py
+++ b/backend/tests/test_per_agency_routing.py
@@ -1,0 +1,127 @@
+"""Which agency a redirected resident is actually shown.
+
+The routing modal writes one card per agency into `third_party_contacts`, each
+carrying its own road list, message and contact details, and separately syncs
+the *combined* road names into `exclusion_list` so the coverage map has
+something to draw.
+
+Nothing read the per-agency shape. Both resolvers looked for `jurisdictions`,
+did not find it, and fell through to the pre-multi-jurisdiction branch, which
+reads `exclusion_list` as one nameless agency's roads and hands back
+`third_party_contacts` wholesale as its contacts. So a resident reporting a
+pothole on a state highway was told "Another agency" and shown the county's
+phone number next to the state's -- every agency at once, on every road.
+"""
+
+import pytest
+
+from app.services.road_matching import jurisdictions_from_config, resolve_jurisdiction
+
+
+CONFIG = {
+    "third_party_contacts": [
+        {
+            "name": "State DOT",
+            "phone": "555-0100",
+            "email": "roads@dot.example.gov",
+            "url": "dot.example.gov/report",
+            "message": "Route 1 is a state highway.",
+            "road_list": "Route 1, Route 130",
+        },
+        {
+            "name": "County DPW",
+            "phone": "555-0200",
+            "email": "dpw@county.example.gov",
+            "url": "county.example.gov",
+            "message": "Cranbury Rd is county-maintained.",
+            "road_list": "Cranbury Rd",
+        },
+    ],
+    # What the modal syncs for the coverage map -- every road, flattened.
+    "exclusion_list": "Route 1, Route 130, Cranbury Rd",
+}
+
+
+def test_each_agency_owns_only_its_own_roads():
+    built = jurisdictions_from_config(CONFIG)
+    assert [j["name"] for j in built] == ["State DOT", "County DPW"]
+    assert built[0]["roads"] == ["Route 1", "Route 130"]
+    assert built[1]["roads"] == ["Cranbury Rd"]
+
+
+def test_a_state_road_shows_only_the_state():
+    match = resolve_jurisdiction(CONFIG, "Route 1")
+    assert match is not None
+    assert match.name == "State DOT"
+    assert match.message == "Route 1 is a state highway."
+    assert len(match.contacts) == 1, "the county must not appear on a state road"
+    assert match.contacts[0]["phone"] == "555-0100"
+
+
+def test_a_county_road_shows_only_the_county():
+    match = resolve_jurisdiction(CONFIG, "Cranbury Rd")
+    assert match is not None
+    assert match.name == "County DPW"
+    assert match.message == "Cranbury Rd is county-maintained."
+    assert len(match.contacts) == 1, "the state must not appear on a county road"
+    assert match.contacts[0]["phone"] == "555-0200"
+
+
+def test_the_email_the_clerk_entered_reaches_the_resident():
+    """The modal collects an email; the resident-facing payload dropped it."""
+    match = resolve_jurisdiction(CONFIG, "Route 1")
+    assert match.contacts[0]["email"] == "roads@dot.example.gov"
+
+
+def test_an_unlisted_road_is_not_redirected():
+    assert resolve_jurisdiction(CONFIG, "Elm Street") is None
+
+
+def test_a_town_claimed_road_beats_an_agency_claim():
+    config = dict(CONFIG, inclusion_list="Route 130")
+    assert resolve_jurisdiction(config, "Route 130") is None
+
+
+# ---- the shapes that came before ------------------------------------------
+
+def test_the_explicit_jurisdictions_shape_still_wins():
+    config = dict(CONFIG, jurisdictions=[
+        {"name": "Turnpike Authority", "roads": ["Route 1"], "message": "", "contacts": []},
+    ])
+    assert [j["name"] for j in jurisdictions_from_config(config)] == ["Turnpike Authority"]
+
+
+def test_the_pre_multi_jurisdiction_shape_still_works():
+    """Contacts as a plain list with no roads on them: the old single-agency
+    config, which must not be mistaken for the per-agency shape."""
+    legacy = {
+        "exclusion_list": "Route 1",
+        "third_party_name": "State DOT",
+        "third_party_message": "State highway.",
+        "third_party_contacts": [{"name": "State DOT", "phone": "555-0100", "url": ""}],
+    }
+    match = resolve_jurisdiction(legacy, "Route 1")
+    assert match.name == "State DOT"
+    assert match.message == "State highway."
+    assert match.contacts == [{"name": "State DOT", "phone": "555-0100", "url": ""}]
+
+
+def test_an_agency_with_no_roads_is_skipped_not_promoted():
+    """A half-filled card must not swallow every road via the legacy branch."""
+    config = {
+        "third_party_contacts": [
+            {"name": "Half-filled", "phone": "555-0300"},
+            {"name": "County DPW", "phone": "555-0200", "road_list": "Cranbury Rd"},
+        ],
+        "exclusion_list": "Cranbury Rd",
+    }
+    built = jurisdictions_from_config(config)
+    assert [j["name"] for j in built] == ["County DPW"]
+
+
+def test_both_resolvers_read_the_config_identically():
+    """The spatial resolver had its own copy of this parsing. A resident in the
+    portal and the same report phoned in must not get different answers."""
+    from app.services import road_geometry
+
+    assert road_geometry._jurisdictions(CONFIG) == jurisdictions_from_config(CONFIG)

--- a/backend/tests/test_per_agency_routing.py
+++ b/backend/tests/test_per_agency_routing.py
@@ -122,6 +122,8 @@ def test_an_agency_with_no_roads_is_skipped_not_promoted():
 def test_both_resolvers_read_the_config_identically():
     """The spatial resolver had its own copy of this parsing. A resident in the
     portal and the same report phoned in must not get different answers."""
-    from app.services import road_geometry
+    road_geometry = pytest.importorskip(
+        "app.services.road_geometry",  # needs geoalchemy2, absent in CI
+    )
 
     assert road_geometry._jurisdictions(CONFIG) == jurisdictions_from_config(CONFIG)

--- a/frontend/src/components/RedirectNotice.tsx
+++ b/frontend/src/components/RedirectNotice.tsx
@@ -35,6 +35,10 @@ interface RedirectNoticeProps {
     jurisdiction?: string | null;
     /** The clerk's own wording for this agency, if they wrote any. */
     message?: string;
+    /** True when `message` is the backend's generated sentence rather than the
+     *  clerk's. It restates the heading, so the notice says something more
+     *  useful instead. */
+    messageIsDefault?: boolean;
     contacts: RedirectContact[];
     /** The road the pin landed on, when the redirect was decided spatially. */
     roadName?: string | null;
@@ -60,10 +64,10 @@ function ContactAction({ icon: Icon, label, value, kind }: {
         <a
             href={href(kind, value)}
             {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-            className="contact-action group flex items-center gap-3 rounded-2xl bg-white/[0.06] hover:bg-white/[0.11] border border-white/10 hover:border-white/20 px-4 py-3 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/70"
+            className="contact-action group flex items-center gap-3 rounded-2xl bg-white/[0.06] hover:bg-white/[0.11] border border-white/10 hover:border-white/20 px-4 py-3 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70"
         >
             <span className="w-9 h-9 rounded-xl bg-white/10 flex items-center justify-center shrink-0">
-                <Icon className="w-4 h-4 text-amber-200" aria-hidden="true" />
+                <Icon className="w-4 h-4 text-rose-300" aria-hidden="true" />
             </span>
             <span className="min-w-0 flex-1">
                 <span className="block text-[11px] uppercase tracking-wider text-white/45 font-semibold">{label}</span>
@@ -85,7 +89,7 @@ function ContactAction({ icon: Icon, label, value, kind }: {
 }
 
 export default function RedirectNotice({
-    jurisdiction, message, contacts, roadName, variant = 'road',
+    jurisdiction, message, messageIsDefault, contacts, roadName, variant = 'road',
 }: RedirectNoticeProps) {
     const agency = (jurisdiction || '').trim();
     const heading = agency
@@ -105,36 +109,37 @@ export default function RedirectNotice({
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25, ease: 'easeOut' }}
             role="status"
-            className="relative overflow-hidden rounded-3xl border border-amber-300/25 bg-gradient-to-br from-amber-500/[0.14] via-orange-500/[0.08] to-transparent shadow-xl"
+            className="relative overflow-hidden rounded-3xl border border-rose-400/30 bg-gradient-to-br from-rose-500/[0.17] via-red-500/[0.09] to-transparent shadow-xl"
         >
             {/* Top glow accent, matching the service cards. */}
             <div
-                className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-amber-200/60 to-transparent"
+                className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-300/60 to-transparent"
                 aria-hidden="true"
             />
             <div
-                className="pointer-events-none absolute -top-24 left-1/2 -translate-x-1/2 w-72 h-48 rounded-full bg-amber-400/15 blur-3xl"
+                className="pointer-events-none absolute -top-24 left-1/2 -translate-x-1/2 w-72 h-48 rounded-full bg-rose-500/15 blur-3xl"
                 aria-hidden="true"
             />
 
             <div className="relative p-6 sm:p-7">
                 <div className="flex items-start gap-4">
-                    <span className="w-11 h-11 rounded-2xl bg-amber-400/15 border border-amber-300/25 flex items-center justify-center shrink-0">
-                        <Building2 className="w-5 h-5 text-amber-200" aria-hidden="true" />
+                    <span className="w-11 h-11 rounded-2xl bg-rose-500/15 border border-rose-400/30 flex items-center justify-center shrink-0">
+                        <Building2 className="w-5 h-5 text-rose-300" aria-hidden="true" />
                     </span>
                     <div className="min-w-0 flex-1">
-                        <p className="text-[11px] uppercase tracking-[0.14em] text-amber-200/70 font-bold">
+                        <p className="text-[11px] uppercase tracking-[0.14em] text-rose-300/85 font-bold">
                             Report this to another agency
                         </p>
                         <h3 className="text-lg sm:text-xl font-semibold text-white mt-1 leading-snug">
                             {heading}
                         </h3>
 
-                        {message ? (
+                        {message && !messageIsDefault ? (
                             <p className="text-white/70 mt-2.5 leading-relaxed">{message}</p>
                         ) : (
-                            /* Only when the clerk wrote nothing -- otherwise this
-                               restates their own sentence back at the resident. */
+                            /* The clerk wrote nothing, so `message` is the generated
+                               sentence, which is the heading again. Say something the
+                               heading does not. */
                             <p className="text-white/70 mt-2.5 leading-relaxed">
                                 The town cannot take this one, so filing it here would not reach
                                 anyone who can fix it. {agency || 'The agency below'} accepts

--- a/frontend/src/components/RedirectNotice.tsx
+++ b/frontend/src/components/RedirectNotice.tsx
@@ -42,6 +42,9 @@ interface RedirectNoticeProps {
     contacts: RedirectContact[];
     /** The road the pin landed on, when the redirect was decided spatially. */
     roadName?: string | null;
+    /** The category being reported, e.g. "Pothole". Lets the heading say what
+     *  is handled elsewhere, not just where. */
+    serviceName?: string | null;
     /** Whole-service redirects are not about a location, so they say less. */
     variant?: 'road' | 'service';
 }
@@ -64,13 +67,13 @@ function ContactAction({ icon: Icon, label, value, kind }: {
         <a
             href={href(kind, value)}
             {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-            className="contact-action group flex items-center gap-3 rounded-2xl bg-white/[0.06] hover:bg-white/[0.11] border border-white/10 hover:border-white/20 px-4 py-3 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70"
+            className="contact-action group flex items-center gap-3 rounded-2xl bg-white/[0.09] hover:bg-white/[0.15] border border-white/[0.14] hover:border-white/25 px-4 py-3 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-300/70"
         >
-            <span className="w-9 h-9 rounded-xl bg-white/10 flex items-center justify-center shrink-0">
-                <Icon className="w-4 h-4 text-rose-300" aria-hidden="true" />
+            <span className="w-9 h-9 rounded-xl bg-white/[0.13] flex items-center justify-center shrink-0">
+                <Icon className="w-4 h-4 text-rose-200" aria-hidden="true" />
             </span>
             <span className="min-w-0 flex-1">
-                <span className="block text-[11px] uppercase tracking-wider text-white/45 font-semibold">{label}</span>
+                <span className="block text-[11px] uppercase tracking-wider text-white/55 font-semibold">{label}</span>
                 {/* anywhere, not break-all: a long address still wraps rather than
                     widening the card, but it breaks at a sensible point instead of
                     mid-word ("example.go / v"). */}
@@ -89,16 +92,26 @@ function ContactAction({ icon: Icon, label, value, kind }: {
 }
 
 export default function RedirectNotice({
-    jurisdiction, message, messageIsDefault, contacts, roadName, variant = 'road',
+    jurisdiction, message, messageIsDefault, contacts, roadName, serviceName,
+    variant = 'road',
 }: RedirectNoticeProps) {
     const agency = (jurisdiction || '').trim();
-    const heading = agency
-        ? (variant === 'road' && roadName
-            ? `${roadName} is maintained by ${agency}`
-            : `${agency} handles this`)
-        : (variant === 'road'
-            ? 'This road is maintained by another agency'
-            : 'Another agency handles this');
+    const category = (serviceName || '').trim();
+
+    /* One sentence carrying all three facts: what is being reported, where, and
+       whose it is -- "Pothole reports on Route 1 are handled by New Jersey DOT".
+       That is the whole explanation, so nothing below needs to restate it.
+       "reports" keeps it grammatical whatever the category is called, singular
+       ("Pothole") or not ("Street Light Out"). */
+    const heading = (() => {
+        const who = agency || 'another agency';
+        if (category && roadName && variant === 'road') {
+            return `${category} reports on ${roadName} are handled by ${who}`;
+        }
+        if (category) return `${category} reports are handled by ${who}`;
+        if (roadName && variant === 'road') return `${roadName} is maintained by ${who}`;
+        return `${who} handles this`;
+    })();
 
     // Empty names would render as a blank contact block.
     const usable = contacts.filter(c => c && (c.phone || c.email || c.url || c.name));
@@ -109,42 +122,36 @@ export default function RedirectNotice({
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.25, ease: 'easeOut' }}
             role="status"
-            className="relative overflow-hidden rounded-3xl border border-rose-400/30 bg-gradient-to-br from-rose-500/[0.17] via-red-500/[0.09] to-transparent shadow-xl"
+            className="relative overflow-hidden rounded-3xl border border-white/[0.14] bg-white/[0.06] bg-gradient-to-br from-rose-400/[0.10] via-transparent to-transparent shadow-xl"
         >
             {/* Top glow accent, matching the service cards. */}
             <div
-                className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-300/60 to-transparent"
+                className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-200/70 to-transparent"
                 aria-hidden="true"
             />
             <div
-                className="pointer-events-none absolute -top-24 left-1/2 -translate-x-1/2 w-72 h-48 rounded-full bg-rose-500/15 blur-3xl"
+                className="pointer-events-none absolute -top-20 -left-10 w-64 h-40 rounded-full bg-rose-400/15 blur-3xl"
                 aria-hidden="true"
             />
 
             <div className="relative p-6 sm:p-7">
                 <div className="flex items-start gap-4">
-                    <span className="w-11 h-11 rounded-2xl bg-rose-500/15 border border-rose-400/30 flex items-center justify-center shrink-0">
-                        <Building2 className="w-5 h-5 text-rose-300" aria-hidden="true" />
+                    <span className="w-11 h-11 rounded-2xl bg-rose-400/20 border border-rose-300/35 flex items-center justify-center shrink-0">
+                        <Building2 className="w-5 h-5 text-rose-200" aria-hidden="true" />
                     </span>
                     <div className="min-w-0 flex-1">
-                        <p className="text-[11px] uppercase tracking-[0.14em] text-rose-300/85 font-bold">
+                        <p className="text-[11px] uppercase tracking-[0.14em] text-rose-200/90 font-bold">
                             Report this to another agency
                         </p>
                         <h3 className="text-lg sm:text-xl font-semibold text-white mt-1 leading-snug">
                             {heading}
                         </h3>
 
-                        {message && !messageIsDefault ? (
+                        {/* Only the clerk's own words. When they wrote none, the
+                            backend's default just restates the heading, and a
+                            paragraph of filler underneath it reads as padding. */}
+                        {message && !messageIsDefault && (
                             <p className="text-white/70 mt-2.5 leading-relaxed">{message}</p>
-                        ) : (
-                            /* The clerk wrote nothing, so `message` is the generated
-                               sentence, which is the heading again. Say something the
-                               heading does not. */
-                            <p className="text-white/70 mt-2.5 leading-relaxed">
-                                The town cannot take this one, so filing it here would not reach
-                                anyone who can fix it. {agency || 'The agency below'} accepts
-                                reports directly.
-                            </p>
                         )}
                     </div>
                 </div>
@@ -152,9 +159,9 @@ export default function RedirectNotice({
                 {/* Why this road, and how to disagree with it. The most common cause of
                     a wrong redirect is a pin a lane off, and only the resident can see that. */}
                 {variant === 'road' && roadName && (
-                    <div className="mt-5 flex items-start gap-2.5 rounded-2xl bg-white/[0.04] border border-white/10 px-4 py-3">
+                    <div className="mt-5 flex items-start gap-2.5 rounded-2xl bg-white/[0.07] border border-white/[0.12] px-4 py-3">
                         <MapPin className="w-4 h-4 text-white/40 mt-0.5 shrink-0" aria-hidden="true" />
-                        <p className="text-sm text-white/60 leading-relaxed">
+                        <p className="text-sm text-white/70 leading-relaxed">
                             Your pin is on <span className="text-white/90 font-medium">{roadName}</span>.
                             If that is not the road you meant, move the pin and this will update.
                         </p>
@@ -163,7 +170,7 @@ export default function RedirectNotice({
 
                 {usable.length > 0 && (
                     <div className="mt-5">
-                        <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold mb-2.5">
+                        <p className="text-[11px] uppercase tracking-wider text-white/55 font-semibold mb-2.5">
                             How to reach them
                         </p>
                         <div className="space-y-3">

--- a/frontend/src/components/RedirectNotice.tsx
+++ b/frontend/src/components/RedirectNotice.tsx
@@ -1,0 +1,191 @@
+import { motion } from 'framer-motion';
+import { ArrowUpRight, Building2, ExternalLink, Mail, MapPin, Phone } from 'lucide-react';
+
+/**
+ * What a resident sees when the thing they are reporting is not the town's to fix.
+ *
+ * This is the least satisfying moment in the portal, so it carries the most
+ * design weight. Someone has already picked a category, dropped a pin and, very
+ * often, taken a photo. Being turned away at that point reads as rejection
+ * unless three things are unmistakable:
+ *
+ *   1. WHO. Named, once, in the heading -- not "another agency". The redirect is
+ *      only credible if it can say whose road it is.
+ *   2. WHY. The road that decided it, spelled out, because the most common cause
+ *      of a wrong redirect is a pin one lane off. Naming the road is what lets
+ *      someone notice that and drag it back.
+ *   3. WHAT NOW. The contact details as things you can press -- a phone number
+ *      that dials, an address that composes, a site that opens -- rather than
+ *      text to copy down. On a phone at the roadside that difference is the
+ *      whole interaction.
+ *
+ * It is deliberately not styled as an error. Nothing has gone wrong; the report
+ * is being pointed somewhere it will actually be read.
+ */
+
+export interface RedirectContact {
+    name?: string;
+    phone?: string;
+    email?: string;
+    url?: string;
+}
+
+interface RedirectNoticeProps {
+    /** The agency, already resolved to the one that owns this road. */
+    jurisdiction?: string | null;
+    /** The clerk's own wording for this agency, if they wrote any. */
+    message?: string;
+    contacts: RedirectContact[];
+    /** The road the pin landed on, when the redirect was decided spatially. */
+    roadName?: string | null;
+    /** Whole-service redirects are not about a location, so they say less. */
+    variant?: 'road' | 'service';
+}
+
+function href(kind: 'phone' | 'email' | 'url', value: string): string {
+    if (kind === 'phone') return `tel:${value.replace(/[^\d+]/g, '')}`;
+    if (kind === 'email') return `mailto:${value}`;
+    return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+/** One pressable contact row: what it is, the actual value, and an affordance. */
+function ContactAction({ icon: Icon, label, value, kind }: {
+    icon: typeof Phone;
+    label: string;
+    value: string;
+    kind: 'phone' | 'email' | 'url';
+}) {
+    const external = kind === 'url';
+    return (
+        <a
+            href={href(kind, value)}
+            {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            className="contact-action group flex items-center gap-3 rounded-2xl bg-white/[0.06] hover:bg-white/[0.11] border border-white/10 hover:border-white/20 px-4 py-3 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/70"
+        >
+            <span className="w-9 h-9 rounded-xl bg-white/10 flex items-center justify-center shrink-0">
+                <Icon className="w-4 h-4 text-amber-200" aria-hidden="true" />
+            </span>
+            <span className="min-w-0 flex-1">
+                <span className="block text-[11px] uppercase tracking-wider text-white/45 font-semibold">{label}</span>
+                {/* anywhere, not break-all: a long address still wraps rather than
+                    widening the card, but it breaks at a sensible point instead of
+                    mid-word ("example.go / v"). */}
+                <span className="block text-sm text-white font-medium [overflow-wrap:anywhere]">{value}</span>
+            </span>
+            {/* Decorative -- the leading icon and the label already say this is an
+                action. Hidden on narrow screens because the ~28px it occupies is
+                the difference between an email address fitting on one line and
+                breaking mid-word. */}
+            <ArrowUpRight
+                className="hidden sm:block w-4 h-4 text-white/25 group-hover:text-white/60 shrink-0 transition-colors"
+                aria-hidden="true"
+            />
+        </a>
+    );
+}
+
+export default function RedirectNotice({
+    jurisdiction, message, contacts, roadName, variant = 'road',
+}: RedirectNoticeProps) {
+    const agency = (jurisdiction || '').trim();
+    const heading = agency
+        ? (variant === 'road' && roadName
+            ? `${roadName} is maintained by ${agency}`
+            : `${agency} handles this`)
+        : (variant === 'road'
+            ? 'This road is maintained by another agency'
+            : 'Another agency handles this');
+
+    // Empty names would render as a blank contact block.
+    const usable = contacts.filter(c => c && (c.phone || c.email || c.url || c.name));
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, ease: 'easeOut' }}
+            role="status"
+            className="relative overflow-hidden rounded-3xl border border-amber-300/25 bg-gradient-to-br from-amber-500/[0.14] via-orange-500/[0.08] to-transparent shadow-xl"
+        >
+            {/* Top glow accent, matching the service cards. */}
+            <div
+                className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-amber-200/60 to-transparent"
+                aria-hidden="true"
+            />
+            <div
+                className="pointer-events-none absolute -top-24 left-1/2 -translate-x-1/2 w-72 h-48 rounded-full bg-amber-400/15 blur-3xl"
+                aria-hidden="true"
+            />
+
+            <div className="relative p-6 sm:p-7">
+                <div className="flex items-start gap-4">
+                    <span className="w-11 h-11 rounded-2xl bg-amber-400/15 border border-amber-300/25 flex items-center justify-center shrink-0">
+                        <Building2 className="w-5 h-5 text-amber-200" aria-hidden="true" />
+                    </span>
+                    <div className="min-w-0 flex-1">
+                        <p className="text-[11px] uppercase tracking-[0.14em] text-amber-200/70 font-bold">
+                            Report this to another agency
+                        </p>
+                        <h3 className="text-lg sm:text-xl font-semibold text-white mt-1 leading-snug">
+                            {heading}
+                        </h3>
+
+                        {message ? (
+                            <p className="text-white/70 mt-2.5 leading-relaxed">{message}</p>
+                        ) : (
+                            /* Only when the clerk wrote nothing -- otherwise this
+                               restates their own sentence back at the resident. */
+                            <p className="text-white/70 mt-2.5 leading-relaxed">
+                                The town cannot take this one, so filing it here would not reach
+                                anyone who can fix it. {agency || 'The agency below'} accepts
+                                reports directly.
+                            </p>
+                        )}
+                    </div>
+                </div>
+
+                {/* Why this road, and how to disagree with it. The most common cause of
+                    a wrong redirect is a pin a lane off, and only the resident can see that. */}
+                {variant === 'road' && roadName && (
+                    <div className="mt-5 flex items-start gap-2.5 rounded-2xl bg-white/[0.04] border border-white/10 px-4 py-3">
+                        <MapPin className="w-4 h-4 text-white/40 mt-0.5 shrink-0" aria-hidden="true" />
+                        <p className="text-sm text-white/60 leading-relaxed">
+                            Your pin is on <span className="text-white/90 font-medium">{roadName}</span>.
+                            If that is not the road you meant, move the pin and this will update.
+                        </p>
+                    </div>
+                )}
+
+                {usable.length > 0 && (
+                    <div className="mt-5">
+                        <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold mb-2.5">
+                            How to reach them
+                        </p>
+                        <div className="space-y-3">
+                            {usable.map((contact, idx) => (
+                                <div key={idx} className="space-y-2">
+                                    {/* Only when there is more than one to tell apart. With a
+                                        single contact this just reprints the heading. */}
+                                    {usable.length > 1 && contact.name && (
+                                        <p className="text-sm font-semibold text-white/85">{contact.name}</p>
+                                    )}
+                                    <div className="grid gap-2 sm:grid-cols-2">
+                                        {contact.phone && (
+                                            <ContactAction icon={Phone} label="Call" value={contact.phone} kind="phone" />
+                                        )}
+                                        {contact.email && (
+                                            <ContactAction icon={Mail} label="Email" value={contact.email} kind="email" />
+                                        )}
+                                        {contact.url && (
+                                            <ContactAction icon={ExternalLink} label="Report online" value={contact.url} kind="url" />
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -652,17 +652,27 @@ a:focus-visible {
 
 /* Link underlines for accessibility.
  *
- * `.brand-link` opts out. The rule exists so a link inside a paragraph is
- * distinguishable without relying on colour, which is the right default -- but
- * the "Powered by <logo>" credit is a wordmark, not prose. The underline drew
- * under the words and stopped at the image, which read as a rendering fault
- * rather than a link. Its target is unambiguous from the logo itself. */
-a:not(.skip-link):not(.brand-link):not([class*="btn"]):not([class*="button"]) {
+ * The rule exists so a link inside a paragraph is distinguishable without
+ * relying on colour, which is the right default. Two things opt out, both
+ * because they are not prose links and already meet that bar by other means:
+ *
+ *   `.brand-link` -- the "Powered by <logo>" credit is a wordmark. The
+ *   underline drew under the words and stopped at the image, which read as a
+ *   rendering fault rather than a link.
+ *
+ *   `.contact-action` -- the call/email/website rows in the redirect notice.
+ *   Each is a bordered card with its own background, a leading icon and a
+ *   trailing arrow, so it is identifiable as an action with colour removed.
+ *   Underlining the phone number inside it made a button look like broken text.
+ *
+ * Specificity here is deliberately above Tailwind's utilities, so `no-underline`
+ * on the element will NOT work -- add the class to this list instead. */
+a:not(.skip-link):not(.brand-link):not(.contact-action):not([class*="btn"]):not([class*="button"]) {
     text-decoration: underline;
     text-underline-offset: 2px;
 }
 
-a:not(.skip-link):not(.brand-link):not([class*="btn"]):not([class*="button"]):hover {
+a:not(.skip-link):not(.brand-link):not(.contact-action):not([class*="btn"]):not([class*="button"]):hover {
     text-decoration-thickness: 2px;
 }
 

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -83,7 +83,7 @@ import { useAuth } from '../context/AuthContext';
 import { useSettings } from '../context/SettingsContext';
 import { useDialog } from '../components/DialogProvider';
 import { api, MapLayer } from '../services/api';
-import { User, ServiceDefinition, SystemSettings, SystemSecret, Department } from '../types';
+import { User, ServiceDefinition, SystemSettings, SystemSecret, Department, RoutingContact } from '../types';
 import { usePageNavigation } from '../hooks/usePageNavigation';
 import ClientErrorPanel from '../components/ClientErrorPanel';
 import OperationsPanel from '../components/OperationsPanel';
@@ -609,13 +609,15 @@ export default function AdminConsole() {
             staff_ids: [] as number[],
             // Third party mode
             message: '',
-            contacts: [] as { name: string; phone: string; url: string }[],
+            contacts: [] as RoutingContact[],
             // Road-based mode
             default_handler: 'township' as 'township' | 'third_party',
             exclusion_list: '', // County roads (when township is default)
             inclusion_list: '', // Township roads (when third party is default)
             third_party_message: '',
-            third_party_contacts: [] as { name: string; phone: string; email?: string; url: string; message?: string; road_list?: string; roads?: string[] }[],
+            // The shared shape, so the admin state, the API type and the
+            // resident-facing notice cannot drift apart again.
+            third_party_contacts: [] as RoutingContact[],
             // Custom questions
             custom_questions: [] as { id: string; label: string; type: string; options: string[]; required: boolean; placeholder: string }[],
         },

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -611,7 +611,10 @@ export default function AdminConsole() {
             message: '',
             contacts: [] as RoutingContact[],
             // Road-based mode
-            default_handler: 'township' as 'township' | 'third_party',
+            // 'township', or a configured agency's name. Not a closed union:
+            // narrowing it here is what forced the `as any` that hid the value
+            // never matching an agency.
+            default_handler: 'township' as string,
             exclusion_list: '', // County roads (when township is default)
             inclusion_list: '', // Township roads (when third party is default)
             third_party_message: '',
@@ -3817,7 +3820,7 @@ export default function AdminConsole() {
                                     value={serviceRouting.routing_config.default_handler}
                                     onChange={(e) => setServiceRouting(p => ({
                                         ...p,
-                                        routing_config: { ...p.routing_config, default_handler: e.target.value as any }
+                                        routing_config: { ...p.routing_config, default_handler: e.target.value }
                                     }))}
                                     className="w-full h-11 rounded-2xl bg-white/[0.08] border border-white/20 text-white px-4 text-sm focus:outline-none focus:border-amber-400"
                                     aria-label="Who handles a road that is not listed"

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -3799,9 +3799,20 @@ export default function AdminConsole() {
                                 <Route className="w-4 h-4" /> Road-Based Routing
                             </h4>
 
-                            {/* Default Handler */}
+                            {/* Default Handler.
+
+                                This used to offer a generic "Third party handles by
+                                default", which stored the literal string "third_party".
+                                The backend resolves this setting by matching it against
+                                the configured agencies' names, so it matched nothing and
+                                every road quietly stayed with the town -- the exact
+                                opposite of what was selected. Naming the agency makes the
+                                setting mean something, and with several agencies it is
+                                the only way to say which one gets an unlisted road. */}
                             <div className="space-y-2">
-                                <label className="block text-xs font-bold uppercase tracking-wider text-white/70">Default Handler</label>
+                                <label className="block text-xs font-bold uppercase tracking-wider text-white/70">
+                                    Who handles a road that is not listed below?
+                                </label>
                                 <select
                                     value={serviceRouting.routing_config.default_handler}
                                     onChange={(e) => setServiceRouting(p => ({
@@ -3809,11 +3820,35 @@ export default function AdminConsole() {
                                         routing_config: { ...p.routing_config, default_handler: e.target.value as any }
                                     }))}
                                     className="w-full h-11 rounded-2xl bg-white/[0.08] border border-white/20 text-white px-4 text-sm focus:outline-none focus:border-amber-400"
-                                    aria-label="Default handler"
+                                    aria-label="Who handles a road that is not listed"
                                 >
-                                    <option value="township">Municipality handles by default</option>
-                                    <option value="third_party">Third party handles by default</option>
+                                    <option value="township">The municipality (roads below are the exceptions)</option>
+                                    {(serviceRouting.routing_config.third_party_contacts || [])
+                                        .map(a => (a?.name || '').trim())
+                                        .filter(Boolean)
+                                        .map(name => (
+                                            <option key={name} value={name}>
+                                                {name} (the municipality keeps only its own roads)
+                                            </option>
+                                        ))}
+                                    {/* Keep a saved value selectable even if that agency was
+                                        since renamed, so opening the modal cannot silently
+                                        reset the setting to "municipality" on the next save. */}
+                                    {serviceRouting.routing_config.default_handler
+                                        && serviceRouting.routing_config.default_handler !== 'township'
+                                        && !(serviceRouting.routing_config.third_party_contacts || [])
+                                            .some(a => (a?.name || '').trim() === serviceRouting.routing_config.default_handler) && (
+                                            <option value={serviceRouting.routing_config.default_handler}>
+                                                {serviceRouting.routing_config.default_handler === 'third_party'
+                                                    ? 'A third party (not yet named — pick an agency above)'
+                                                    : `${serviceRouting.routing_config.default_handler} (no longer configured)`}
+                                            </option>
+                                        )}
                                 </select>
+                                <p className="text-xs text-white/45">
+                                    Pick an agency to invert the rule: they maintain everything
+                                    except the roads you list as the municipality's.
+                                </p>
                             </div>
 
                             {/* Municipality Department */}

--- a/frontend/src/pages/ResidentPortal.tsx
+++ b/frontend/src/pages/ResidentPortal.tsx
@@ -18,7 +18,6 @@ import {
     Camera,
     X,
     Phone,
-    ExternalLink,
     ClipboardList,
     Globe,
     Facebook,
@@ -30,6 +29,7 @@ import {
 } from 'lucide-react';
 import { Button, Input, Textarea, Card } from '../components/ui';
 import LocationPicker from '../components/LocationPicker';
+import RedirectNotice, { RedirectContact } from '../components/RedirectNotice';
 import TrackRequests from '../components/TrackRequests';
 import LanguageSelector from '../components/LanguageSelector';
 import StaffDashboardMap from '../components/StaffDashboardMap';
@@ -215,7 +215,7 @@ export default function ResidentPortal() {
     // rather than only quoting the town's configured sentence.
     const [blockJurisdiction, setBlockJurisdiction] = useState<string | null>(null);
     const [blockMessage, setBlockMessage] = useState('');
-    const [blockContacts, setBlockContacts] = useState<{ name: string; phone: string; url: string }[]>([]);
+    const [blockContacts, setBlockContacts] = useState<RedirectContact[]>([]);
 
     // Custom question answers
     const [customAnswers, setCustomAnswers] = useState<Record<string, string | string[]>>({});
@@ -312,8 +312,15 @@ export default function ResidentPortal() {
         // Check if third-party only service - block immediately
         if (service.routing_mode === 'third_party') {
             setIsBlocked(true);
-            setBlockMessage(service.routing_config?.message || 'This service is handled by a third party.');
+            setBlockMessage(service.routing_config?.message || '');
             setBlockContacts(service.routing_config?.contacts || []);
+            // Same fallback the backend uses for this mode: no agency-name field
+            // exists, so the first contact's name is who the clerk named.
+            setBlockJurisdiction(
+                service.routing_config?.third_party_name
+                || service.routing_config?.contacts?.[0]?.name
+                || null,
+            );
         }
 
         setStep('form');
@@ -348,7 +355,14 @@ export default function ResidentPortal() {
             setBlockMessage(result.blocked ? result.message : '');
             setBlockContacts(
                 result.blocked
-                    ? (result.contacts || []).map(c => ({ name: c.name || '', phone: c.phone || '', url: c.url || '' }))
+                    ? (result.contacts || []).map(c => ({
+                        name: c.name || '',
+                        phone: c.phone || '',
+                        // Collected in the routing modal and previously dropped here,
+                        // so an agency that only publishes an address was unreachable.
+                        email: (c as { email?: string }).email || '',
+                        url: c.url || '',
+                    }))
                     : [],
             );
             setBlockJurisdiction(result.blocked ? result.jurisdiction : null);
@@ -955,57 +969,16 @@ export default function ResidentPortal() {
                                     </div>
                                 </div>
 
-                                {/* Third-Party Service Blocking Notice - shown when entire service is third-party */}
+                                {/* Whole service handled elsewhere -- not about a location, so the
+                                    notice omits the road line. Same component as the road-based
+                                    redirect so a resident meets one design, not two. */}
                                 {isBlocked && selectedService.routing_mode === 'third_party' && (
-                                    <motion.div
-                                        initial={{ opacity: 0, y: 20 }}
-                                        animate={{ opacity: 1, y: 0 }}
-                                        className="p-6 rounded-2xl bg-gradient-to-br from-amber-500/20 to-orange-500/20 border border-amber-500/30"
-                                    >
-                                        <div className="flex items-start gap-4">
-                                            <div className="w-12 h-12 rounded-full bg-amber-500/20 flex items-center justify-center flex-shrink-0">
-                                                <AlertCircle className="w-6 h-6 text-amber-400" />
-                                            </div>
-                                            <div className="flex-1">
-                                                <h3 className="text-lg font-semibold text-amber-300 mb-2">
-                                                    {"Third-Party Service"}
-                                                </h3>
-                                                <p className="text-white/70 mb-4">
-                                                    {blockMessage}
-                                                </p>
-
-                                                {blockContacts.length > 0 && (
-                                                    <div className="space-y-3 p-4 rounded-xl bg-white/5">
-                                                        <p className="text-sm text-white/50 font-medium">{"Please contact:"}</p>
-                                                        {blockContacts.map((contact, idx) => (
-                                                            <div key={idx} className="flex flex-wrap gap-4 text-sm">
-                                                                {contact.name && (
-                                                                    <span className="text-white font-semibold">{contact.name}</span>
-                                                                )}
-                                                                {contact.phone && (
-                                                                    <a href={`tel:${contact.phone}`} className="inline-flex items-center gap-2 text-primary-400 hover:text-primary-300 font-medium">
-                                                                        <Phone className="w-4 h-4" />
-                                                                        {contact.phone}
-                                                                    </a>
-                                                                )}
-                                                                {contact.url && (
-                                                                    <a
-                                                                        href={contact.url.startsWith('http') ? contact.url : `https://${contact.url}`}
-                                                                        target="_blank"
-                                                                        rel="noopener noreferrer"
-                                                                        className="inline-flex items-center gap-2 text-white hover:text-primary-200 font-medium underline"
-                                                                    >
-                                                                        <ExternalLink className="w-4 h-4" />
-                                                                        Visit Website
-                                                                    </a>
-                                                                )}
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </motion.div>
+                                    <RedirectNotice
+                                        variant="service"
+                                        jurisdiction={blockJurisdiction}
+                                        message={blockMessage}
+                                        contacts={blockContacts}
+                                    />
                                 )}
 
                                 {/* Form - only show if NOT blocked OR if road-based (need address first) */}
@@ -1105,68 +1078,17 @@ export default function ResidentPortal() {
                                                     </div>
                                                 )}
 
-                                                {/* Blocking Notice for Road-Based Services - shown after map */}
+                                                {/* This road belongs to someone else. detectedRoad is what
+                                                    decided it, and naming it is the only way a resident can
+                                                    spot a pin that landed one lane over and drag it back. */}
                                                 {isBlocked && (
-                                                    <motion.div
-                                                        initial={{ opacity: 0, scale: 0.95 }}
-                                                        animate={{ opacity: 1, scale: 1 }}
-                                                        className="p-6 rounded-2xl bg-gradient-to-br from-red-500/20 to-orange-500/20 border border-red-500/30"
-                                                    >
-                                                        <div className="flex items-start gap-4">
-                                                            <div className="w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center flex-shrink-0">
-                                                                <AlertCircle className="w-6 h-6 text-red-400" />
-                                                            </div>
-                                                            <div className="flex-1">
-                                                                <h3 className="text-lg font-semibold text-red-300 mb-2">
-                                                                    {blockJurisdiction
-                                                                        ? `${blockJurisdiction} maintains this location`
-                                                                        : 'This location is handled by another agency'}
-                                                                </h3>
-                                                                <p className="text-white/70 mb-2">
-                                                                    {blockMessage}
-                                                                </p>
-                                                                {/* Say which road decided this. A redirect with no
-                                                                    reason reads as the system being broken; naming the
-                                                                    road lets someone see it picked the wrong one and
-                                                                    move their pin. */}
-                                                                {detectedRoad && (
-                                                                    <p className="text-white/45 text-sm mb-4">
-                                                                        Your pin is on{' '}
-                                                                        <span className="text-white/70 font-medium">{detectedRoad.name}</span>.
-                                                                        If that is not the road you meant, move the pin and this will update.
-                                                                    </p>
-                                                                )}
-
-                                                                {blockContacts.length > 0 && (
-                                                                    <div className="space-y-2">
-                                                                        <p className="text-sm text-white/50 font-medium">Contact Information:</p>
-                                                                        {blockContacts.map((contact, idx) => (
-                                                                            <div key={idx} className="flex flex-wrap gap-3 text-sm">
-                                                                                {contact.name && (
-                                                                                    <span className="text-white font-medium">{contact.name}</span>
-                                                                                )}
-                                                                                {contact.phone && (
-                                                                                    <a href={`tel:${contact.phone}`} className="text-primary-400 hover:text-primary-300">
-                                                                                        📞 {contact.phone}
-                                                                                    </a>
-                                                                                )}
-                                                                                {contact.url && (
-                                                                                    <a
-                                                                                        href={contact.url.startsWith('http') ? contact.url : `https://${contact.url}`}
-                                                                                        target="_blank"
-                                                                                        rel="noopener noreferrer"
-                                                                                        className="text-white hover:text-primary-200 underline"
-                                                                                    >
-                                                                                        🔗 {"Visit Website"}
-                                                                                    </a>
-                                                                                )}
-                                                                            </div>
-                                                                        ))}
-                                                                    </div>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                    </motion.div>
+                                                    <RedirectNotice
+                                                        variant="road"
+                                                        jurisdiction={blockJurisdiction}
+                                                        message={blockMessage}
+                                                        contacts={blockContacts}
+                                                        roadName={detectedRoad?.name}
+                                                    />
                                                 )}
 
                                                 {/* Photo Upload */}

--- a/frontend/src/pages/ResidentPortal.tsx
+++ b/frontend/src/pages/ResidentPortal.tsx
@@ -215,6 +215,9 @@ export default function ResidentPortal() {
     // rather than only quoting the town's configured sentence.
     const [blockJurisdiction, setBlockJurisdiction] = useState<string | null>(null);
     const [blockMessage, setBlockMessage] = useState('');
+    // Whether blockMessage is the backend's generated sentence rather than the
+    // clerk's own, so the notice can avoid restating its own heading.
+    const [blockMessageIsDefault, setBlockMessageIsDefault] = useState(false);
     const [blockContacts, setBlockContacts] = useState<RedirectContact[]>([]);
 
     // Custom question answers
@@ -313,6 +316,7 @@ export default function ResidentPortal() {
         if (service.routing_mode === 'third_party') {
             setIsBlocked(true);
             setBlockMessage(service.routing_config?.message || '');
+            setBlockMessageIsDefault(!(service.routing_config?.message || '').trim());
             setBlockContacts(service.routing_config?.contacts || []);
             // Same fallback the backend uses for this mode: no agency-name field
             // exists, so the first contact's name is who the clerk named.
@@ -353,6 +357,7 @@ export default function ResidentPortal() {
             setDetectedRoad(result.detected_road);
             setIsBlocked(result.blocked);
             setBlockMessage(result.blocked ? result.message : '');
+            setBlockMessageIsDefault(Boolean(result.blocked && result.message_is_default));
             setBlockContacts(
                 result.blocked
                     ? (result.contacts || []).map(c => ({
@@ -977,6 +982,7 @@ export default function ResidentPortal() {
                                         variant="service"
                                         jurisdiction={blockJurisdiction}
                                         message={blockMessage}
+                                        messageIsDefault={blockMessageIsDefault}
                                         contacts={blockContacts}
                                     />
                                 )}
@@ -1086,6 +1092,7 @@ export default function ResidentPortal() {
                                                         variant="road"
                                                         jurisdiction={blockJurisdiction}
                                                         message={blockMessage}
+                                                        messageIsDefault={blockMessageIsDefault}
                                                         contacts={blockContacts}
                                                         roadName={detectedRoad?.name}
                                                     />

--- a/frontend/src/pages/ResidentPortal.tsx
+++ b/frontend/src/pages/ResidentPortal.tsx
@@ -984,6 +984,7 @@ export default function ResidentPortal() {
                                         message={blockMessage}
                                         messageIsDefault={blockMessageIsDefault}
                                         contacts={blockContacts}
+                                        serviceName={selectedService.service_name}
                                     />
                                 )}
 
@@ -1095,6 +1096,7 @@ export default function ResidentPortal() {
                                                         messageIsDefault={blockMessageIsDefault}
                                                         contacts={blockContacts}
                                                         roadName={detectedRoad?.name}
+                                                        serviceName={selectedService.service_name}
                                                     />
                                                 )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -761,7 +761,9 @@ class ApiClient {
         block_type: string | null;
         jurisdiction: string | null;
         message: string;
-        contacts: { name?: string; phone?: string; url?: string }[];
+        /** True when `message` is the generated sentence, not the clerk's own. */
+        message_is_default?: boolean;
+        contacts: { name?: string; phone?: string; email?: string; url?: string }[];
         road: string | null;
         detected_road: { name: string; distance_m: number } | null;
     }> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,19 @@ export interface CustomQuestion {
 }
 
 // Service types
+/** A third-party agency as the routing modal stores it: contact details flat on
+ *  the entry, plus the roads and message that belong to that agency alone. */
+export interface RoutingContact {
+    name?: string;
+    phone?: string;
+    email?: string;
+    url?: string;
+    message?: string;
+    /** Raw comma-separated text as the clerk types it. */
+    road_list?: string;
+    roads?: string[];
+}
+
 export interface ServiceDefinition {
     id: number;
     service_code: string;
@@ -74,13 +87,17 @@ export interface ServiceDefinition {
         staff_ids?: number[];
         // Third party mode
         message?: string;
-        contacts?: { name: string; phone: string; url: string }[];
+        third_party_name?: string;
+        contacts?: RoutingContact[];
         // Road-based mode
         default_handler?: 'township' | 'third_party';
         exclusion_list?: string[];
         inclusion_list?: string[];
         third_party_message?: string;
-        third_party_contacts?: { name: string; phone: string; url: string }[];
+        /** One entry per agency card in the routing modal. Each owns its own
+         *  roads, message and contact details -- reading them as a single
+         *  flattened list is what showed a resident every agency at once. */
+        third_party_contacts?: RoutingContact[];
         /** Stretches a clerk switched off, keyed to the road publisher's own
          *  feature ids so a data refresh cannot orphan the corrections. */
         excluded_segments?: string[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -90,7 +90,11 @@ export interface ServiceDefinition {
         third_party_name?: string;
         contacts?: RoutingContact[];
         // Road-based mode
-        default_handler?: 'township' | 'third_party';
+        /** Who handles a road no rule names: 'township' for the municipality,
+         *  or a configured agency's name. The old literal 'third_party' is
+         *  still read for configs saved before agencies were named, and
+         *  resolves only when exactly one agency exists. */
+        default_handler?: string;
         exclusion_list?: string[];
         inclusion_list?: string[];
         third_party_message?: string;


### PR DESCRIPTION
Seven commits on top of #412, all in the road-based routing path. Two are real routing bugs; the rest is the resident-facing notice they surface through.

## A redirected resident saw every agency at once

The routing modal writes one card per agency into `third_party_contacts`, each with its own road list, message and contacts, and separately syncs the *combined* road names into `exclusion_list` so the coverage map has something to draw.

Nothing read the per-agency shape. Both resolvers looked for a `jurisdictions` key, did not find it, and fell through to the pre-multi-jurisdiction branch — which reads `exclusion_list` as one nameless agency's roads and returns `third_party_contacts` wholesale as its contacts. Measured on a two-agency config:

```
before   'Route 1'      -> name='Another agency'  message=''
                           contacts = [State DOT, County DPW]
         'Cranbury Rd'  -> name='Another agency'  message=''
                           contacts = [State DOT, County DPW]

after    'Route 1'      -> name='State DOT'   message='Route 1 is a state highway.'
                           contacts = [State DOT]
         'Cranbury Rd'  -> name='County DPW'  message='Cranbury Rd is county-maintained.'
                           contacts = [County DPW]
```

So it was not only leaking the wrong agency's details — the agency name and the clerk's per-agency message were being lost entirely.

Parsing now lives in one `jurisdictions_from_config`, called by both resolvers. They had **separate copies**, which meant a report phoned in through manual intake would have disagreed with the same report filed in the portal.

## "Another agency handles everything but our roads" never worked

The inverted mode — an agency maintains the roads, the town keeps only the ones on its own list — has been in the UI all along and has never done anything, for two independent reasons.

The dropdown stored the literal `"third_party"`. The resolver looks that value up against the configured agencies' names and ids, where it matches nothing, and falls through to "the municipality handles it" — exactly the behaviour selecting it was meant to replace. And the spatial resolver, the one the resident portal uses, never read the setting at all, so even a correctly named agency only took effect for reports typed in by address.

```
before   by address : NOT redirected (stays with town)
         spatially  : NOT redirected (stays with town)

after    by address : redirected to County DPW
         spatially  : redirected to County DPW
         Elm Street (the town's own road): stays with town
```

`default_jurisdiction()` resolves the setting once for both resolvers, and the dropdown now lists configured agencies by name — also the only way to say *which* agency gets an unlisted road when a town has several.

Three judgement calls in here:

- **Ambiguity fails open.** The old literal resolves when exactly one agency is configured and does not when there are several: "a third party" does not say which, and guessing would hand a resident a phone number for a road that agency does not maintain. Same for a default naming a since-deleted agency.
- **Silent failure is how this survived**, so `check_config` reports it — the setting is on, it cannot be resolved, every road is staying with the town, and here is what to do.
- **A stretch switched off or trimmed in the coverage map stays with the town** even under an agency default. The clerk did that deliberately, and inverting it would turn every exclusion into its opposite. An off-road pin is never redirected by the default either.

## What the resident sees

One `RedirectNotice` for both the road-based and whole-service cases, replacing two hand-rolled blocks. The heading carries the whole explanation:

> **Pothole reports on Route 1 are handled by New Jersey DOT**

What, where, whose. "reports" keeps it grammatical whatever a category is called. It degrades to `Stray Animal reports are handled by …` without a road, and `Cranbury Road is maintained by …` without a category.

Contacts are pressable rows — a number that dials, an address that composes, a site that opens — rather than a wrapped line of text with emoji. At the roadside on a phone that is the whole interaction.

**The email the clerk enters now reaches the resident.** It was collected in the modal and dropped in the mapping, so an agency publishing only an address was unreachable.

The backend always fills a message when the clerk leaves one blank, and that default restates the heading — so the common case printed the same sentence twice. The string still has to exist, because API clients of the 409 get only that field, so `BlockDecision` reports `message_is_default` and the notice omits it rather than string-matching a sentence that varies by agency name.

Colour is a neutral glass card with red accents, not a red card: a translucent red wash over a near-black page turns the whole surface maroon, which reads as a crisis banner.

## Also

`RoadCorridorMap`'s zoom tracking called `renderer.onBoundsChange`, which no renderer implements — optional chaining meant it never fired, so `zoomLevel` stayed at its initial 13 for the life of the map. Now on `idle`. The visible corridor was always correct (the canvas overlay reads `view.zoom` itself); what went stale was the clickable width of a road drifting from its drawn width as you zoomed.

`default_handler` was typed `'township' | 'third_party'` with an `as any` hiding the mismatch — a union that does not describe the values plus a cast to silence the compiler is the shape the original bug had.

## Verification

648 backend tests pass, up from 630; the 28 new ones fail against the old resolution, which I checked by stashing the fix. 80 frontend tests pass. Build succeeds. `tsc --noEmit` holds at 11 errors, all pre-existing (9 Azure renderer, 2 dead search state in AdminConsole).

The notice was rendered in real Chromium at 900px and 390px across all three heading shapes — no horizontal overflow, `tel:`/`mailto:`/`https:` targets correct, long addresses wrapping at sensible points.

Not verified end to end against a live deployment with real road data; the routing changes are demonstrated by driving the resolvers directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_