### PR TITLE
Make every provider pluggable from the page, and guide setup one step at a time

### DIFF
--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -286,6 +286,23 @@ async def refresh_ai_models(
     return {"provider": provider, **result}
 
 
+@router.get("/{capability}/catalog", include_in_schema=False)
+async def get_capability_catalog(capability: str, _: User = Depends(get_current_admin)):
+    """Catalog for the capabilities added after the first four, which each had
+    their own near-identical route. Declared before /ai/catalog would shadow it
+    Registered after every hand-written catalog route, because FastAPI takes the
+    first match: declared earlier, this would shadow /ai/catalog and 404 it."""
+    from app.services.delivery_providers import _CATALOGS, catalog_for_api, normalize_provider
+    if capability not in _CATALOGS:
+        raise HTTPException(status_code=404, detail="Unknown capability")
+    from app.services.secret_manager import get_secret
+    from app.services.delivery_providers import _DEFAULTS
+    current = normalize_provider(capability, await get_secret(_PROVIDER_SELECT_KEY[capability]))
+    providers = catalog_for_api(capability)
+    return {"current_provider": current, "default_provider": _DEFAULTS[capability],
+            "providers": providers, "configured": await _configured_map(providers)}
+
+
 # ---- Unified provider save + test (AI / translation / identity) ----
 
 _PROVIDER_SELECT_KEY = {
@@ -293,6 +310,14 @@ _PROVIDER_SELECT_KEY = {
     "translation": "TRANSLATION_PROVIDER",
     "identity": "IDENTITY_PROVIDER",
     "maps": "MAP_PROVIDER",
+    # Four capabilities whose provider switch already existed in the dispatch
+    # code and had no catalog, so nothing surfaced them: notifications went out
+    # through a hand-written SMTP/Twilio card, and KMS and photo redaction could
+    # only be changed by setting a secret by hand.
+    "email": "EMAIL_PROVIDER",
+    "sms": "SMS_PROVIDER",
+    "kms": "KMS_PROVIDER",
+    "redaction": "REDACTION_PROVIDER",
 }
 
 
@@ -341,6 +366,9 @@ def _capability_catalog(capability: str) -> Dict:
     if capability == "maps":
         from app.services.map_provider import MAP_CATALOG
         return MAP_CATALOG
+    if capability in ("email", "sms", "kms", "redaction"):
+        from app.services.delivery_providers import _CATALOGS
+        return _CATALOGS[capability]
     return {}
 
 

--- a/backend/app/services/delivery_providers.py
+++ b/backend/app/services/delivery_providers.py
@@ -223,7 +223,7 @@ REDACTION_CATALOG: Dict[str, Dict[str, Any]] = {
         "boundary": "Google Cloud — Assured Workloads / FedRAMP High",
         "credential_fields": list(_REDACTION_TOGGLES),
         "field_help": {
-            "REDACT_PLATES": "Plate detection guesses. The failure it makes is blurring a house number, so decide knowingly.",
+            "REDACT_PLATES": "On by default. Detection guesses, so it occasionally blurs a house number — switch it off if your crews rely on those.",
         },
     },
     "aws": {

--- a/backend/app/services/delivery_providers.py
+++ b/backend/app/services/delivery_providers.py
@@ -1,0 +1,293 @@
+"""Email, text messaging and PII encryption as pluggable capabilities.
+
+All three were already switchable and none of them was visible. `EMAIL_PROVIDER`
+picks between SMTP, Amazon SES and Azure Communication Services;
+`SMS_PROVIDER` picks between Twilio, a generic HTTP gateway, Amazon SNS and ACS;
+`KMS_PROVIDER` picks which key service wraps the PII encryption key. Every one
+of those branches exists and runs -- see `configure_notifications` in
+tasks/service_requests.py and `pii_crypto.wrap/unwrap` -- but there was no
+catalog for any of them, so the admin UI had a hand-written SMTP-and-Twilio card
+and no way at all to reach the other five providers or to choose a KMS.
+
+The lists here are deliberately confined to what the dispatch code actually
+implements. Offering a provider the backend cannot route to is the failure this
+codebase has produced repeatedly: a setting that stores fine, reads back fine,
+and silently does nothing. Each entry below was checked against its branch.
+
+Credentials resolve through the Secret Manager of record like every other
+capability; this module only says which are needed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+EMAIL_PROVIDER_KEY = "EMAIL_PROVIDER"
+SMS_PROVIDER_KEY = "SMS_PROVIDER"
+KMS_PROVIDER_KEY = "KMS_PROVIDER"
+
+DEFAULT_EMAIL_PROVIDER = "smtp"
+DEFAULT_SMS_PROVIDER = "none"
+DEFAULT_KMS_PROVIDER = "google"
+
+
+# ---- email -------------------------------------------------------------------
+# Branches: tasks/service_requests.py configure_notifications, provider_type
+# "ses" | "acs" | "smtp".
+
+EMAIL_CATALOG: Dict[str, Dict[str, Any]] = {
+    "smtp": {
+        "name": "SMTP",
+        "description": (
+            "Any mail server, including the one your town already has. Works with "
+            "Microsoft 365 and Google Workspace using an app password."
+        ),
+        "boundary": "Wherever your mail server already is",
+        "credential_fields": [
+            {"key": "SMTP_HOST", "label": "SMTP host", "required": True},
+            {"key": "SMTP_PORT", "label": "Port (optional, defaults to 587)", "required": False},
+            {"key": "SMTP_USER", "label": "Username", "required": True},
+            {"key": "SMTP_PASSWORD", "label": "Password", "secret": True, "required": True},
+            {"key": "SMTP_FROM_EMAIL", "label": "From address", "required": True},
+            {"key": "SMTP_FROM_NAME", "label": "From name (optional)", "required": False},
+        ],
+        "field_help": {
+            "SMTP_PASSWORD": "For Microsoft 365 or Google Workspace this is an app password, not the account password.",
+            "SMTP_FROM_EMAIL": "Residents reply to this address, so use one somebody reads.",
+        },
+    },
+    "ses": {
+        "name": "Amazon SES",
+        "description": "Amazon's mail service. Uses the same AWS credentials as the rest of your AWS setup.",
+        "boundary": "AWS — GovCloud available",
+        "credential_fields": [
+            {"key": "AWS_REGION", "label": "AWS Region", "required": True},
+            {"key": "SES_FROM_EMAIL", "label": "Verified from address", "required": True},
+            {"key": "SMTP_FROM_NAME", "label": "From name (optional)", "required": False},
+            {"key": "AWS_ACCESS_KEY_ID", "label": "Access Key ID (optional with an instance role)", "required": False},
+            {"key": "AWS_SECRET_ACCESS_KEY", "label": "Secret Access Key (optional with an instance role)", "secret": True, "required": False},
+        ],
+        "field_help": {
+            "SES_FROM_EMAIL": "SES will not send from an address or domain you have not verified in the console first.",
+        },
+    },
+    "acs": {
+        "name": "Azure Communication Services",
+        "description": "Microsoft's mail service. The natural choice if the rest of your town runs on Azure.",
+        "boundary": "Azure — Government available",
+        "credential_fields": [
+            {"key": "ACS_ENDPOINT", "label": "ACS endpoint", "required": True},
+            {"key": "ACS_ACCESS_KEY", "label": "Access key", "secret": True, "required": True},
+            {"key": "ACS_FROM_EMAIL", "label": "From address", "required": True},
+            {"key": "SMTP_FROM_NAME", "label": "From name (optional)", "required": False},
+        ],
+    },
+}
+
+
+# ---- text messages -----------------------------------------------------------
+# Branches: "twilio" | "http" | "sns" | "acs". Anything else disables SMS, which
+# is why "none" is a first-class entry rather than an empty string a clerk has
+# to guess at.
+
+SMS_CATALOG: Dict[str, Dict[str, Any]] = {
+    "none": {
+        "name": "Off",
+        "description": "No text messages. Residents still get email updates if email is set up.",
+        "boundary": "—",
+        "credential_fields": [],
+    },
+    "twilio": {
+        "name": "Twilio",
+        "description": "The most common choice, and the quickest to set up from nothing.",
+        "boundary": "Twilio (commercial)",
+        "credential_fields": [
+            {"key": "TWILIO_ACCOUNT_SID", "label": "Account SID", "required": True},
+            {"key": "TWILIO_AUTH_TOKEN", "label": "Auth token", "secret": True, "required": True},
+            {"key": "TWILIO_PHONE_NUMBER", "label": "From number", "required": True},
+        ],
+        "field_help": {
+            "TWILIO_PHONE_NUMBER": "In +1XXXXXXXXXX form. It must be a number you own in Twilio.",
+        },
+    },
+    "sns": {
+        "name": "Amazon SNS",
+        "description": "Amazon's messaging service, using the same AWS credentials as the rest of your AWS setup.",
+        "boundary": "AWS — GovCloud available",
+        "credential_fields": [
+            {"key": "AWS_REGION", "label": "AWS Region", "required": True},
+            {"key": "AWS_ACCESS_KEY_ID", "label": "Access Key ID (optional with an instance role)", "required": False},
+            {"key": "AWS_SECRET_ACCESS_KEY", "label": "Secret Access Key (optional with an instance role)", "secret": True, "required": False},
+            {"key": "SMS_SENDER_ID", "label": "Sender ID (optional)", "required": False},
+        ],
+    },
+    "acs": {
+        "name": "Azure Communication Services",
+        "description": "Microsoft's messaging service, sharing the ACS resource with email if you use both.",
+        "boundary": "Azure — Government available",
+        "credential_fields": [
+            {"key": "ACS_ENDPOINT", "label": "ACS endpoint", "required": True},
+            {"key": "ACS_ACCESS_KEY", "label": "Access key", "secret": True, "required": True},
+            {"key": "SMS_FROM_NUMBER", "label": "From number", "required": True},
+        ],
+    },
+    "http": {
+        "name": "Other gateway (HTTP)",
+        "description": (
+            "Any gateway that accepts an HTTP POST. Configure it yourself — this is a generic "
+            "client, not certified against a particular vendor, so run a test send before relying on it."
+        ),
+        "boundary": "Wherever your gateway is",
+        "credential_fields": [
+            {"key": "SMS_HTTP_API_URL", "label": "POST URL", "required": True},
+            {"key": "SMS_HTTP_API_KEY", "label": "API key", "secret": True, "required": False},
+        ],
+    },
+}
+
+
+# ---- PII encryption ----------------------------------------------------------
+# Branches: pii_crypto wrap/unwrap handle "azure", "aws" and "google". Anything
+# else falls back to the application SECRET_KEY, which is a real and supported
+# state for a town with no cloud KMS -- so it is listed honestly rather than
+# hidden.
+
+KMS_CATALOG: Dict[str, Dict[str, Any]] = {
+    "google": {
+        "name": "Google Cloud KMS",
+        "description": "Wraps the key that encrypts resident personal information. Uses your existing Google Cloud service account.",
+        "boundary": "Google Cloud — Assured Workloads / FedRAMP High",
+        "credential_fields": [
+            {"key": "KMS_LOCATION", "label": "Key location (optional, defaults to us-central1)", "required": False},
+            {"key": "KMS_KEY_RING", "label": "Key ring (optional, defaults to pinpoint311-keyring)", "required": False},
+            {"key": "KMS_KEY_ID", "label": "Key name (optional, defaults to pii-encryption-key)", "required": False},
+        ],
+        "field_help": {
+            "KMS_LOCATION": "The project comes from your Google Cloud credentials; these three only name the key within it.",
+        },
+    },
+    "azure": {
+        "name": "Azure Key Vault",
+        "description": "Wraps the PII encryption key in Key Vault. The natural choice for an Azure town.",
+        "boundary": "Azure Government / GCC High",
+        "credential_fields": [
+            {"key": "AZURE_KEYVAULT_URL", "label": "Key Vault URL", "required": True},
+            {"key": "AZURE_KEYVAULT_KEY", "label": "Key name", "required": True},
+            {"key": "AZURE_TENANT_ID", "label": "Directory (tenant) ID", "required": True},
+            {"key": "AZURE_KEYVAULT_CLIENT_ID", "label": "Application (client) ID", "required": True},
+            {"key": "AZURE_KEYVAULT_CLIENT_SECRET", "label": "Client secret", "secret": True, "required": True},
+        ],
+    },
+    "aws": {
+        "name": "AWS KMS",
+        "description": "Wraps the PII encryption key in AWS KMS, using your existing AWS credentials.",
+        "boundary": "AWS — GovCloud available",
+        "credential_fields": [
+            {"key": "AWS_REGION", "label": "AWS Region", "required": True},
+            {"key": "AWS_KMS_KEY_ID", "label": "Key ID or ARN", "required": True},
+        ],
+    },
+    "local": {
+        "name": "Application key (no cloud KMS)",
+        "description": (
+            "Personal information is still encrypted, using the application's own SECRET_KEY "
+            "rather than a cloud key service. Workable for a small town, but the key lives with "
+            "the app, so a cloud KMS is the stronger choice where one is available."
+        ),
+        "boundary": "Self-hosted",
+        "credential_fields": [],
+    },
+}
+
+
+# ---- photo redaction ---------------------------------------------------------
+# Branches: image_redaction.PROVIDERS = ("google", "aws", "azure", "local").
+# It reuses the cloud credentials already entered for AI, so the only settings
+# here are which detector to use and what to blur.
+#
+# The two toggles are stored as strings because that is what the shared save
+# endpoint writes and what image_redaction._flag parses ("1/true/yes/on/enabled").
+
+REDACTION_PROVIDER_KEY = "REDACTION_PROVIDER"
+DEFAULT_REDACTION_PROVIDER = "google"
+
+_REDACTION_TOGGLES = [
+    {"key": "REDACT_FACES", "label": "Blur faces (true/false)", "required": False},
+    {"key": "REDACT_PLATES", "label": "Blur licence plates (true/false)", "required": False},
+]
+
+REDACTION_CATALOG: Dict[str, Dict[str, Any]] = {
+    "google": {
+        "name": "Google Cloud Vision",
+        "description": "Finds faces and plates in resident photos and blurs them before the photo is stored. Uses your existing Google Cloud credentials.",
+        "boundary": "Google Cloud — Assured Workloads / FedRAMP High",
+        "credential_fields": list(_REDACTION_TOGGLES),
+        "field_help": {
+            "REDACT_PLATES": "Plate detection guesses. The failure it makes is blurring a house number, so decide knowingly.",
+        },
+    },
+    "aws": {
+        "name": "Amazon Rekognition",
+        "description": "Amazon's detector, using the AWS credentials already entered elsewhere.",
+        "boundary": "AWS — GovCloud available",
+        "credential_fields": list(_REDACTION_TOGGLES),
+    },
+    "azure": {
+        "name": "Azure AI Vision",
+        "description": "Microsoft's detector, using your Azure credentials.",
+        "boundary": "Azure — Government available",
+        "credential_fields": list(_REDACTION_TOGGLES),
+    },
+    "local": {
+        "name": "On this server (no cloud)",
+        "description": (
+            "Detection runs on your own server with OpenCV and Tesseract — no photo leaves the "
+            "building. Less accurate than the cloud detectors, and the only option that costs nothing "
+            "per photo."
+        ),
+        "boundary": "Self-hosted",
+        "credential_fields": list(_REDACTION_TOGGLES),
+    },
+}
+
+
+_CATALOGS = {
+    "email": EMAIL_CATALOG,
+    "sms": SMS_CATALOG,
+    "kms": KMS_CATALOG,
+    "redaction": REDACTION_CATALOG,
+}
+_DEFAULTS = {
+    "email": DEFAULT_EMAIL_PROVIDER,
+    "sms": DEFAULT_SMS_PROVIDER,
+    "kms": DEFAULT_KMS_PROVIDER,
+    "redaction": DEFAULT_REDACTION_PROVIDER,
+}
+
+
+def catalog_for_api(capability: str) -> List[Dict[str, Any]]:
+    """Provider list in the shape the shared Service Providers UI expects."""
+    return [
+        {
+            "provider": provider_id,
+            "name": spec["name"],
+            "description": spec["description"],
+            "boundary": spec.get("boundary", ""),
+            "credential_fields": spec["credential_fields"],
+            "field_help": spec.get("field_help", {}),
+        }
+        for provider_id, spec in _CATALOGS[capability].items()
+    ]
+
+
+def normalize_provider(capability: str, value: Optional[str]) -> str:
+    """An unknown or missing provider falls back to that capability's default.
+
+    SMS is the one that matters here: the dispatch code treats any unrecognised
+    value as "off", so an empty string and a typo mean the same thing, and the
+    UI should say so rather than showing a blank selection.
+    """
+    candidate = (value or "").strip().lower()
+    if candidate in _CATALOGS[capability]:
+        return candidate
+    return _DEFAULTS[capability]

--- a/backend/app/services/image_redaction.py
+++ b/backend/app/services/image_redaction.py
@@ -637,14 +637,21 @@ async def settings() -> Tuple[Optional[str], bool, bool]:
     on a municipal website is a harm a town incurs by doing nothing, and the
     default should not be the harmful one.
 
-    Plates default off. The detector guesses (see `plate_like`), the failure
-    mode is a blurred house number on an otherwise useful report, and a town
-    should opt into that knowingly.
+    Plates now default on too, for the same reason as faces: a plate published
+    on a municipal website is a harm the town causes by leaving a setting alone,
+    and the privacy-protecting state should be the one you get without acting.
+
+    This is a deliberate reversal. Plates were off because the detector guesses
+    (see `plate_like`) and its failure is a blurred house number on an otherwise
+    useful report -- a real cost, but one a clerk can see and correct, whereas
+    the published plate is one nobody notices until it matters. A town that
+    would rather have the house numbers can switch plates off on the Photo
+    Redaction card, which is reachable now that the card exists.
     """
     provider = await resolve_provider()
     if not provider:
         return (None, False, False)
-    return (provider, await _flag(REDACT_FACES_KEY, True), await _flag(REDACT_PLATES_KEY, False))
+    return (provider, await _flag(REDACT_FACES_KEY, True), await _flag(REDACT_PLATES_KEY, True))
 
 
 # --------------------------------------------------------------------------

--- a/backend/tests/test_capability_catalogs.py
+++ b/backend/tests/test_capability_catalogs.py
@@ -1,0 +1,126 @@
+"""The capabilities whose provider switch existed but was never surfaced.
+
+`EMAIL_PROVIDER`, `SMS_PROVIDER`, `KMS_PROVIDER` and `REDACTION_PROVIDER` are
+each read by live dispatch code -- configure_notifications, pii_crypto's
+wrap/unwrap, and image_redaction's detector selection -- and not one of them had
+a catalog. The admin console had a hand-written SMTP-and-Twilio card and no way
+at all to reach Amazon SES, Azure Communication Services, Amazon SNS, any KMS,
+or photo redaction. Those settings could only be changed by writing a secret by
+hand.
+
+Two things are guarded here, and they are the two ways this goes wrong quietly:
+
+  * every field a card collects must be a key the dispatch code actually reads,
+    or the town types a credential into a box and nothing uses it;
+  * the generic catalog route must stay registered after the hand-written ones,
+    because FastAPI takes the first match and /{capability}/catalog would
+    otherwise shadow /ai/catalog and 404 it.
+"""
+
+import re
+
+import pytest
+
+from app.services.delivery_providers import (
+    _CATALOGS,
+    _DEFAULTS,
+    catalog_for_api,
+    normalize_provider,
+)
+
+# Where each provider's settings are actually consumed.
+DISPATCH_SOURCES = (
+    "app/tasks/service_requests.py",
+    "app/core/encryption.py",
+    "app/core/azure_keyvault.py",
+    "app/core/aws_kms.py",
+    "app/core/pii_crypto.py",
+    "app/services/notifications.py",
+    "app/services/image_redaction.py",
+)
+
+
+def _keys_the_code_reads():
+    seen = set()
+    for path in DISPATCH_SOURCES:
+        try:
+            seen |= set(re.findall(r'"([A-Z][A-Z0-9_]{3,})"', open(path).read()))
+        except OSError:
+            pass
+    return seen
+
+
+def test_every_declared_field_is_a_key_the_code_reads():
+    """The whole failure mode this catalog exists to avoid: a card that collects
+    a credential nothing consumes. Caught three wrong names when written --
+    TWILIO_FROM_NUMBER for TWILIO_PHONE_NUMBER, SMS_API_URL for
+    SMS_HTTP_API_URL, AZURE_KEY_VAULT_URL for AZURE_KEYVAULT_URL."""
+    read = _keys_the_code_reads()
+    orphans = [
+        f"{cap}/{provider}: {field['key']}"
+        for cap, catalog in _CATALOGS.items()
+        for provider, spec in catalog.items()
+        for field in spec["credential_fields"]
+        if field["key"] not in read
+    ]
+    assert not orphans, "fields nothing reads: " + ", ".join(orphans)
+
+
+@pytest.mark.parametrize("capability", sorted(_CATALOGS))
+def test_the_catalog_matches_the_providers_the_dispatch_code_branches_on(capability):
+    """Offering a provider the backend cannot route to stores fine, reads back
+    fine and silently does nothing -- the exact shape of several bugs already
+    fixed in this codebase."""
+    implemented = {
+        "email": {"smtp", "ses", "acs"},
+        "sms": {"none", "twilio", "http", "sns", "acs"},
+        "kms": {"google", "azure", "aws", "local"},
+        "redaction": {"google", "aws", "azure", "local"},
+    }[capability]
+    assert set(_CATALOGS[capability]) == implemented
+
+
+@pytest.mark.parametrize("capability", sorted(_CATALOGS))
+def test_the_api_shape_matches_the_other_capabilities(capability):
+    """Same shape as AI/translation/identity/maps, so the existing card renders
+    them without a special case."""
+    for entry in catalog_for_api(capability):
+        assert set(entry) >= {"provider", "name", "description", "credential_fields"}
+        assert isinstance(entry["credential_fields"], list)
+
+
+@pytest.mark.parametrize("capability", sorted(_CATALOGS))
+def test_an_unknown_provider_falls_back_to_the_default(capability):
+    assert normalize_provider(capability, "nonsense") == _DEFAULTS[capability]
+    assert normalize_provider(capability, None) == _DEFAULTS[capability]
+    assert normalize_provider(capability, "") == _DEFAULTS[capability]
+
+
+def test_sms_off_is_a_real_choice_not_an_empty_string():
+    """The dispatch code treats any unrecognised value as off, so a blank and a
+    typo mean the same thing. The picker says so instead of showing nothing."""
+    assert "none" in _CATALOGS["sms"]
+    assert _CATALOGS["sms"]["none"]["credential_fields"] == []
+
+
+def test_every_capability_has_a_provider_select_key():
+    pytest.importorskip("fastapi")  # system.py pulls in the API stack
+    from app.api.system import _PROVIDER_SELECT_KEY
+
+    for capability in _CATALOGS:
+        assert capability in _PROVIDER_SELECT_KEY, capability
+
+
+def test_the_generic_catalog_route_does_not_shadow_the_handwritten_ones():
+    """FastAPI takes the first match. Declared before /ai/catalog, the generic
+    /{capability}/catalog swallows it and 404s -- which is what happened on the
+    first attempt, and it does not show up in any other test."""
+    pytest.importorskip("fastapi")
+    from app.api.system import router
+
+    paths = [r.path for r in router.routes if r.path.endswith("/catalog")]
+    generic = paths.index("/{capability}/catalog")
+    for handwritten in ("/ai/catalog", "/translation/catalog", "/identity/catalog", "/maps/catalog"):
+        assert paths.index(handwritten) < generic, (
+            f"{handwritten} is registered after the generic route and would be shadowed"
+        )

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -123,7 +123,7 @@ export interface CapStatus {
     configured?: boolean;
 }
 
-function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided }: {
+function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided, instructions }: {
     cap: Capability; title: string; blurb: string; icon: typeof Sparkles; delay: number;
     recheckToken: number; reloadToken: number; onStatus: (cap: Capability, s: CapStatus) => void;
     health?: ConnectorHealth;
@@ -133,6 +133,12 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
      * undefined once setup is done and the page is just cards again. */
     step?: { index: number; total: number; active: boolean };
     guided?: boolean;
+    /* How to obtain the credentials for the provider currently selected,
+     * rendered immediately above the boxes they go into. The instructions used
+     * to sit in one long document at the top of the page, three thousand pixels
+     * from the fields, so following step four meant scrolling away from the
+     * instruction to find the box and back again to read the next one. */
+    instructions?: (provider: string) => ReactNode;
 }) {
     const [catalog, setCatalog] = useState<ProviderCatalog | null>(null);
     const [selected, setSelected] = useState<string>('');
@@ -586,6 +592,16 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                 {active && (active?.credential_fields || []).length > 0 && (
                     <div>
                     <Step n={cap === 'ai' ? 3 : 2}>Credentials</Step>
+                    {instructions?.(selected) && (
+                        <div className="mb-3 rounded-2xl bg-white/[0.05] border border-white/10 px-4 py-3">
+                            <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold mb-1.5">
+                                How to get these
+                            </p>
+                            <div className="text-sm text-white/70 leading-relaxed space-y-1.5">
+                                {instructions(selected)}
+                            </div>
+                        </div>
+                    )}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
                         {active.credential_fields.map(f => {
                             const alreadySet = !!(catalog.configured?.[selected] && selected === catalog.current_provider);
@@ -824,7 +840,7 @@ function CloudEnvironment({ onApplied }: { onApplied: () => void }) {
     );
 }
 
-export default function ServiceProviders({ show, extras }: {
+export default function ServiceProviders({ show, extras, instructions }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -841,6 +857,8 @@ export default function ServiceProviders({ show, extras }: {
      * across both. Rendered here instead, after the capability cards, so the
      * page has one list. */
     extras?: ReactNode;
+    /** Per-capability, per-provider "how to get these credentials". */
+    instructions?: (cap: Capability, provider: string) => ReactNode;
 } = {}) {
     const [recheckToken, setRecheckToken] = useState(0);
     /* One request for the whole section rather than one per card: the endpoint
@@ -983,6 +1001,7 @@ export default function ServiceProviders({ show, extras }: {
                     <CapabilityCard key={c.key} cap={c.key} title={c.title} blurb={c.blurb} icon={c.icon} delay={i * 0.08}
                         recheckToken={recheckToken} reloadToken={reloadToken} onStatus={onStatus}
                         health={health[c.key]} guided={guided}
+                        instructions={instructions ? (provider) => instructions(c.key, provider) : undefined}
                         step={{ index: i, total: visible.length, active: i === cursor }} />
                 ))}
             </div>

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -4,6 +4,7 @@ import {
     Sparkles, Languages, KeyRound, CheckCircle, AlertCircle,
     ChevronDown, Loader2, Check, ShieldCheck, RefreshCw,
     Cloud, MapPin, Lock, Info, Map as MapIcon,
+    Mail, MessageSquare, Image as ImageIcon,
 } from 'lucide-react';
 
 import { CollapsibleSection } from './ui';
@@ -23,7 +24,7 @@ function agoLabel(epochSeconds?: number | null): string {
     return `${Math.round(hrs / 24)}d ago`;
 }
 
-type Capability = 'ai' | 'translation' | 'identity' | 'maps';
+import type { Capability } from '../services/api';
 
 const CAPS: { key: Capability; title: string; blurb: string; icon: typeof Sparkles }[] = [
     { key: 'ai', title: 'AI Provider', blurb: 'Where AI triage & the analytics assistant run. Each town brings its own key and pays only for what it uses.', icon: Sparkles },
@@ -33,6 +34,14 @@ const CAPS: { key: Capability; title: string; blurb: string; icon: typeof Sparkl
     // as switching an AI or translation provider -- same card, same save, same
     // test button. A separate picker elsewhere would be a second thing to learn.
     { key: 'maps', title: 'Maps Provider', blurb: 'Draws the map residents drop a pin on, and looks up addresses. Google is the simplest to set up; Esri suits a town whose county already publishes its own basemap.', icon: MapIcon },
+    // Four capabilities whose provider switch the backend already honoured and
+    // nothing surfaced. Email and text had one hand-written SMTP/Twilio card
+    // between them; PII encryption and photo redaction had no UI at all, so
+    // face and plate blurring was a shipped feature a town could not turn on.
+    { key: 'email', title: 'Email', blurb: 'Sends confirmations and status updates to residents. SMTP works with the mail server your town already has.', icon: Mail },
+    { key: 'sms', title: 'Text Messages', blurb: 'Optional text alerts. Residents who give a mobile number get updates without checking email.', icon: MessageSquare },
+    { key: 'kms', title: 'PII Encryption (KMS)', blurb: 'Which key service wraps the key that encrypts resident personal information. Cloud KMS is stronger than the application key.', icon: Lock },
+    { key: 'redaction', title: 'Photo Redaction', blurb: 'Blurs faces and licence plates in resident photos before they are stored, so a municipal site never publishes them.', icon: ImageIcon },
 ];
 
 /** A numbered section heading inside a provider card.

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -823,7 +824,7 @@ function CloudEnvironment({ onApplied }: { onApplied: () => void }) {
     );
 }
 
-export default function ServiceProviders({ show }: {
+export default function ServiceProviders({ show, extras }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -833,6 +834,13 @@ export default function ServiceProviders({ show }: {
      * them, so hiding them behind a question would let someone opt out of
      * having a working system. */
     show?: Set<Capability>;
+    /* The settings that are not a provider choice -- the Google Cloud
+     * credentials, error reporting, database backups. They lived in a second
+     * collapsible section beside this one, which meant two places to look for
+     * "the thing I have not configured yet" and a Setup Progress bar counting
+     * across both. Rendered here instead, after the capability cards, so the
+     * page has one list. */
+    extras?: ReactNode;
 } = {}) {
     const [recheckToken, setRecheckToken] = useState(0);
     /* One request for the whole section rather than one per card: the endpoint
@@ -978,6 +986,19 @@ export default function ServiceProviders({ show }: {
                         step={{ index: i, total: visible.length, active: i === cursor }} />
                 ))}
             </div>
+
+            {extras && (
+                <div className="mt-8">
+                    <div className="flex items-center gap-3 mb-4">
+                        <h3 className="text-xs font-bold uppercase tracking-wider text-white/45">Other settings</h3>
+                        <div className="h-px flex-1 bg-white/10" />
+                    </div>
+                    {/* Not provider choices -- there is nothing to pick between --
+                        so these render without a provider row rather than being
+                        given invented alternatives the backend cannot route to. */}
+                    {extras}
+                </div>
+            )}
         </CollapsibleSection>
     );
 }

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -122,10 +122,16 @@ export interface CapStatus {
     configured?: boolean;
 }
 
-function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health }: {
+function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided }: {
     cap: Capability; title: string; blurb: string; icon: typeof Sparkles; delay: number;
     recheckToken: number; reloadToken: number; onStatus: (cap: Capability, s: CapStatus) => void;
     health?: ConnectorHealth;
+    /* Guided setup: the parent walks one capability at a time, so it decides
+     * which card is open rather than each card deciding for itself. `step` is
+     * the position in that walk, shown so a clerk can see where they are; it is
+     * undefined once setup is done and the page is just cards again. */
+    step?: { index: number; total: number; active: boolean };
+    guided?: boolean;
 }) {
     const [catalog, setCatalog] = useState<ProviderCatalog | null>(null);
     const [selected, setSelected] = useState<string>('');
@@ -276,7 +282,10 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     const statusUnknown = configuredState === undefined;
     // null means "not touched yet", so an unconfigured card starts open and a
     // configured one starts closed, without overriding a deliberate click.
-    const isOpen = open === null ? !configured : open;
+    /* In guided setup the parent's cursor wins until the clerk clicks a
+     * header, at which point their click wins -- being walked through setup
+     * should not mean losing the ability to jump back to something. */
+    const isOpen = open !== null ? open : (guided ? !!step?.active : !configured);
 
     const handleSave = async () => {
         if (!active) return;
@@ -338,16 +347,21 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                     gradient icon tile, the name, and a status pill on the right. */}
                 <button
                     type="button"
-                    onClick={() => setOpen(v => (v === null ? configured : !v))}
+                    onClick={() => setOpen(v => (v === null ? !isOpen : !v))}
                     aria-expanded={isOpen}
                     aria-controls={`prov-${cap}`}
                     className="w-full flex items-start justify-between gap-4 flex-wrap text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
                 >
                     <div className="flex items-center gap-4 min-w-0">
-                        <div className={`w-14 h-14 shrink-0 rounded-2xl flex items-center justify-center transition-all duration-300 ${configured
+                        <div className={`relative w-14 h-14 shrink-0 rounded-2xl flex items-center justify-center transition-all duration-300 ${configured
                             ? 'bg-gradient-to-br from-green-400 to-emerald-500 shadow-lg shadow-green-500/30'
                             : 'setup-tile'}`}>
-                            <Icon className="w-7 h-7 text-white" />
+                            {configured ? <Check className="w-7 h-7 text-white" /> : <Icon className="w-7 h-7 text-white" />}
+                            {guided && step && !configured && (
+                                <span className="absolute -top-1.5 -left-1.5 w-6 h-6 rounded-full bg-primary-500 border-2 border-slate-900 text-[11px] font-bold text-white flex items-center justify-center">
+                                    {step.index + 1}
+                                </span>
+                            )}
                         </div>
                         <div className="min-w-0">
                             <h3 className="font-bold text-lg text-white leading-tight">{title}</h3>
@@ -809,7 +823,17 @@ function CloudEnvironment({ onApplied }: { onApplied: () => void }) {
     );
 }
 
-export default function ServiceProviders() {
+export default function ServiceProviders({ show }: {
+    /* Which capabilities the town said it wants, from the setup questions.
+     * Undefined means "no answer yet", which shows everything -- an absent
+     * answer must not read as "wanted nothing", the same distinction the
+     * configured badges make between unknown and no.
+     *
+     * Sign-in and maps are never filtered: a town cannot take a report without
+     * them, so hiding them behind a question would let someone opt out of
+     * having a working system. */
+    show?: Set<Capability>;
+} = {}) {
     const [recheckToken, setRecheckToken] = useState(0);
     /* One request for the whole section rather than one per card: the endpoint
      * returns every connector, and four parallel calls on page load for data
@@ -837,9 +861,31 @@ export default function ServiceProviders() {
         setStatuses(prev => ({ ...prev, [cap]: { ...prev[cap], ...s } }));
     }, []);
 
-    const loaded = CAPS.filter(c => statuses[c.key]);
+    const ALWAYS = new Set<Capability>(['identity', 'maps']);
+    const visible = CAPS.filter(c => !show || ALWAYS.has(c.key) || show.has(c.key));
+    const loaded = visible.filter(c => statuses[c.key]);
     const onDefaultCount = (loaded || []).filter(c => statuses[c.key]?.onDefault).length;
     const configuredCount = (loaded || []).filter(c => statuses[c.key]?.configured).length;
+
+    /* Guided setup versus the plain card list.
+     *
+     * Derived rather than stored: guided while anything the town asked for
+     * still has no credentials, cards once it all does. A stored "I am done"
+     * flag would let a half-finished town dismiss the guidance it still needs,
+     * and would need a migration to carry a boolean that the data already
+     * answers.
+     *
+     * `manualMode` is the override -- somebody adding text messages a year
+     * later wants the steps back, and somebody who knows the product wants them
+     * gone. Null means "follow the data". */
+    const [manualMode, setManualMode] = useState<'guided' | 'cards' | null>(null);
+    const everythingConfigured = loaded.length > 0 && configuredCount === loaded.length;
+    const guided = manualMode ? manualMode === 'guided' : !everythingConfigured;
+
+    // The cursor: the first thing still missing credentials. It moves on its own
+    // as each one is saved, because `configured` comes back from the reload the
+    // save already triggers.
+    const cursor = visible.findIndex(c => statuses[c.key] && !statuses[c.key]?.configured);
     const verifiedCount = (loaded || []).filter(c => statuses[c.key]?.verified === true).length;
     const failedCount = (loaded || []).filter(c => statuses[c.key]?.verified === false).length;
 
@@ -884,11 +930,52 @@ export default function ServiceProviders() {
                 width, and at a third of the page they were squeezed into
                 unusable slivers. The connector cards this matches are
                 full-width for the same reason. */}
+            {guided && loaded.length > 0 && (
+                <div className="setup-panel p-4 mb-4 relative">
+                    <div className="relative flex items-center justify-between gap-4 flex-wrap">
+                        <div className="min-w-0">
+                            <p className="text-sm font-semibold text-white">
+                                {everythingConfigured
+                                    ? 'Everything is set up'
+                                    : `Step ${Math.max(0, cursor) + 1} of ${visible.length} — ${visible[Math.max(0, cursor)]?.title}`}
+                            </p>
+                            <p className="text-white/50 text-xs mt-0.5">
+                                One at a time, in order. Save it and the next one opens.
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => setManualMode('cards')}
+                            className="text-xs text-white/60 hover:text-white underline underline-offset-2 shrink-0"
+                        >
+                            Skip the guide
+                        </button>
+                    </div>
+                    <div className="relative h-1.5 rounded-full bg-white/10 overflow-hidden mt-3">
+                        <div
+                            className="h-full rounded-full bg-gradient-to-r from-emerald-400 to-teal-400 transition-all duration-500"
+                            style={{ width: `${(configuredCount / Math.max(1, loaded.length)) * 100}%` }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            {!guided && !everythingConfigured && (
+                <button
+                    type="button"
+                    onClick={() => setManualMode('guided')}
+                    className="mb-4 text-xs text-white/60 hover:text-white underline underline-offset-2"
+                >
+                    Walk me through what is left
+                </button>
+            )}
+
             <div className="relative grid grid-cols-1 gap-4">
-                {CAPS.map((c, i) => (
+                {visible.map((c, i) => (
                     <CapabilityCard key={c.key} cap={c.key} title={c.title} blurb={c.blurb} icon={c.icon} delay={i * 0.08}
                         recheckToken={recheckToken} reloadToken={reloadToken} onStatus={onStatus}
-                        health={health[c.key]} />
+                        health={health[c.key]} guided={guided}
+                        step={{ index: i, total: visible.length, active: i === cursor }} />
                 ))}
             </div>
         </CollapsibleSection>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { Card, Button, Input, Select, Badge, CollapsibleSection } from './ui';
 import { SystemSecret } from '../types';
 import { api } from '../services/api';
+import type { Capability } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 
@@ -58,9 +59,16 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const [setupCloud, setSetupCloud] = useState<'google' | 'azure' | 'aws'>('google');
     const [setupIdp, setSetupIdp] = useState<'auth0' | 'entra' | 'okta' | 'oidc'>('auth0');
     const [setupMaps, setSetupMaps] = useState<'google' | 'esri' | 'azure' | 'apple'>('google');
-    const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(
-        new Set(['ai', 'secrets', 'email'])
-    );
+    /* Everything on, untick to hide.
+     *
+     * This started as opt-in with three ticked, which quietly set the default
+     * for every town that never touched it: a page that asks what you want,
+     * pre-answered "not much". A town that never opens this question should end
+     * up with the whole platform switched on, not the three we happened to
+     * pre-tick -- so the list below is every feature, and a town removes what
+     * it genuinely does not want. */
+    const ALL_FEATURES = ['ai', 'translation', 'moderation', 'email', 'sms', 'secrets', 'govtech', 'backups'];
+    const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(new Set(ALL_FEATURES));
     const toggleFeature = (f: string) =>
         setWantedFeatures(prev => {
             const next = new Set(prev);
@@ -68,6 +76,23 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             return next;
         });
     const wants = (f: string) => wantedFeatures.has(f);
+
+    /* The setup questions are asked in feature terms ("AI triage", "Secret
+     * storage + PII encryption") and the provider cards are keyed by
+     * capability. This is the one mapping between them. `secrets` covers the
+     * KMS card because the same question is what a town answers about where
+     * keys and resident data are protected, and `moderation` covers photo
+     * redaction for the same reason -- both are about screening what gets
+     * stored. */
+    const FEATURE_TO_CAPABILITY: Record<string, Capability> = {
+        ai: 'ai', translation: 'translation', email: 'email',
+        sms: 'sms', secrets: 'kms', moderation: 'redaction',
+    };
+    const wantedCapabilities = new Set<Capability>(
+        Object.entries(FEATURE_TO_CAPABILITY)
+            .filter(([feature]) => wantedFeatures.has(feature))
+            .map(([, capability]) => capability),
+    );
 
     // Managed (state-hosted) mode: infrastructure cards are locked because the
     // state's orchestrator owns those keys (Google Cloud, Backups, domain).
@@ -708,7 +733,11 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                 open above everything that actually needed attention. */}
 
             {/* 1 — Required + core capabilities: sign-in, maps, AI, translation */}
-            <div id="sec-providers"><ServiceProviders /></div>
+            {/* Only the capabilities the town asked for. The question above is
+                the single place that decides what this page shows, so answering
+                it once removes the steps and the inputs together rather than
+                leaving inputs for providers whose instructions are hidden. */}
+            <div id="sec-providers"><ServiceProviders show={wantedCapabilities} /></div>
 
             <CollapsibleSection id="sec-optional" title="Notifications & Extras" icon={Cloud} subtitle="Email, text messages, cloud services, error reporting, backups — none required to take reports" defaultOpen={false}>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -143,6 +143,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             && isConfigured('APPLE_MAPKIT_PRIVATE_KEY'));
     const smsConfigured = !!(localSmsProvider && localSmsProvider !== 'none');
     const backupConfigured = isConfigured('BACKUP_S3_BUCKET') && isConfigured('BACKUP_S3_ACCESS_KEY') && isConfigured('BACKUP_S3_SECRET_KEY') && isConfigured('BACKUP_ENCRYPTION_KEY');
+    // The capabilities that gained a card. Each is "done" when any one of its
+    // providers has the credentials that provider needs, so a town on Azure is
+    // not marked incomplete for having no Google key.
+    const aiConfigured = isConfigured('VERTEX_AI_PROJECT') || isConfigured('AZURE_OPENAI_API_KEY') || isConfigured('AWS_REGION');
+    const translationConfigured = isConfigured('GOOGLE_CLOUD_PROJECT') || isConfigured('AZURE_TRANSLATOR_KEY') || isConfigured('AWS_REGION');
+    const kmsConfigured = isConfigured('KMS_KEY_ID') || isConfigured('AZURE_KEYVAULT_URL') || isConfigured('AWS_KMS_KEY_ID');
+    // Redaction needs no credentials of its own -- it reuses the cloud ones --
+    // so it counts as set up once a detector has been chosen.
+    const redactionConfigured = isConfigured('REDACTION_PROVIDER');
 
     // Setup progress calculation. In managed mode the platform-managed steps
     // (Google Cloud, DB Backups) are excluded — the state handles them, so
@@ -153,6 +162,10 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         ...(managedMode ? [] : [{ label: 'Google Cloud', done: !!gcpConfigured, required: false }]),
         { label: 'Map provider', done: !!mapsConfigured, required: false },
         { label: 'SMS Alerts', done: smsConfigured, required: false },
+        { label: 'AI triage', done: !!aiConfigured, required: false },
+        { label: 'Translation', done: !!translationConfigured, required: false },
+        { label: 'PII encryption', done: !!kmsConfigured, required: false },
+        { label: 'Photo redaction', done: !!redactionConfigured, required: false },
         ...(managedMode ? [] : [{ label: 'DB Backups', done: !!backupConfigured, required: false }]),
     ];
 
@@ -304,7 +317,13 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                     </div>
                     <div>
                         <h2 className="font-semibold text-white">Setup Progress</h2>
-                        <p className="text-white/50 text-xs">{completedCount} of {setupSteps.length} integrations configured</p>
+                        <p className="text-white/50 text-xs">
+                            {completedCount} of {setupSteps.length} integrations configured{' · '}
+                            <span className="text-white/70 font-medium">{Math.round((completedCount / setupSteps.length) * 100)}%</span>
+                            {completedCount < setupSteps.length && (
+                                <span className="text-white/40">{' · '}{setupSteps.length - completedCount} left</span>
+                            )}
+                        </p>
                     </div>
                 </div>
 

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -91,6 +91,55 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             .map(([, capability]) => capability),
     );
 
+    /* What to do to obtain the credentials for a given provider, shown inside
+     * the card immediately above the boxes.
+     *
+     * Short on purpose. The long guide above still exists for someone starting
+     * from nothing; this is the reminder you want when you are already looking
+     * at the field and have forgotten which console page the value is on. Keyed
+     * by capability and provider so switching provider switches the reminder,
+     * the same way the fields themselves switch.
+     *
+     * Returning null is normal -- a provider that needs no explanation beyond
+     * its field labels should not be given filler. */
+    const cardInstructions = (cap: Capability, provider: string): React.ReactNode => {
+        const K: Record<string, React.ReactNode> = {
+            'ai:vertex': <>Enable <strong className="text-white/85">Vertex AI API</strong> in Google Cloud, then use the project ID and service-account JSON from the Google Cloud step above.</>,
+            'ai:azure': <>Create an <strong className="text-white/85">Azure OpenAI</strong> resource and deploy a vision-capable model. The deployment name is what goes in the third box, not the model name.</>,
+            'ai:bedrock': <>In <strong className="text-white/85">Bedrock → Model access</strong>, enable the models you want first — a region alone is not enough if nothing is enabled in it.</>,
+            'translation:google': <>Nothing new to fetch. Enable <strong className="text-white/85">Cloud Translation API</strong> and reuse the same project as AI.</>,
+            'translation:azure': <>Create a <strong className="text-white/85">Translator</strong> resource; its Key and Region are on the resource's Keys and Endpoint page.</>,
+            'translation:aws': <>No resource to create. Amazon Translate works with the region and credentials you already use.</>,
+            'identity:auth0': <>Applications → your app → Settings. Add <code className="bg-black/30 px-1 rounded text-[11px]">{window.location.origin}/api/auth/callback</code> as an Allowed Callback URL first, or sign-in fails after the password.</>,
+            'identity:entra': <>App registrations → your app. Overview holds both IDs; the secret <em>Value</em> (not the Secret ID) is under Certificates &amp; secrets and is shown only once.</>,
+            'identity:okta': <>The Issuer is your Okta domain, e.g. <code className="bg-black/30 px-1 rounded text-[11px]">https://your-org.okta.com</code>. Assign the app to a staff group or nobody can sign in.</>,
+            'identity:oidc': <>Enter the issuer itself. If your provider's docs show a URL ending <code className="bg-black/30 px-1 rounded text-[11px]">/.well-known/openid-configuration</code>, leave that part off.</>,
+            'maps:google': <>Enable Maps JavaScript, Geocoding and Places, attach billing, then restrict the key to <code className="bg-black/30 px-1 rounded text-[11px]">{window.location.origin}/*</code>. Without billing the key looks fine and the map stays grey.</>,
+            'maps:esri': <>An API key from ArcGIS Location Platform. Check whether your county's licence already covers you before buying one.</>,
+            'maps:azure': <>Azure Maps account → Authentication → Primary Key.</>,
+            'maps:apple': <>Needs a paid Apple Developer account. Paste the whole <code className="bg-black/30 px-1 rounded text-[11px]">.p8</code> file including its BEGIN and END lines.</>,
+            'email:smtp': <>Your existing mail server. For Microsoft 365 or Google Workspace this needs an <strong className="text-white/85">app password</strong>, not the account password.</>,
+            'email:ses': <>SES refuses to send from an address or domain you have not verified in its console first.</>,
+            'email:acs': <>The endpoint and key are on the Communication Services resource, under Keys.</>,
+            'sms:none': <>Nothing to enter. Residents still get email updates.</>,
+            'sms:twilio': <>Account SID and Auth Token are on the Twilio console home page. The number must be one you own there, in <code className="bg-black/30 px-1 rounded text-[11px]">+1XXXXXXXXXX</code> form.</>,
+            'sms:sns': <>Uses your existing AWS credentials. New AWS accounts are sandboxed for SMS — request production access or only verified numbers receive anything.</>,
+            'sms:acs': <>The same Communication Services resource as email, plus a number provisioned in it.</>,
+            'sms:http': <>For a gateway not listed here. Not certified against any particular vendor, so send a test before relying on it.</>,
+            'kms:google': <>Enable <strong className="text-white/85">Cloud KMS API</strong>. The three boxes only name the key inside your project; leave them blank for the defaults.</>,
+            'kms:azure': <>Key Vault URL and key name, plus an app registration that can wrap and unwrap with it.</>,
+            'kms:aws': <>A KMS key ID or ARN in the same region as the rest of your AWS setup.</>,
+            'kms:local': <>Nothing to enter. Resident data is still encrypted, using the application's own key rather than a cloud key service.</>,
+            'redaction:local': <>Nothing to enter — detection runs here and no photo leaves the building. Less accurate than the cloud detectors.</>,
+        };
+        const cloud = K[`${cap}:${provider}`];
+        if (cloud) return cloud;
+        if (cap === 'redaction') {
+            return <>No new credentials — this reuses the {provider === 'google' ? 'Google Cloud' : provider === 'aws' ? 'AWS' : 'Azure'} keys you entered above. Both toggles are on by default; plate detection guesses, and what it occasionally blurs is a house number.</>;
+        }
+        return null;
+    };
+
     // Managed (state-hosted) mode: infrastructure cards are locked because the
     // state's orchestrator owns those keys (Google Cloud, Backups, domain).
     const [managedMode, setManagedMode] = useState(false);
@@ -753,6 +802,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             <div id="sec-providers">
                 <ServiceProviders
                     show={wantedCapabilities}
+                    instructions={cardInstructions}
                     extras={
                         <>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -10,7 +10,7 @@ import {
     Clock, DollarSign,
 } from 'lucide-react';
 
-import { Card, Button, Input, Select, Badge, CollapsibleSection } from './ui';
+import { Card, Button, Input, Badge, CollapsibleSection } from './ui';
 import { SystemSecret } from '../types';
 import { api } from '../services/api';
 import type { Capability } from '../services/api';
@@ -40,9 +40,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const [savingKey, setSavingKey] = useState<string | null>(null);
 
     const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
-    const [localSmsProvider, setLocalSmsProvider] = useState<string>('none');
-    const [savingSmsProvider, setSavingSmsProvider] = useState(false);
-    const userModifiedSms = useRef(false);
     /* The guide starts open on a fresh install and closed once the required
      * integrations are in. It is a first-run document: hidden behind a click it
      * is missed by the person who needs it most, and left open forever it pushes
@@ -149,12 +146,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         || (isConfigured('AWS_REGION') && (isConfigured('SES_FROM_EMAIL') || isConfigured('SMTP_FROM_EMAIL')))
         || (isConfigured('ACS_ENDPOINT') && isConfigured('ACS_ACCESS_KEY'));
 
-    // Sync local SMS provider state with secrets (only if user hasn't modified)
-    useEffect(() => {
-        if (smsProviderFromSecrets && !userModifiedSms.current) {
-            setLocalSmsProvider(smsProviderFromSecrets);
-        }
-    }, [smsProviderFromSecrets]);
     const sentryConfigured = isConfigured('SENTRY_DSN');
     const gcpConfigured = isConfigured('GOOGLE_CLOUD_PROJECT');
     // Same trap as sign-in: maps is a pluggable capability with four providers,
@@ -166,7 +157,9 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         || isConfigured('AZURE_MAPS_KEY')
         || (isConfigured('APPLE_MAPKIT_TEAM_ID') && isConfigured('APPLE_MAPKIT_KEY_ID')
             && isConfigured('APPLE_MAPKIT_PRIVATE_KEY'));
-    const smsConfigured = !!(localSmsProvider && localSmsProvider !== 'none');
+    // Read straight from the stored provider: the Text Messages card writes it,
+    // and 'none' is a real value there rather than an absence.
+    const smsConfigured = !!(smsProviderFromSecrets && smsProviderFromSecrets !== 'none');
     const backupConfigured = isConfigured('BACKUP_S3_BUCKET') && isConfigured('BACKUP_S3_ACCESS_KEY') && isConfigured('BACKUP_S3_SECRET_KEY') && isConfigured('BACKUP_ENCRYPTION_KEY');
     // The capabilities that gained a card. Each is "done" when any one of its
     // providers has the credentials that provider needs, so a town on Azure is
@@ -624,7 +617,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     what={<>Sends the resident a confirmation when they file, and an update when staff change the status. Without it a resident has no way to know anything happened, which is the most common complaint about 311 systems.</>}
                                     time="About 15 minutes"
                                     cost="Free at a town's volume with most providers.">
-                                    <InstructionStep num={1}><strong className="text-white/90">Any cloud — SMTP:</strong> use SendGrid, Gmail App Passwords, or your org relay. Host <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">smtp.sendgrid.net</code> / <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">587</code>, then fill the <strong className="text-white/90">Email (SMTP)</strong> card below.</InstructionStep>
+                                    <InstructionStep num={1}><strong className="text-white/90">Any cloud — SMTP:</strong> use SendGrid, Gmail App Passwords, or your org relay. Host <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">smtp.sendgrid.net</code> / <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">587</code>, then fill the <strong className="text-white/90">Email</strong> card in Service Providers, picking <strong className="text-white/90">SMTP</strong>.</InstructionStep>
                                     {setupCloud === 'azure' && <InstructionStep num={2}><strong className="text-white/90">Or native Azure:</strong> create an <strong className="text-white/90">Azure Communication Services</strong> resource, connect an email domain, and use its connection string (provider "acs").</InstructionStep>}
                                     {setupCloud === 'aws' && <InstructionStep num={2}><strong className="text-white/90">Or native AWS:</strong> verify a sender/domain in <strong className="text-white/90">Amazon SES</strong> and use SES (provider "ses") with your region + credentials.</InstructionStep>}
                                 </Guide>
@@ -705,6 +698,26 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                 </Guide>
 
                                 {/* ── Database backups ── */}
+                                {/* ── Photo redaction ── */}
+                                <Guide show={wants('moderation')} tone="rose" icon={ImageIcon} title="Blurring faces and licence plates" done={redactionConfigured}
+                                    what={<>Residents photograph the pothole and the neighbour walking past it. This finds faces and plates before the photo is stored, so the municipal site never publishes them. It runs on the way in — the unblurred original is never saved.</>}
+                                    time="About 2 minutes"
+                                    cost={setupCloud === 'google' ? "Roughly a tenth of a cent per photo on Cloud Vision." : "A fraction of a cent per photo, or nothing at all on your own server."}>
+                                    <InstructionStep num={1}>Open <strong className="text-white/90">Service Providers → Photo Redaction</strong> and pick a detector. The cloud ones reuse the credentials you already entered — there is no new key. <strong className="text-white/90">On this server</strong> needs no account at all and no photo leaves the building, at some cost in accuracy.</InstructionStep>
+                                    <InstructionStep num={2} check={<>a face blurred in the photo on the request you just filed.</>}>Faces and plates are both on by default. Save, then file a test report with a photo of a person or a car and open it in the staff view.</InstructionStep>
+                                    <Trouble>Plate detection guesses, and what it occasionally guesses wrong is a house number. If your crews work from those, switch <strong className="text-white/90">Blur licence plates</strong> off on the same card — faces stay on.</Trouble>
+                                </Guide>
+
+                                {/* ── Error reporting ── */}
+                                <Guide tone="violet" icon={AlertTriangle} title="Knowing when something breaks" done={sentryConfigured}
+                                    what={<>Without this, a page that crashes for a resident is something you hear about only if they phone. Browser crashes are already collected and shown under Browser errors in the admin console; this sends them somewhere off the server as well, so they survive a container restart.</>}
+                                    time="About 5 minutes"
+                                    cost="Sentry's free tier covers a town's volume comfortably.">
+                                    <InstructionStep num={1} check={<>a DSN that looks like <code className="bg-black/30 px-1 rounded">https://…@…ingest.sentry.io/…</code></>}>Create a free account at <a href="https://sentry.io" target="_blank" rel="noopener noreferrer" className="text-violet-300 underline underline-offset-2">sentry.io</a>, make a project, and copy its <strong className="text-white/90">DSN</strong>.</InstructionStep>
+                                    <InstructionStep num={2}>Paste it into the <strong className="text-white/90">Sentry</strong> card under Other settings, and save.</InstructionStep>
+                                    <InstructionStep num={3}><em className="text-white/50">Optional:</em> this is genuinely skippable. Crashes are still recorded in the admin console without it — Sentry adds alerting and keeps the history longer.</InstructionStep>
+                                </Guide>
+
                                 <Guide show={wants('backups')} tone="amber" icon={HardDrive} title="Automatic backups" done={backupConfigured}
                                     what={<>Takes a nightly encrypted copy of everything and stores it off the server. Do this one. 311 reports are public records the town is legally required to keep, and a server can fail.</>}
                                     time="About 20 minutes"
@@ -737,872 +750,546 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                 the single place that decides what this page shows, so answering
                 it once removes the steps and the inputs together rather than
                 leaving inputs for providers whose instructions are hidden. */}
-            <div id="sec-providers"><ServiceProviders show={wantedCapabilities} /></div>
-
-            <CollapsibleSection id="sec-optional" title="Notifications & Extras" icon={Cloud} subtitle="Email, text messages, cloud services, error reporting, backups — none required to take reports" defaultOpen={false}>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    {/* SMS Notifications - Premium Card */}
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.1 }}
-                        className={`relative rounded-3xl border p-6 transition-all duration-300 ${localSmsProvider && localSmsProvider !== 'none'
-                            ? 'bg-gradient-to-br from-emerald-500/10 via-green-500/5 to-teal-500/10 border-emerald-500/30 shadow-lg shadow-emerald-500/10'
-                            : 'setup-panel border-transparent'
-                            }`}
-                    >
-
-                        {/* Glow effect when configured */}
-                        {localSmsProvider && localSmsProvider !== 'none' && (
-                            <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/5 via-transparent to-teal-500/5 pointer-events-none" />
-                        )}
-
-                        <div className="relative">
-                            <div className="flex items-start justify-between mb-4">
-                                <div className="flex items-center gap-4">
-                                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${localSmsProvider && localSmsProvider !== 'none'
-                                        ? 'bg-gradient-to-br from-emerald-400 to-teal-500 shadow-lg shadow-emerald-500/30'
-                                        : 'setup-tile'
-                                        }`}>
-                                        <MessageSquare className="w-7 h-7 text-white" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-bold text-lg text-white">SMS Notifications</h3>
-                                        <p className="text-white/50 text-sm">Text alerts to residents</p>
-                                    </div>
-                                </div>
-                                {localSmsProvider && localSmsProvider !== 'none' ? (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-emerald-300 border border-emerald-500/30 shadow-lg shadow-emerald-500/10">
-                                        <CheckCircle className="w-3.5 h-3.5" />
-                                        Active
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                        Disabled
-                                    </span>
-                                )}
-                            </div>
-
-                            {/* SMS Provider Selection */}
-                            <div className="space-y-4">
-                                <div>
-                                    <label className="text-sm text-white/60 mb-2 block">Provider</label>
-                                    <div className="flex gap-2">
-                                        <Select
-                                            options={[
-                                                { value: 'none', label: 'Disabled' },
-                                                { value: 'twilio', label: 'Twilio' },
-                                                { value: 'http', label: 'Custom HTTP API' },
-                                            ]}
-                                            value={localSmsProvider}
-                                            onChange={(e) => {
-                                                userModifiedSms.current = true; // Mark as user-modified
-                                                setLocalSmsProvider(e.target.value);
-                                            }}
-                                        />
-                                        <Button
-                                            size="sm"
-                                            disabled={savingSmsProvider || localSmsProvider === (smsProviderFromSecrets || 'none')}
-                                            onClick={async () => {
-                                                setSavingSmsProvider(true);
-                                                try {
-                                                    await onSaveSecret('SMS_PROVIDER', localSmsProvider);
-
-                                                    // Sync with modules if available
-                                                    const wasEnabled = (smsProviderFromSecrets || 'none') !== 'none';
-                                                    const isEnabled = localSmsProvider !== 'none';
-                                                    if (modules && onUpdateModules && wasEnabled !== isEnabled) {
-                                                        await onUpdateModules({ ...modules, sms_alerts: isEnabled });
-                                                    }
-
-                                                    userModifiedSms.current = false; // Reset flag after successful save
-                                                } catch (err) {
-                                                    console.error('Failed to save SMS provider:', err);
-                                                }
-                                                setSavingSmsProvider(false);
-                                            }}
-                                            className="bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700 whitespace-nowrap"
-                                        >
-                                            {savingSmsProvider ? 'Saving...' : 'Save'}
-                                        </Button>
-                                    </div>
-                                </div>
-
-
-                                {/* Twilio Configuration Fields */}
-                                {localSmsProvider === 'twilio' && (
-                                    <div className="space-y-3 pt-2 border-t border-white/10">
+            <div id="sec-providers">
+                <ServiceProviders
+                    show={wantedCapabilities}
+                    extras={
+                        <>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            {/* Google Cloud - Premium Card (locked in managed mode: the state owns these keys) */}
+                            {managedMode ? (
+                                <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
+                                    <div className="flex items-center gap-4 mb-2">
+                                        <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
+                                            <Cloud className="w-7 h-7 text-white/50" />
+                                        </div>
                                         <div>
-                                            <label className="text-sm text-white/60 mb-1.5 block">Account SID</label>
-                                            <div className="flex gap-2">
-                                                <Input
-                                                    type="text"
-                                                    placeholder="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-                                                    value={secretValues['TWILIO_ACCOUNT_SID'] || ''}
-                                                    onChange={(e) => setSecretValues(p => ({ ...p, 'TWILIO_ACCOUNT_SID': e.target.value }))}
-                                                    className="flex-1 text-sm"
-                                                />
+                                            <h3 className="font-bold text-lg text-white/70">Google Cloud</h3>
+                                            <p className="text-white/40 text-sm">AI, encryption &amp; translation infrastructure</p>
+                                        </div>
+                                        <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
+                                            <Shield className="w-3.5 h-3.5" />
+                                            Managed by your state
+                                        </span>
+                                    </div>
+                                    <p className="text-white/50 text-sm">
+                                        Cloud project, KMS encryption keys, and secrets storage are provisioned and maintained by your state hosting program. Nothing to configure here.
+                                    </p>
+                                </div>
+                            ) : (
+                            <motion.div
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ delay: 0.3 }}
+                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${gcpConfigured
+                                    ? 'bg-gradient-to-br from-blue-500/10 via-cyan-500/5 to-sky-500/10 border-blue-500/30 shadow-lg shadow-blue-500/10'
+                                    : 'setup-panel border-transparent'
+                                    }`}
+                            >
+                                {gcpConfigured && (
+                                    <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 via-transparent to-cyan-500/5 pointer-events-none" />
+                                )}
+
+                                <div className="relative">
+                                    <div className="flex items-start justify-between mb-4">
+                                        <div className="flex items-center gap-4">
+                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${gcpConfigured
+                                                ? 'bg-gradient-to-br from-blue-400 to-cyan-500 shadow-lg shadow-blue-500/30'
+                                                : 'setup-tile'
+                                                }`}>
+                                                <Cloud className="w-7 h-7 text-white" />
+                                            </div>
+                                            <div>
+                                                <h3 className="font-bold text-lg text-white">Google Cloud</h3>
+                                                <p className="text-white/50 text-sm">AI, KMS, Secrets, Translation</p>
                                             </div>
                                         </div>
-                                        <div>
-                                            <label className="text-sm text-white/60 mb-1.5 block">Auth Token</label>
-                                            <Input
-                                                type="password"
-                                                placeholder="Your Twilio auth token"
-                                                value={secretValues['TWILIO_AUTH_TOKEN'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'TWILIO_AUTH_TOKEN': e.target.value }))}
-                                                className="text-sm"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-sm text-white/60 mb-1.5 block">From Phone Number</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="+1234567890"
-                                                value={secretValues['TWILIO_PHONE_NUMBER'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'TWILIO_PHONE_NUMBER': e.target.value }))}
-                                                className="text-sm"
-                                            />
-                                        </div>
-                                        <Button
-                                            size="sm"
-                                            className="w-full bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700"
-                                            onClick={async () => {
-                                                if (secretValues['TWILIO_ACCOUNT_SID']) await handleSave('TWILIO_ACCOUNT_SID');
-                                                if (secretValues['TWILIO_AUTH_TOKEN']) await handleSave('TWILIO_AUTH_TOKEN');
-                                                if (secretValues['TWILIO_PHONE_NUMBER']) await handleSave('TWILIO_PHONE_NUMBER');
-                                            }}
-                                            disabled={!secretValues['TWILIO_ACCOUNT_SID'] || savingKey !== null}
-
-                                        >
-                                            {savingKey ? 'Saving...' : 'Save Twilio Credentials'}
-                                        </Button>
-                                    </div>
-                                )}
-
-                                {/* Custom HTTP Configuration Fields */}
-                                {localSmsProvider === 'http' && (
-                                    <div className="space-y-3 pt-2 border-t border-white/10">
-                                        <div>
-                                            <label className="text-sm text-white/60 mb-1.5 block">API Endpoint URL</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="https://your-sms-api.com/send"
-                                                value={secretValues['SMS_HTTP_ENDPOINT'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'SMS_HTTP_ENDPOINT': e.target.value }))}
-                                                className="text-sm"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-sm text-white/60 mb-1.5 block">API Key (optional)</label>
-                                            <Input
-                                                type="password"
-                                                placeholder="Your API key"
-                                                value={secretValues['SMS_HTTP_API_KEY'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'SMS_HTTP_API_KEY': e.target.value }))}
-                                                className="text-sm"
-                                            />
-                                        </div>
-                                        <Button
-                                            size="sm"
-                                            className="w-full bg-gradient-to-r from-emerald-500 to-teal-600 hover:from-emerald-600 hover:to-teal-700"
-                                            onClick={async () => {
-                                                if (secretValues['SMS_HTTP_ENDPOINT']) await handleSave('SMS_HTTP_ENDPOINT');
-                                                if (secretValues['SMS_HTTP_API_KEY']) await handleSave('SMS_HTTP_API_KEY');
-                                            }}
-                                            disabled={!secretValues['SMS_HTTP_ENDPOINT'] || savingKey !== null}
-                                        >
-                                            {savingKey ? 'Saving...' : 'Save HTTP Settings'}
-                                        </Button>
-                                    </div>
-                                )}
-
-                                {/* Module sync indicator */}
-                                {modules && (
-                                    <div className={`flex items-center gap-2 text-xs ${modules.sms_alerts ? 'text-emerald-400' : 'text-white/40'}`}>
-                                        {modules.sms_alerts ? (
-                                            <>
-                                                <div className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
-                                                Module enabled in Feature Settings
-                                            </>
+                                        {gcpConfigured ? (
+                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-blue-500/20 to-cyan-500/20 text-blue-300 border border-blue-500/30 shadow-lg shadow-blue-500/10">
+                                                <CheckCircle className="w-3.5 h-3.5" />
+                                                Configured
+                                            </span>
                                         ) : (
-                                            <>
-                                                <div className="w-2 h-2 rounded-full bg-white/30" />
-                                                Module disabled in Feature Settings
-                                            </>
+                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
+                                                Optional
+                                            </span>
                                         )}
                                     </div>
-                                )}
-                            </div>
-                        </div>
-                    </motion.div>
 
-
-                    {/* Email SMTP - Premium Card */}
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.2 }}
-                        className={`relative rounded-3xl border p-6 transition-all duration-300 ${smtpConfigured
-                            ? 'bg-gradient-to-br from-violet-500/10 via-purple-500/5 to-fuchsia-500/10 border-violet-500/30 shadow-lg shadow-violet-500/10'
-                            : 'setup-panel border-transparent'
-                            }`}
-                    >
-                        {smtpConfigured && (
-                            <div className="absolute inset-0 bg-gradient-to-r from-violet-500/5 via-transparent to-fuchsia-500/5 pointer-events-none" />
-                        )}
-
-                        <div className="relative">
-                            <div className="flex items-start justify-between mb-4">
-                                <div className="flex items-center gap-4">
-                                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${smtpConfigured
-                                        ? 'bg-gradient-to-br from-violet-400 to-purple-500 shadow-lg shadow-violet-500/30'
-                                        : 'setup-tile'
-                                        }`}>
-                                        <Mail className="w-7 h-7 text-white" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-bold text-lg text-white">Email (SMTP)</h3>
-                                        <p className="text-white/50 text-sm">Outgoing notifications</p>
-                                    </div>
-                                </div>
-                                {smtpConfigured ? (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-violet-500/20 to-purple-500/20 text-violet-300 border border-violet-500/30 shadow-lg shadow-violet-500/10">
-                                        <CheckCircle className="w-3.5 h-3.5" />
-                                        Configured
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-3 py-1.5 rounded-2xl text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30">
-                                        <AlertCircle className="w-3.5 h-3.5 mr-1" />
-                                        Setup Required
-                                    </span>
-                                )}
-                            </div>
-
-                            {!smtpConfigured || secretValues['SMTP_HOST'] !== undefined ? (
-                                <div className="space-y-3">
-                                    <div className="flex gap-2">
-                                        <Input
-                                            type="text"
-                                            placeholder="SMTP Host (e.g., smtp.gmail.com)"
-                                            value={secretValues['SMTP_HOST'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'SMTP_HOST': e.target.value }))}
-                                            className="flex-1 text-sm"
-                                        />
-                                        <Input
-                                            type="text"
-                                            placeholder="Port"
-                                            value={secretValues['SMTP_PORT'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'SMTP_PORT': e.target.value }))}
-                                            className="w-20 text-sm"
-                                        />
-                                    </div>
-                                    <Input
-                                        type="text"
-                                        placeholder="From Email Address"
-                                        value={secretValues['SMTP_FROM_EMAIL'] || ''}
-                                        onChange={(e) => setSecretValues(p => ({ ...p, 'SMTP_FROM_EMAIL': e.target.value }))}
-                                        className="text-sm"
-                                    />
-                                    <div className="flex gap-2">
-                                        <Input
-                                            type="text"
-                                            placeholder="Username"
-                                            value={secretValues['SMTP_USERNAME'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'SMTP_USERNAME': e.target.value }))}
-                                            className="flex-1 text-sm"
-                                        />
-                                        <Input
-                                            type="password"
-                                            placeholder="Password"
-                                            value={secretValues['SMTP_PASSWORD'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'SMTP_PASSWORD': e.target.value }))}
-                                            className="flex-1 text-sm"
-                                        />
-                                    </div>
-                                    <Button
-                                        size="sm"
-                                        className="w-full bg-gradient-to-r from-violet-500 to-purple-600 hover:from-violet-600 hover:to-purple-700"
-                                        onClick={async () => {
-                                            if (secretValues['SMTP_HOST']) await handleSave('SMTP_HOST');
-                                            if (secretValues['SMTP_PORT']) await handleSave('SMTP_PORT');
-                                            if (secretValues['SMTP_FROM_EMAIL']) await handleSave('SMTP_FROM_EMAIL');
-                                            if (secretValues['SMTP_USERNAME']) await handleSave('SMTP_USERNAME');
-                                            if (secretValues['SMTP_PASSWORD']) await handleSave('SMTP_PASSWORD');
-
-                                            // Auto-enable email module when SMTP is configured
-                                            if (modules && onUpdateModules && secretValues['SMTP_HOST']) {
-                                                await onUpdateModules({ ...modules, email_notifications: true });
-                                            }
-                                        }}
-                                        disabled={!secretValues['SMTP_HOST'] || savingKey !== null}
-                                    >
-                                        {savingKey ? 'Saving...' : 'Save SMTP Settings'}
-                                    </Button>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    <div className="flex items-center gap-2">
-                                        <div className="flex-1 h-10 rounded-xl bg-violet-500/20 border border-violet-500/30 flex items-center px-4">
-                                            <CheckCircle className="w-4 h-4 text-violet-400 mr-2" />
-                                            <span className="text-violet-200 text-sm">SMTP configured and ready</span>
-                                        </div>
-                                        <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'SMTP_HOST': '' }))}>
-                                            Change
-                                        </Button>
-                                    </div>
-
-                                    {/* Module sync indicator */}
-                                    {modules && (
-                                        <div className={`flex items-center gap-2 text-xs ${modules.email_notifications ? 'text-violet-400' : 'text-white/40'}`}>
-                                            {modules.email_notifications ? (
-                                                <>
-                                                    <div className="w-2 h-2 rounded-full bg-violet-400 animate-pulse" />
-                                                    Module enabled in Feature Settings
-                                                </>
-                                            ) : (
-                                                <>
-                                                    <div className="w-2 h-2 rounded-full bg-white/30" />
-                                                    Module disabled in Feature Settings
-                                                </>
-                                            )}
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    </motion.div>
-
-                    {/* Google Cloud - Premium Card (locked in managed mode: the state owns these keys) */}
-                    {managedMode ? (
-                        <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
-                            <div className="flex items-center gap-4 mb-2">
-                                <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
-                                    <Cloud className="w-7 h-7 text-white/50" />
-                                </div>
-                                <div>
-                                    <h3 className="font-bold text-lg text-white/70">Google Cloud</h3>
-                                    <p className="text-white/40 text-sm">AI, encryption &amp; translation infrastructure</p>
-                                </div>
-                                <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
-                                    <Shield className="w-3.5 h-3.5" />
-                                    Managed by your state
-                                </span>
-                            </div>
-                            <p className="text-white/50 text-sm">
-                                Cloud project, KMS encryption keys, and secrets storage are provisioned and maintained by your state hosting program. Nothing to configure here.
-                            </p>
-                        </div>
-                    ) : (
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.3 }}
-                        className={`relative rounded-3xl border p-6 transition-all duration-300 ${gcpConfigured
-                            ? 'bg-gradient-to-br from-blue-500/10 via-cyan-500/5 to-sky-500/10 border-blue-500/30 shadow-lg shadow-blue-500/10'
-                            : 'setup-panel border-transparent'
-                            }`}
-                    >
-                        {gcpConfigured && (
-                            <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 via-transparent to-cyan-500/5 pointer-events-none" />
-                        )}
-
-                        <div className="relative">
-                            <div className="flex items-start justify-between mb-4">
-                                <div className="flex items-center gap-4">
-                                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${gcpConfigured
-                                        ? 'bg-gradient-to-br from-blue-400 to-cyan-500 shadow-lg shadow-blue-500/30'
-                                        : 'setup-tile'
-                                        }`}>
-                                        <Cloud className="w-7 h-7 text-white" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-bold text-lg text-white">Google Cloud</h3>
-                                        <p className="text-white/50 text-sm">AI, KMS, Secrets, Translation</p>
-                                    </div>
-                                </div>
-                                {gcpConfigured ? (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-blue-500/20 to-cyan-500/20 text-blue-300 border border-blue-500/30 shadow-lg shadow-blue-500/10">
-                                        <CheckCircle className="w-3.5 h-3.5" />
-                                        Configured
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                        Optional
-                                    </span>
-                                )}
-                            </div>
-
-                            <p className="text-white/60 text-sm mb-4">
-                                Enables AI analysis (Vertex AI), PII encryption (Cloud KMS), multi-language translation, and secure secrets storage.
-                                See the <strong className="text-blue-300">Setup Instructions</strong> above for a full walkthrough.
-                            </p>
-
-                            {/* Manual configuration fields */}
-                            {!gcpConfigured || secretValues['GOOGLE_CLOUD_PROJECT'] !== undefined ? (
-                                <div className="space-y-3">
-                                    <div>
-                                        <label className="text-sm text-white/60 mb-1.5 block">GCP Project ID</label>
-                                        <div className="flex gap-2">
-                                            <Input
-                                                type="text"
-                                                placeholder="my-municipality-project"
-                                                value={secretValues['GOOGLE_CLOUD_PROJECT'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': e.target.value }))}
-                                                className="flex-1 text-sm"
-                                            />
-                                            <Button
-                                                size="sm"
-                                                className="bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
-                                                onClick={() => handleSave('GOOGLE_CLOUD_PROJECT')}
-                                                disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey === 'GOOGLE_CLOUD_PROJECT'}
-                                            >
-                                                {savingKey === 'GOOGLE_CLOUD_PROJECT' ? '...' : 'Save'}
-                                            </Button>
-                                        </div>
-                                    </div>
-
-                                    <div className="grid grid-cols-3 gap-2">
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">KMS Location</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="us-central1"
-                                                value={secretValues['KMS_LOCATION'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_LOCATION': e.target.value }))}
-                                                className="text-xs"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">KMS Key Ring</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="pinpoint311-keyring"
-                                                value={secretValues['KMS_KEY_RING'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_RING': e.target.value }))}
-                                                className="text-xs"
-                                            />
-                                        </div>
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">KMS Key ID</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="pii-encryption-key"
-                                                value={secretValues['KMS_KEY_ID'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_ID': e.target.value }))}
-                                                className="text-xs"
-                                            />
-                                        </div>
-                                    </div>
-
-                                    <Button
-                                        size="sm"
-                                        className="w-full bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
-                                        onClick={async () => {
-                                            if (secretValues['GOOGLE_CLOUD_PROJECT']) await handleSave('GOOGLE_CLOUD_PROJECT');
-                                            if (secretValues['KMS_LOCATION']) await handleSave('KMS_LOCATION');
-                                            if (secretValues['KMS_KEY_RING']) await handleSave('KMS_KEY_RING');
-                                            if (secretValues['KMS_KEY_ID']) await handleSave('KMS_KEY_ID');
-
-                                            // Auto-enable AI module when GCP is configured
-                                            if (modules && onUpdateModules && secretValues['GOOGLE_CLOUD_PROJECT']) {
-                                                await onUpdateModules({ ...modules, ai_analysis: true });
-                                            }
-                                        }}
-                                        disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey !== null}
-                                    >
-                                        {savingKey ? 'Saving...' : 'Save GCP Settings'}
-                                    </Button>
-
-                                    <p className="text-white/40 text-xs">
-                                        KMS fields are optional — the platform defaults to <code className="bg-black/20 px-1 rounded">us-central1</code> / <code className="bg-black/20 px-1 rounded">pinpoint311-keyring</code> / <code className="bg-black/20 px-1 rounded">pii-encryption-key</code> if left blank. These must match your KMS key ring and key names exactly, or PII encryption silently falls back to local (Fernet) encryption.
+                                    <p className="text-white/60 text-sm mb-4">
+                                        Enables AI analysis (Vertex AI), PII encryption (Cloud KMS), multi-language translation, and secure secrets storage.
+                                        See the <strong className="text-blue-300">Setup Instructions</strong> above for a full walkthrough.
                                     </p>
 
-                                    {/* Divider */}
-                                    <div className="border-t border-white/10 my-4" />
-
-                                    {/* GCP Service Account JSON */}
-                                    <div>
-                                        <label className="text-sm text-white/60 mb-1.5 block flex items-center gap-2">
-                                            <Key className="w-4 h-4 text-amber-400" />
-                                            GCP Service Account JSON
-                                            {isConfigured('GCP_SERVICE_ACCOUNT_JSON') && <CheckCircle className="w-3.5 h-3.5 text-green-400" />}
-                                        </label>
-                                        <textarea
-                                            placeholder='{"type": "service_account", "project_id": "...", ...}'
-                                            value={secretValues['GCP_SERVICE_ACCOUNT_JSON'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': e.target.value }))}
-                                            rows={4}
-                                            className="w-full text-sm bg-white/5 border border-white/10 rounded-xl px-3 py-2 text-white placeholder-white/30 focus:outline-none focus:border-blue-500/50 resize-none font-mono"
-                                        />
-                                        <div className="flex gap-2 mt-2">
-                                            <label className="flex-1 cursor-pointer">
-                                                <div className="h-9 rounded-lg border border-dashed border-white/20 flex items-center justify-center text-white/40 text-xs hover:border-white/40 transition-colors">
-                                                    📁 Or drop / select a .json key file
+                                    {/* Manual configuration fields */}
+                                    {!gcpConfigured || secretValues['GOOGLE_CLOUD_PROJECT'] !== undefined ? (
+                                        <div className="space-y-3">
+                                            <div>
+                                                <label className="text-sm text-white/60 mb-1.5 block">GCP Project ID</label>
+                                                <div className="flex gap-2">
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="my-municipality-project"
+                                                        value={secretValues['GOOGLE_CLOUD_PROJECT'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': e.target.value }))}
+                                                        className="flex-1 text-sm"
+                                                    />
+                                                    <Button
+                                                        size="sm"
+                                                        className="bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
+                                                        onClick={() => handleSave('GOOGLE_CLOUD_PROJECT')}
+                                                        disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey === 'GOOGLE_CLOUD_PROJECT'}
+                                                    >
+                                                        {savingKey === 'GOOGLE_CLOUD_PROJECT' ? '...' : 'Save'}
+                                                    </Button>
                                                 </div>
-                                                <input
-                                                    type="file"
-                                                    accept=".json"
-                                                    className="hidden"
-                                                    onChange={(e) => {
-                                                        const file = e.target.files?.[0];
-                                                        if (file) {
-                                                            const reader = new FileReader();
-                                                            reader.onload = (ev) => {
-                                                                setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': ev.target?.result as string || '' }));
-                                                            };
-                                                            reader.readAsText(file);
+                                            </div>
+
+                                            <div className="grid grid-cols-3 gap-2">
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">KMS Location</label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="us-central1"
+                                                        value={secretValues['KMS_LOCATION'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_LOCATION': e.target.value }))}
+                                                        className="text-xs"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">KMS Key Ring</label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="pinpoint311-keyring"
+                                                        value={secretValues['KMS_KEY_RING'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_RING': e.target.value }))}
+                                                        className="text-xs"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">KMS Key ID</label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="pii-encryption-key"
+                                                        value={secretValues['KMS_KEY_ID'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_ID': e.target.value }))}
+                                                        className="text-xs"
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            <Button
+                                                size="sm"
+                                                className="w-full bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
+                                                onClick={async () => {
+                                                    if (secretValues['GOOGLE_CLOUD_PROJECT']) await handleSave('GOOGLE_CLOUD_PROJECT');
+                                                    if (secretValues['KMS_LOCATION']) await handleSave('KMS_LOCATION');
+                                                    if (secretValues['KMS_KEY_RING']) await handleSave('KMS_KEY_RING');
+                                                    if (secretValues['KMS_KEY_ID']) await handleSave('KMS_KEY_ID');
+
+                                                    // Auto-enable AI module when GCP is configured
+                                                    if (modules && onUpdateModules && secretValues['GOOGLE_CLOUD_PROJECT']) {
+                                                        await onUpdateModules({ ...modules, ai_analysis: true });
+                                                    }
+                                                }}
+                                                disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey !== null}
+                                            >
+                                                {savingKey ? 'Saving...' : 'Save GCP Settings'}
+                                            </Button>
+
+                                            <p className="text-white/40 text-xs">
+                                                KMS fields are optional — the platform defaults to <code className="bg-black/20 px-1 rounded">us-central1</code> / <code className="bg-black/20 px-1 rounded">pinpoint311-keyring</code> / <code className="bg-black/20 px-1 rounded">pii-encryption-key</code> if left blank. These must match your KMS key ring and key names exactly, or PII encryption silently falls back to local (Fernet) encryption.
+                                            </p>
+
+                                            {/* Divider */}
+                                            <div className="border-t border-white/10 my-4" />
+
+                                            {/* GCP Service Account JSON */}
+                                            <div>
+                                                <label className="text-sm text-white/60 mb-1.5 block flex items-center gap-2">
+                                                    <Key className="w-4 h-4 text-amber-400" />
+                                                    GCP Service Account JSON
+                                                    {isConfigured('GCP_SERVICE_ACCOUNT_JSON') && <CheckCircle className="w-3.5 h-3.5 text-green-400" />}
+                                                </label>
+                                                <textarea
+                                                    placeholder='{"type": "service_account", "project_id": "...", ...}'
+                                                    value={secretValues['GCP_SERVICE_ACCOUNT_JSON'] || ''}
+                                                    onChange={(e) => setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': e.target.value }))}
+                                                    rows={4}
+                                                    className="w-full text-sm bg-white/5 border border-white/10 rounded-xl px-3 py-2 text-white placeholder-white/30 focus:outline-none focus:border-blue-500/50 resize-none font-mono"
+                                                />
+                                                <div className="flex gap-2 mt-2">
+                                                    <label className="flex-1 cursor-pointer">
+                                                        <div className="h-9 rounded-lg border border-dashed border-white/20 flex items-center justify-center text-white/40 text-xs hover:border-white/40 transition-colors">
+                                                            📁 Or drop / select a .json key file
+                                                        </div>
+                                                        <input
+                                                            type="file"
+                                                            accept=".json"
+                                                            className="hidden"
+                                                            onChange={(e) => {
+                                                                const file = e.target.files?.[0];
+                                                                if (file) {
+                                                                    const reader = new FileReader();
+                                                                    reader.onload = (ev) => {
+                                                                        setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': ev.target?.result as string || '' }));
+                                                                    };
+                                                                    reader.readAsText(file);
+                                                                }
+                                                            }}
+                                                        />
+                                                    </label>
+                                                    <Button
+                                                        size="sm"
+                                                        className="bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
+                                                        onClick={() => handleSave('GCP_SERVICE_ACCOUNT_JSON')}
+                                                        disabled={!secretValues['GCP_SERVICE_ACCOUNT_JSON'] || savingKey === 'GCP_SERVICE_ACCOUNT_JSON'}
+                                                    >
+                                                        {savingKey === 'GCP_SERVICE_ACCOUNT_JSON' ? 'Saving...' : 'Save Key'}
+                                                    </Button>
+                                                </div>
+                                                <p className="text-white/30 text-xs mt-1">Required for Vertex AI analysis, multi-language translation, and secure secrets storage</p>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="space-y-3">
+                                            <div className="flex items-center gap-2">
+                                                <div className="flex-1 h-10 rounded-xl bg-blue-500/20 border border-blue-500/30 flex items-center px-4">
+                                                    <CheckCircle className="w-4 h-4 text-blue-400 mr-2" />
+                                                    <span className="text-blue-200 text-sm">GCP configured and ready</span>
+                                                </div>
+                                                <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': '' }))}>
+                                                    Change
+                                                </Button>
+                                            </div>
+
+                                            {/* Module sync indicator */}
+                                            {modules && (
+                                                <div className={`flex items-center gap-2 text-xs ${modules.ai_analysis ? 'text-blue-400' : 'text-white/40'}`}>
+                                                    {modules.ai_analysis ? (
+                                                        <>
+                                                            <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+                                                            AI Analysis module enabled
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <div className="w-2 h-2 rounded-full bg-white/30" />
+                                                            AI Analysis module disabled
+                                                        </>
+                                                    )}
+                                                </div>
+                                            )}
+
+                                            {/* Migrate Secrets to GCP */}
+                                            <div className="border-t border-white/10 pt-3 mt-3">
+                                                <Button
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
+                                                    onClick={async () => {
+                                                        try {
+                                                            setSaveMessage('Migrating secrets to GCP...');
+                                                            const result = await api.migrateToSecretManager();
+                                                            setSaveMessage(
+                                                                `✅ Migrated: ${result.migrated} keys. Scrubbed from DB: ${result.scrubbed}.` +
+                                                                (result.failed > 0 ? ` Failed: ${result.failed}` : '')
+                                                            );
+                                                        } catch (err: any) {
+                                                            setSaveMessage(`❌ ${err.message || 'Migration failed'}`);
                                                         }
                                                     }}
-                                                />
-                                            </label>
-                                            <Button
-                                                size="sm"
-                                                className="bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
-                                                onClick={() => handleSave('GCP_SERVICE_ACCOUNT_JSON')}
-                                                disabled={!secretValues['GCP_SERVICE_ACCOUNT_JSON'] || savingKey === 'GCP_SERVICE_ACCOUNT_JSON'}
-                                            >
-                                                {savingKey === 'GCP_SERVICE_ACCOUNT_JSON' ? 'Saving...' : 'Save Key'}
-                                            </Button>
-                                        </div>
-                                        <p className="text-white/30 text-xs mt-1">Required for Vertex AI analysis, multi-language translation, and secure secrets storage</p>
-                                    </div>
-                                </div>
-                            ) : (
-                                <div className="space-y-3">
-                                    <div className="flex items-center gap-2">
-                                        <div className="flex-1 h-10 rounded-xl bg-blue-500/20 border border-blue-500/30 flex items-center px-4">
-                                            <CheckCircle className="w-4 h-4 text-blue-400 mr-2" />
-                                            <span className="text-blue-200 text-sm">GCP configured and ready</span>
-                                        </div>
-                                        <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': '' }))}>
-                                            Change
-                                        </Button>
-                                    </div>
+                                                >
+                                                    Vault Local Secrets to GCP Identity
+                                                </Button>
+                                                <p className="text-white/30 text-[10px] mt-1 text-center">
+                                                    Moves database-encrypted API keys into Secret Manager
+                                                </p>
+                                            </div>
 
-                                    {/* Module sync indicator */}
-                                    {modules && (
-                                        <div className={`flex items-center gap-2 text-xs ${modules.ai_analysis ? 'text-blue-400' : 'text-white/40'}`}>
-                                            {modules.ai_analysis ? (
-                                                <>
-                                                    <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
-                                                    AI Analysis module enabled
-                                                </>
-                                            ) : (
-                                                <>
-                                                    <div className="w-2 h-2 rounded-full bg-white/30" />
-                                                    AI Analysis module disabled
-                                                </>
-                                            )}
+                                            {/* Re-encrypt PII after KMS key rotation */}
+                                            <div className="border-t border-white/10 pt-3 mt-1">
+                                                <Button
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
+                                                    onClick={async () => {
+                                                        try {
+                                                            setSaveMessage('Re-encrypting PII data...');
+                                                            const result = await api.reencryptPii();
+                                                            setSaveMessage(
+                                                                `✅ Done: ${result.reencrypted}/${result.total} rows re-encrypted` +
+                                                                (result.migrated_from_fernet > 0 ? `, ${result.migrated_from_fernet} migrated from Fernet` : '') +
+                                                                (result.errors > 0 ? `, ${result.errors} errors` : '')
+                                                            );
+                                                        } catch (err: any) {
+                                                            setSaveMessage(`❌ ${err.message || 'Re-encryption failed'}`);
+                                                        }
+                                                    }}
+                                                >
+                                                    🔐 Re-encrypt All PII Data (after key rotation)
+                                                </Button>
+                                                <p className="text-white/30 text-[10px] mt-1 text-center">
+                                                    Migrates historical PII to the current primary KMS key version
+                                                </p>
+                                            </div>
                                         </div>
                                     )}
-
-                                    {/* Migrate Secrets to GCP */}
-                                    <div className="border-t border-white/10 pt-3 mt-3">
-                                        <Button
-                                            size="sm"
-                                            variant="ghost"
-                                            className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
-                                            onClick={async () => {
-                                                try {
-                                                    setSaveMessage('Migrating secrets to GCP...');
-                                                    const result = await api.migrateToSecretManager();
-                                                    setSaveMessage(
-                                                        `✅ Migrated: ${result.migrated} keys. Scrubbed from DB: ${result.scrubbed}.` +
-                                                        (result.failed > 0 ? ` Failed: ${result.failed}` : '')
-                                                    );
-                                                } catch (err: any) {
-                                                    setSaveMessage(`❌ ${err.message || 'Migration failed'}`);
-                                                }
-                                            }}
-                                        >
-                                            Vault Local Secrets to GCP Identity
-                                        </Button>
-                                        <p className="text-white/30 text-[10px] mt-1 text-center">
-                                            Moves database-encrypted API keys into Secret Manager
-                                        </p>
-                                    </div>
-
-                                    {/* Re-encrypt PII after KMS key rotation */}
-                                    <div className="border-t border-white/10 pt-3 mt-1">
-                                        <Button
-                                            size="sm"
-                                            variant="ghost"
-                                            className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
-                                            onClick={async () => {
-                                                try {
-                                                    setSaveMessage('Re-encrypting PII data...');
-                                                    const result = await api.reencryptPii();
-                                                    setSaveMessage(
-                                                        `✅ Done: ${result.reencrypted}/${result.total} rows re-encrypted` +
-                                                        (result.migrated_from_fernet > 0 ? `, ${result.migrated_from_fernet} migrated from Fernet` : '') +
-                                                        (result.errors > 0 ? `, ${result.errors} errors` : '')
-                                                    );
-                                                } catch (err: any) {
-                                                    setSaveMessage(`❌ ${err.message || 'Re-encryption failed'}`);
-                                                }
-                                            }}
-                                        >
-                                            🔐 Re-encrypt All PII Data (after key rotation)
-                                        </Button>
-                                        <p className="text-white/30 text-[10px] mt-1 text-center">
-                                            Migrates historical PII to the current primary KMS key version
-                                        </p>
-                                    </div>
                                 </div>
+                            </motion.div>
                             )}
-                        </div>
-                    </motion.div>
-                    )}
 
 
-                    {/* Sentry Error Tracking - Premium Card */}
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.4 }}
-                        className={`relative rounded-3xl border p-6 transition-all duration-300 ${sentryConfigured
-                            ? 'bg-gradient-to-br from-rose-500/10 via-red-500/5 to-orange-500/10 border-rose-500/30 shadow-lg shadow-rose-500/10'
-                            : 'setup-panel border-transparent'
-                            }`}
-                    >
-                        {sentryConfigured && (
-                            <div className="absolute inset-0 bg-gradient-to-r from-rose-500/5 via-transparent to-orange-500/5 pointer-events-none" />
-                        )}
-
-                        <div className="relative">
-                            <div className="flex items-start justify-between mb-4">
-                                <div className="flex items-center gap-4">
-                                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${sentryConfigured
-                                        ? 'bg-gradient-to-br from-rose-400 to-orange-500 shadow-lg shadow-rose-500/30'
-                                        : 'setup-tile'
-                                        }`}>
-                                        <AlertTriangle className="w-7 h-7 text-white" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-bold text-lg text-white">Sentry</h3>
-                                        <p className="text-white/50 text-sm">Error monitoring</p>
-                                    </div>
-                                </div>
-                                {sentryConfigured ? (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-rose-500/20 to-orange-500/20 text-rose-300 border border-rose-500/30 shadow-lg shadow-rose-500/10">
-                                        <CheckCircle className="w-3.5 h-3.5" />
-                                        Active
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                        Optional
-                                    </span>
+                            {/* Sentry Error Tracking - Premium Card */}
+                            <motion.div
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ delay: 0.4 }}
+                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${sentryConfigured
+                                    ? 'bg-gradient-to-br from-rose-500/10 via-red-500/5 to-orange-500/10 border-rose-500/30 shadow-lg shadow-rose-500/10'
+                                    : 'setup-panel border-transparent'
+                                    }`}
+                            >
+                                {sentryConfigured && (
+                                    <div className="absolute inset-0 bg-gradient-to-r from-rose-500/5 via-transparent to-orange-500/5 pointer-events-none" />
                                 )}
-                            </div>
 
-                            {!sentryConfigured || secretValues['SENTRY_DSN'] !== undefined ? (
-                                <div className="flex gap-2">
-                                    <Input
-                                        type="text"
-                                        placeholder="https://xxx@sentry.io/xxx"
-                                        value={secretValues['SENTRY_DSN'] || ''}
-                                        onChange={(e) => setSecretValues(p => ({ ...p, 'SENTRY_DSN': e.target.value }))}
-                                        className="flex-1 text-sm"
-                                    />
-                                    <Button
-                                        size="sm"
-                                        className="bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600"
-                                        onClick={() => handleSave('SENTRY_DSN')}
-                                        disabled={!secretValues['SENTRY_DSN'] || savingKey === 'SENTRY_DSN'}
-                                    >
-                                        Save
-                                    </Button>
-                                </div>
-                            ) : (
-                                <div className="flex items-center gap-2">
-                                    <div className="flex-1 h-10 rounded-xl bg-rose-500/20 border border-rose-500/30 flex items-center px-4">
-                                        <CheckCircle className="w-4 h-4 text-rose-400 mr-2" />
-                                        <span className="text-rose-200 text-sm">Monitoring active</span>
+                                <div className="relative">
+                                    <div className="flex items-start justify-between mb-4">
+                                        <div className="flex items-center gap-4">
+                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${sentryConfigured
+                                                ? 'bg-gradient-to-br from-rose-400 to-orange-500 shadow-lg shadow-rose-500/30'
+                                                : 'setup-tile'
+                                                }`}>
+                                                <AlertTriangle className="w-7 h-7 text-white" />
+                                            </div>
+                                            <div>
+                                                <h3 className="font-bold text-lg text-white">Sentry</h3>
+                                                <p className="text-white/50 text-sm">Error monitoring</p>
+                                            </div>
+                                        </div>
+                                        {sentryConfigured ? (
+                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-rose-500/20 to-orange-500/20 text-rose-300 border border-rose-500/30 shadow-lg shadow-rose-500/10">
+                                                <CheckCircle className="w-3.5 h-3.5" />
+                                                Active
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
+                                                Optional
+                                            </span>
+                                        )}
                                     </div>
-                                    <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'SENTRY_DSN': '' }))}>
-                                        Change
-                                    </Button>
-                                </div>
-                            )}
-                        </div>
-                    </motion.div>
 
-                    {/* Database Backups - Premium Card (locked in managed mode: the state owns backups) */}
-                    {managedMode ? (
-                        <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
-                            <div className="flex items-center gap-4 mb-2">
-                                <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
-                                    <HardDrive className="w-7 h-7 text-white/50" />
-                                </div>
-                                <div>
-                                    <h3 className="font-bold text-lg text-white/70">Database Backups</h3>
-                                    <p className="text-white/40 text-sm">Encrypted off-site backups</p>
-                                </div>
-                                <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
-                                    <Shield className="w-3.5 h-3.5" />
-                                    Managed by your state
-                                </span>
-                            </div>
-                            <p className="text-white/50 text-sm">
-                                Automated encrypted backups run under your state hosting program's disaster-recovery plan. Nothing to configure here.
-                            </p>
-                        </div>
-                    ) : (
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: 0.5 }}
-                        className={`relative rounded-3xl border p-6 transition-all duration-300 ${backupConfigured
-                            ? 'bg-gradient-to-br from-amber-500/10 via-yellow-500/5 to-orange-500/10 border-amber-500/30 shadow-lg shadow-amber-500/10'
-                            : 'setup-panel border-transparent'
-                            }`}
-                    >
-                        {backupConfigured && (
-                            <div className="absolute inset-0 bg-gradient-to-r from-amber-500/5 via-transparent to-orange-500/5 pointer-events-none" />
-                        )}
-
-                        <div className="relative">
-                            <div className="flex items-start justify-between mb-4">
-                                <div className="flex items-center gap-4">
-                                    <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${backupConfigured
-                                        ? 'bg-gradient-to-br from-amber-400 to-orange-500 shadow-lg shadow-amber-500/30'
-                                        : 'setup-tile'
-                                        }`}>
-                                        <HardDrive className="w-7 h-7 text-white" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-bold text-lg text-white">Database Backups</h3>
-                                        <p className="text-white/50 text-sm">Encrypted S3-compatible storage</p>
-                                    </div>
-                                </div>
-                                {backupConfigured ? (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 border border-amber-500/30 shadow-lg shadow-amber-500/10">
-                                        <CheckCircle className="w-3.5 h-3.5" />
-                                        Configured
-                                    </span>
-                                ) : (
-                                    <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                        Optional
-                                    </span>
-                                )}
-                            </div>
-
-                            <p className="text-white/60 text-sm mb-4">
-                                Backups are encrypted with AES-256 and stored in your S3-compatible bucket. Backup cleanup follows your configured retention policy.
-                                See the <strong className="text-amber-300">Setup Instructions</strong> above for provider-specific guidance.
-                            </p>
-
-                            {!backupConfigured || secretValues['BACKUP_S3_BUCKET'] !== undefined ? (
-                                <div className="space-y-3">
-                                    <div>
-                                        <label className="text-sm text-white/60 mb-1.5 block">S3 Bucket Name</label>
+                                    {!sentryConfigured || secretValues['SENTRY_DSN'] !== undefined ? (
                                         <div className="flex gap-2">
                                             <Input
                                                 type="text"
-                                                placeholder="my-backup-bucket"
-                                                value={secretValues['BACKUP_S3_BUCKET'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': e.target.value }))}
+                                                placeholder="https://xxx@sentry.io/xxx"
+                                                value={secretValues['SENTRY_DSN'] || ''}
+                                                onChange={(e) => setSecretValues(p => ({ ...p, 'SENTRY_DSN': e.target.value }))}
                                                 className="flex-1 text-sm"
                                             />
+                                            <Button
+                                                size="sm"
+                                                className="bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600"
+                                                onClick={() => handleSave('SENTRY_DSN')}
+                                                disabled={!secretValues['SENTRY_DSN'] || savingKey === 'SENTRY_DSN'}
+                                            >
+                                                Save
+                                            </Button>
                                         </div>
-                                    </div>
-
-                                    <div className="grid grid-cols-2 gap-2">
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">Access Key</label>
-                                            <Input
-                                                type="text"
-                                                placeholder="AKIA..."
-                                                value={secretValues['BACKUP_S3_ACCESS_KEY'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ACCESS_KEY': e.target.value }))}
-                                                className="text-sm"
-                                            />
+                                    ) : (
+                                        <div className="flex items-center gap-2">
+                                            <div className="flex-1 h-10 rounded-xl bg-rose-500/20 border border-rose-500/30 flex items-center px-4">
+                                                <CheckCircle className="w-4 h-4 text-rose-400 mr-2" />
+                                                <span className="text-rose-200 text-sm">Monitoring active</span>
+                                            </div>
+                                            <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'SENTRY_DSN': '' }))}>
+                                                Change
+                                            </Button>
                                         </div>
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">Secret Key</label>
-                                            <Input
-                                                type="password"
-                                                placeholder="Your S3 secret key"
-                                                value={secretValues['BACKUP_S3_SECRET_KEY'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_SECRET_KEY': e.target.value }))}
-                                                className="text-sm"
-                                            />
-                                        </div>
-                                    </div>
+                                    )}
+                                </div>
+                            </motion.div>
 
-                                    <div>
-                                        <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
-                                        <Input
-                                            type="password"
-                                            placeholder="Strong passphrase for AES-256 encryption"
-                                            value={secretValues['BACKUP_ENCRYPTION_KEY'] || ''}
-                                            onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_ENCRYPTION_KEY': e.target.value }))}
-                                            className="text-sm"
-                                        />
-                                    </div>
-
-                                    <div className="grid grid-cols-2 gap-2">
-                                        <div>
-                                            <label className="text-xs text-white/50 mb-1 block">S3 Endpoint <span className="text-white/30">(optional)</span></label>
-                                            <Input
-                                                type="text"
-                                                placeholder="https://... (non-AWS only)"
-                                                value={secretValues['BACKUP_S3_ENDPOINT'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ENDPOINT': e.target.value }))}
-                                                className="text-xs"
-                                            />
+                            {/* Database Backups - Premium Card (locked in managed mode: the state owns backups) */}
+                            {managedMode ? (
+                                <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
+                                    <div className="flex items-center gap-4 mb-2">
+                                        <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
+                                            <HardDrive className="w-7 h-7 text-white/50" />
                                         </div>
                                         <div>
-                                            <label className="text-xs text-white/50 mb-1 block">Region <span className="text-white/30">(optional)</span></label>
-                                            <Input
-                                                type="text"
-                                                placeholder="us-ashburn-1"
-                                                value={secretValues['BACKUP_S3_REGION'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_REGION': e.target.value }))}
-                                                className="text-xs"
-                                            />
+                                            <h3 className="font-bold text-lg text-white/70">Database Backups</h3>
+                                            <p className="text-white/40 text-sm">Encrypted off-site backups</p>
                                         </div>
+                                        <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
+                                            <Shield className="w-3.5 h-3.5" />
+                                            Managed by your state
+                                        </span>
                                     </div>
-
-                                    <Button
-                                        size="sm"
-                                        className="w-full bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
-                                        onClick={async () => {
-                                            if (secretValues['BACKUP_S3_BUCKET']) await handleSave('BACKUP_S3_BUCKET');
-                                            if (secretValues['BACKUP_S3_ACCESS_KEY']) await handleSave('BACKUP_S3_ACCESS_KEY');
-                                            if (secretValues['BACKUP_S3_SECRET_KEY']) await handleSave('BACKUP_S3_SECRET_KEY');
-                                            if (secretValues['BACKUP_ENCRYPTION_KEY']) await handleSave('BACKUP_ENCRYPTION_KEY');
-                                            if (secretValues['BACKUP_S3_ENDPOINT']) await handleSave('BACKUP_S3_ENDPOINT');
-                                            if (secretValues['BACKUP_S3_REGION']) await handleSave('BACKUP_S3_REGION');
-                                        }}
-                                        disabled={!secretValues['BACKUP_S3_BUCKET'] || !secretValues['BACKUP_ENCRYPTION_KEY'] || savingKey !== null}
-                                    >
-                                        {savingKey ? 'Saving...' : 'Save Backup Settings'}
-                                    </Button>
-
-                                    <p className="text-white/40 text-xs">
-                                        Endpoint and Region are optional — only needed for non-AWS providers (Oracle, MinIO, etc.).
+                                    <p className="text-white/50 text-sm">
+                                        Automated encrypted backups run under your state hosting program's disaster-recovery plan. Nothing to configure here.
                                     </p>
                                 </div>
                             ) : (
-                                <div className="space-y-3">
-                                    <div className="flex items-center gap-2">
-                                        <div className="flex-1 h-10 rounded-xl bg-amber-500/20 border border-amber-500/30 flex items-center px-4">
-                                            <CheckCircle className="w-4 h-4 text-amber-400 mr-2" />
-                                            <span className="text-amber-200 text-sm">Backup storage configured</span>
+                            <motion.div
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ delay: 0.5 }}
+                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${backupConfigured
+                                    ? 'bg-gradient-to-br from-amber-500/10 via-yellow-500/5 to-orange-500/10 border-amber-500/30 shadow-lg shadow-amber-500/10'
+                                    : 'setup-panel border-transparent'
+                                    }`}
+                            >
+                                {backupConfigured && (
+                                    <div className="absolute inset-0 bg-gradient-to-r from-amber-500/5 via-transparent to-orange-500/5 pointer-events-none" />
+                                )}
+
+                                <div className="relative">
+                                    <div className="flex items-start justify-between mb-4">
+                                        <div className="flex items-center gap-4">
+                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${backupConfigured
+                                                ? 'bg-gradient-to-br from-amber-400 to-orange-500 shadow-lg shadow-amber-500/30'
+                                                : 'setup-tile'
+                                                }`}>
+                                                <HardDrive className="w-7 h-7 text-white" />
+                                            </div>
+                                            <div>
+                                                <h3 className="font-bold text-lg text-white">Database Backups</h3>
+                                                <p className="text-white/50 text-sm">Encrypted S3-compatible storage</p>
+                                            </div>
                                         </div>
-                                        <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': '' }))}>
-                                            Change
-                                        </Button>
+                                        {backupConfigured ? (
+                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 border border-amber-500/30 shadow-lg shadow-amber-500/10">
+                                                <CheckCircle className="w-3.5 h-3.5" />
+                                                Configured
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
+                                                Optional
+                                            </span>
+                                        )}
                                     </div>
+
+                                    <p className="text-white/60 text-sm mb-4">
+                                        Backups are encrypted with AES-256 and stored in your S3-compatible bucket. Backup cleanup follows your configured retention policy.
+                                        See the <strong className="text-amber-300">Setup Instructions</strong> above for provider-specific guidance.
+                                    </p>
+
+                                    {!backupConfigured || secretValues['BACKUP_S3_BUCKET'] !== undefined ? (
+                                        <div className="space-y-3">
+                                            <div>
+                                                <label className="text-sm text-white/60 mb-1.5 block">S3 Bucket Name</label>
+                                                <div className="flex gap-2">
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="my-backup-bucket"
+                                                        value={secretValues['BACKUP_S3_BUCKET'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': e.target.value }))}
+                                                        className="flex-1 text-sm"
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            <div className="grid grid-cols-2 gap-2">
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">Access Key</label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="AKIA..."
+                                                        value={secretValues['BACKUP_S3_ACCESS_KEY'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ACCESS_KEY': e.target.value }))}
+                                                        className="text-sm"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">Secret Key</label>
+                                                    <Input
+                                                        type="password"
+                                                        placeholder="Your S3 secret key"
+                                                        value={secretValues['BACKUP_S3_SECRET_KEY'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_SECRET_KEY': e.target.value }))}
+                                                        className="text-sm"
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            <div>
+                                                <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
+                                                <Input
+                                                    type="password"
+                                                    placeholder="Strong passphrase for AES-256 encryption"
+                                                    value={secretValues['BACKUP_ENCRYPTION_KEY'] || ''}
+                                                    onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_ENCRYPTION_KEY': e.target.value }))}
+                                                    className="text-sm"
+                                                />
+                                            </div>
+
+                                            <div className="grid grid-cols-2 gap-2">
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">S3 Endpoint <span className="text-white/30">(optional)</span></label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="https://... (non-AWS only)"
+                                                        value={secretValues['BACKUP_S3_ENDPOINT'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ENDPOINT': e.target.value }))}
+                                                        className="text-xs"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    <label className="text-xs text-white/50 mb-1 block">Region <span className="text-white/30">(optional)</span></label>
+                                                    <Input
+                                                        type="text"
+                                                        placeholder="us-ashburn-1"
+                                                        value={secretValues['BACKUP_S3_REGION'] || ''}
+                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_REGION': e.target.value }))}
+                                                        className="text-xs"
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            <Button
+                                                size="sm"
+                                                className="w-full bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
+                                                onClick={async () => {
+                                                    if (secretValues['BACKUP_S3_BUCKET']) await handleSave('BACKUP_S3_BUCKET');
+                                                    if (secretValues['BACKUP_S3_ACCESS_KEY']) await handleSave('BACKUP_S3_ACCESS_KEY');
+                                                    if (secretValues['BACKUP_S3_SECRET_KEY']) await handleSave('BACKUP_S3_SECRET_KEY');
+                                                    if (secretValues['BACKUP_ENCRYPTION_KEY']) await handleSave('BACKUP_ENCRYPTION_KEY');
+                                                    if (secretValues['BACKUP_S3_ENDPOINT']) await handleSave('BACKUP_S3_ENDPOINT');
+                                                    if (secretValues['BACKUP_S3_REGION']) await handleSave('BACKUP_S3_REGION');
+                                                }}
+                                                disabled={!secretValues['BACKUP_S3_BUCKET'] || !secretValues['BACKUP_ENCRYPTION_KEY'] || savingKey !== null}
+                                            >
+                                                {savingKey ? 'Saving...' : 'Save Backup Settings'}
+                                            </Button>
+
+                                            <p className="text-white/40 text-xs">
+                                                Endpoint and Region are optional — only needed for non-AWS providers (Oracle, MinIO, etc.).
+                                            </p>
+                                        </div>
+                                    ) : (
+                                        <div className="space-y-3">
+                                            <div className="flex items-center gap-2">
+                                                <div className="flex-1 h-10 rounded-xl bg-amber-500/20 border border-amber-500/30 flex items-center px-4">
+                                                    <CheckCircle className="w-4 h-4 text-amber-400 mr-2" />
+                                                    <span className="text-amber-200 text-sm">Backup storage configured</span>
+                                                </div>
+                                                <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': '' }))}>
+                                                    Change
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
+                            </motion.div>
                             )}
                         </div>
-                    </motion.div>
-                    )}
-                </div>
-            </CollapsibleSection>
+                        </>
+                    }
+                />
+            </div>
+
 
 
             {/* 3 — The town's own systems */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -188,6 +188,12 @@ export interface CloudProfileResult {
     warnings: string[];
 }
 
+/** Every capability with a provider catalog. The last four were already
+ *  switchable in the backend and had no catalog, so nothing surfaced them. */
+export type Capability =
+    | 'ai' | 'translation' | 'identity' | 'maps'
+    | 'email' | 'sms' | 'kms' | 'redaction';
+
 class ApiClient {
     private token: string | null = null;
     private onUnauthorized: (() => void) | null = null;
@@ -584,7 +590,7 @@ class ApiClient {
     }
 
     // Service providers (AI / translation / identity)
-    async getProviderCatalog(capability: 'ai' | 'translation' | 'identity' | 'maps'): Promise<ProviderCatalog> {
+    async getProviderCatalog(capability: Capability): Promise<ProviderCatalog> {
         return this.request<ProviderCatalog>(`/system/${capability}/catalog`);
     }
 


### PR DESCRIPTION
Six commits. Fast-forward.

## Four capabilities were switchable and unreachable

`EMAIL_PROVIDER`, `SMS_PROVIDER`, `KMS_PROVIDER` and `REDACTION_PROVIDER` are each read by live dispatch code — `configure_notifications`, `pii_crypto`'s wrap/unwrap, `image_redaction`'s detector selection. None had a catalog. The console had one hand-written SMTP-and-Twilio card, so the other nine providers, every KMS choice, and photo redaction entirely could only be reached by writing a secret by hand.

**Photo redaction appeared zero times in the frontend** — a privacy feature that exists, works, and effectively did not ship.

| | Now selectable |
|---|---|
| Email | SMTP, Amazon SES, Azure ACS |
| Text | Twilio, Amazon SNS, Azure ACS, HTTP gateway, Off |
| PII encryption | Google KMS, Azure Key Vault, AWS KMS, application key |
| Photo redaction | Google Vision, Rekognition, Azure AI Vision, on-server |

Confined to providers the dispatch code actually branches on, with a test asserting the catalogs equal the implemented sets. Adding one the backend cannot route to is the failure this repo has produced repeatedly — a setting that stores fine, reads back fine, and does nothing.

The same trap in field form: a card collecting a credential nothing consumes. Writing these from memory produced three wrong names — `TWILIO_FROM_NUMBER` for `TWILIO_PHONE_NUMBER`, `SMS_API_URL` for `SMS_HTTP_API_URL`, `AZURE_KEY_VAULT_URL` for `AZURE_KEYVAULT_URL`. Every declared field is now checked against the keys the dispatch code reads, as a test rather than a one-off.

All four route through the existing `_PROVIDER_SELECT_KEY` and `_capability_catalog`, so they get the shared save, validation and connection test. One generic `/{capability}/catalog` serves them, **registered after** the hand-written routes — my first attempt put it earlier, which shadowed `/ai/catalog` and 404'd it. A test pins the ordering.

## One section, not two

Email and SMS becoming catalog cards left the page showing each twice. Both hand-written cards are gone. The three that are not provider choices — Google Cloud credentials, Sentry, database backups — moved into the providers section under an "Other settings" divider. Two sections meant two places to look for "what have I not done", with one progress bar counting across both.

## Guided setup

- **Everything on by default.** The extras question started with three of eight ticked, quietly deciding for every town that never opened it.
- **Answering it removes the inputs, not just the steps.** Unchosen capabilities do not render. Sign-in and maps are never filtered — you cannot take a report without them. An *unanswered* question still shows everything: absent is not "wanted nothing".
- **One capability at a time**, with its position shown, cursor advancing as credentials land. The mode is derived from what is configured, not stored — a stored "I am done" flag would let a half-finished town dismiss guidance it still needs. Overrides both ways.
- **Progress** reads `3 of 10 · 30% · 7 left`, over ten integrations rather than six. Four of the ten were previously untracked, so a town could read "all configured" with AI, translation, PII encryption and redaction untouched.

## Instructions next to the boxes

The guide was one document at the top; the fields were three thousand pixels below. Each card now carries a "How to get these" block immediately above its fields, keyed to the selected provider — switch Vertex to Bedrock and the text switches too.

Short on purpose, and each is the thing that actually catches people out: Google Maps needs billing attached or the key looks fine and the map stays grey; Entra shows the secret Value once; SES refuses unverified domains; new AWS accounts are SMS-sandboxed; a generic OIDC issuer must not include the discovery path.

Photo redaction and error reporting also gained full guide steps, having had none.

## Plates blur by default

A deliberate reversal. The detector guesses and its failure is a blurred house number — a real cost, but one a clerk can see and correct, whereas a published plate is one nobody notices until it matters. Previously "a town can opt in" was not true, because there was no card.

## Verification

664 backend tests (16 new), 80 frontend tests, build succeeds, `tsc --noEmit` holds at 11 pre-existing errors (9 Azure renderer nulls, 2 dead search state). 414 pass / 30 skip under CI's slim dependency set.

Rendered in Chromium against the real shipped catalogs: ten cards, no duplicates, one panel open, cursor on step 1 of 8, both overrides present, instructions swapping with the provider, no page errors.

Not covered: no end-to-end run against a live deployment. The catalogs are verified against the dispatch code by test, not by sending a real email or wrapping a real key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_