### PR TITLE
Setup guide with embedded fields, deployment registration form, and fixes for four silent failures

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -14,7 +14,19 @@ Pinpoint 311 is designed for self-hosted deployment within a municipal jurisdict
   - **Cloud KMS mode**: PII is protected with envelope encryption — a local data key encrypts the field, and that data key is wrapped by your cloud's key service (Google Cloud KMS, Azure Key Vault, or AWS KMS). Ciphertext is stored locally; only the data-key wrap/unwrap involves the cloud.
   - **Local mode**: PII is encrypted locally with Fernet (`SECRET_KEY`-derived), with no cloud dependency.
   - **Fail-loud option**: setting `REQUIRE_KMS` makes the platform refuse to store PII if the key service is unavailable, rather than silently falling back.
-- **No third-party analytics**: no external tracking or analytics services; the application does not phone home.
+- **No third-party analytics**: no external tracking or analytics services; the application does not phone home. There is exactly one voluntary exception, documented below.
+
+### Optional Deployment Registration (the one outbound exception)
+
+The application makes no automatic calls to Pinpoint 311 servers. Because it is self-hosted, that also means there is no way to reach a town when a security fix ships. The admin console therefore includes an **optional, user-initiated registration form**, disclosed here rather than left to be discovered:
+
+- **Nothing is transmitted unless a person fills in the form and presses Submit.** There is no background call, no scheduled call, and no call on install, upgrade or startup. Dismissing the prompt sends nothing.
+- **Submission is browser-side.** The request is made by the admin's browser directly to `pinpoint311.org`, not by the application server. The server holds no connection to Pinpoint 311 infrastructure, before or after. A deployment that blocks outbound traffic simply sees the submission fail; the form then offers a link to the same form on the website, and nothing else changes.
+- **The payload contains only typed values plus two consent flags.** Nothing is inferred, measured, or attached: no version string, no deployment fingerprint, no request counts, no configuration, no identifiers of any kind. The fields are: organization or municipality, contact name, contact email, contact role or title, deployment URL, state or country, how the deployment is being used (self-hosted for one municipality / hosting for multiple / evaluating), consent to receive security advisories and release notes, and consent to be listed publicly as a deployment. The first three are required; the rest are optional. A hidden anti-spam field is submitted empty.
+- **Dismissal is honoured.** Closing the prompt by any route stops it reappearing in that browser. It remains reachable from a dismissible banner and from an entry on the setup page, and never blocks any part of the console.
+- **The receiving endpoint is unauthenticated by design.** Distributing an API key with an open-source install would publish it; requiring one would break the zero-config install. The endpoint accepts requests from any origin, since every deployment is on a different domain, and is rate-limited by IP.
+
+The implementation is `frontend/src/components/StayInformed.tsx`, which carries the same account of what it does and does not send.
 
 ### Audit Logging
 - **Comprehensive trail**: every lifecycle event is recorded in the `request_audit_logs` table (submission, assignment, status changes, comments, edits).

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ graph TB
 
     subgraph "Infrastructure"
         CD[Caddy HTTPS]
-        WT[Watchtower auto-update, optional]
     end
 
     subgraph "Pluggable Providers - bring your own cloud"
@@ -824,7 +823,6 @@ The system automatically recovers from common failures without developer interve
 |-------|------------|-----------------|
 | **Docker healthchecks** | Backend, Worker, Frontend auto-restart if unresponsive | None |
 | **Container restart** | Containers restart after a crash (`unless-stopped`) | None |
-| **Watchtower** | Optional: pulls updated images on a schedule | None |
 | **SSH Auto-Restart** | Force restart via SSH when uptime check fails | Optional* |
 
 *To enable SSH auto-restart, add `PROD_HOST` and `PROD_SSH_KEY` secrets to your GitHub repository.
@@ -1038,23 +1036,34 @@ Yes. Every deployment is self-hosted on your own infrastructure.
 | **Dependencies** | Open-source, with public documentation |
 | **Phone-home** | The application makes no automatic calls back to Pinpoint 311 servers. The single exception is a voluntary registration form in the admin console, which sends only what an administrator types and only when they press Submit — see COMPLIANCE.md |
 | **Recovery** | Container auto-restart and health checks |
-| **Updates** | Optional automatic image updates (see below) |
+| **Updates** | Manual and deliberate — you decide when, see below |
 
-**Watchtower (Optional):**
-Watchtower automatically updates your Docker containers with security patches. It runs at 3am daily.
+**Updating**
+
+Nothing updates itself. There is no agent watching a registry, and no way for
+anybody outside your organisation to change what is running on your server. An
+update happens when somebody on your staff runs two commands:
 
 ```bash
-# Enable Watchtower
-docker compose up -d watchtower
-
-# Disable Watchtower  
-docker compose stop watchtower
-
-# Check status
-docker compose ps watchtower
+docker compose pull                                        # fetch the new images
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
-> 💡 The core system works perfectly without Watchtower. Enable it for hands-off security updates, or disable it for full manual control.
+The container reconciles the database schema on start. Additive migrations apply
+by themselves; a migration that would drop or rewrite data stops the container
+and prints the command a person has to run, rather than doing it unattended.
+
+**Take a backup first.** A restore is only as good as the last one taken, and an
+upgrade is the moment you find out.
+
+*This used to be automatic.* A Watchtower container shipped in the default
+compose file and pulled new images at 3am daily. Two problems: the README called
+it optional while nothing in the compose made it so, and its scope was every
+container it could pull rather than the application — which on a source-built
+install meant it upgraded PostGIS, Redis and Caddy unattended while leaving the
+application alone. An unannounced database-engine change on a municipal server
+at 3am is not a feature. It is gone; updates are now something a person decides
+to do.
 
 **What you'd handle independently:**
 - Security patches for dependencies

--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ Yes. Every deployment is self-hosted on your own infrastructure.
 | **Data ownership** | The PostgreSQL database is yours to control |
 | **License** | MIT — fork, modify, and redistribute freely |
 | **Dependencies** | Open-source, with public documentation |
-| **Phone-home** | The application makes no calls back to Pinpoint 311 servers |
+| **Phone-home** | The application makes no automatic calls back to Pinpoint 311 servers. The single exception is a voluntary registration form in the admin console, which sends only what an administrator types and only when they press Submit — see COMPLIANCE.md |
 | **Recovery** | Container auto-restart and health checks |
 | **Updates** | Optional automatic image updates (see below) |
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -3,8 +3,10 @@ System Health Check API
 
 Tests all integrations and provides detailed status for:
 - Auth0 SSO
-- Google Cloud KMS (PII Encryption)
-- Google Secret Manager
+- Key management for PII encryption (Google Cloud KMS, Azure Key Vault, AWS KMS,
+  or the application key)
+- The configured secret store (Google Secret Manager, Azure Key Vault, AWS
+  Secrets Manager, or the encrypted database)
 - Vertex AI (Gemini)
 - Translation API
 - Database
@@ -94,134 +96,136 @@ async def check_auth0(db: AsyncSession) -> Dict[str, Any]:
 
 
 
-async def check_google_kms(db: AsyncSession) -> Dict[str, Any]:
-    """Test Google Cloud KMS for PII encryption"""
+# Names kept provider-neutral on purpose. These used to be check_google_kms and
+# "Test Google Secret Manager", and both were written as a list of Google
+# config variables to look for -- so a town running Azure Key Vault or AWS KMS,
+# with envelope encryption working perfectly, saw "GCP project not configured"
+# on its health dashboard. A health check that reports a false problem on a
+# supported configuration is worse than not having one.
+#
+# Both now test the thing itself rather than the shape of somebody's config:
+# the KMS check does a real encrypt/decrypt round trip and reports which key
+# manager actually wrapped the data key, and the store check asks the same
+# reachability question the migration gates on.
+
+async def check_kms(db: AsyncSession) -> Dict[str, Any]:
+    """Round-trip PII encryption and report which key manager did the wrapping.
+
+    The selected provider is not the answer; what wrapped the key is. Those
+    differ in exactly the case worth surfacing -- a KMS chosen but unreachable
+    falls back to the application key silently, and this is where that shows.
+    """
     try:
-        # Check environment variables OR database secrets
-        project = await get_config_value(db, "GOOGLE_CLOUD_PROJECT")
-        key_ring = await get_config_value(db, "KMS_KEY_RING")
-        key_id = await get_config_value(db, "KMS_KEY_ID")
-        location = await get_config_value(db, "KMS_LOCATION") or "us-central1"
-        
-        if not project:
-            return {
-                "status": "not_configured",
-                "message": "GCP project not configured (see Admin Console → Setup & Integration)",
-                "project": None
-            }
-        
-        # If project is set but specific KMS vars aren't, show as fallback mode
-        if not all([key_ring, key_id]):
-            return {
-                "status": "fallback",
-                "message": "Using Fernet encryption (KMS keyring not configured)",
-                "project": project,
-                "note": "Fernet encryption is secure; KMS is optional for enhanced key management"
-            }
-        
-        # Encrypt/decrypt test data through the real envelope path
-        from app.core.encryption import encrypt_pii, decrypt_pii, PII_V2_PREFIX
+        from app.core.encryption import encrypt_pii, decrypt_pii, PII_V2_PREFIX, _kms_provider
         from app.core import pii_crypto
+
+        selected = _kms_provider()
 
         test_data = "health_check_test@example.com"
         encrypted = encrypt_pii(test_data)
-        decrypted = decrypt_pii(encrypted)
-
-        if decrypted != test_data:
+        if decrypt_pii(encrypted) != test_data:
             return {
                 "status": "error",
                 "message": "PII encryption round-trip returned incorrect data",
-                "project": project,
-                "key_ring": key_ring,
-                "key_name": key_id,
-                "location": location,
+                "selected_provider": selected,
             }
 
-        # Determine which key manager wraps the data key (envelope scheme).
         if encrypted.startswith(PII_V2_PREFIX):
             backend = pii_crypto.active_backend()
-        elif encrypted.startswith("kms:") or encrypted.startswith("akv:"):
-            backend = "kms"
+        elif encrypted.startswith("kms:"):
+            backend = "google"
+        elif encrypted.startswith("akv:"):
+            backend = "azure"
         else:
             backend = "local"
 
-        if backend in ("google", "azure", "kms"):
+        label = {"google": "Google Cloud KMS", "azure": "Azure Key Vault",
+                 "aws": "AWS KMS"}.get(backend)
+
+        details: Dict[str, Any] = {
+            "kms_backend": backend,
+            "selected_provider": selected,
+            "test_passed": True,
+        }
+        # Only the fields that mean something for the backend in use. Reporting
+        # a key ring to a town on AWS is how the Google shape leaked out before.
+        if backend == "google":
+            details["project"] = await get_config_value(db, "GOOGLE_CLOUD_PROJECT")
+            details["key_ring"] = await get_config_value(db, "KMS_KEY_RING")
+            details["key_name"] = await get_config_value(db, "KMS_KEY_ID")
+            details["location"] = await get_config_value(db, "KMS_LOCATION") or "us-central1"
+        elif backend == "azure":
+            details["vault"] = await get_config_value(db, "AZURE_KEYVAULT_URL")
+            details["key_name"] = await get_config_value(db, "AZURE_KEYVAULT_KEY")
+        elif backend == "aws":
+            details["key_name"] = await get_config_value(db, "AWS_KMS_KEY_ID")
+            details["region"] = await get_config_value(db, "AWS_REGION")
+
+        if label:
+            return {"status": "healthy",
+                    "message": f"Envelope encryption working (data key wrapped by {label})",
+                    **details}
+
+        # Local wrapping. Expected on a self-hosted install with no cloud
+        # account, and a real warning when a KMS was selected and is not being
+        # used -- which is silent everywhere else.
+        if selected in ("google", "azure", "aws"):
             return {
-                "status": "healthy",
-                "message": f"Envelope encryption working (data key wrapped by {backend} KMS)",
-                "project": project,
-                "key_ring": key_ring,
-                "key_name": key_id,
-                "location": location,
-                "kms_backend": backend,
-                "test_passed": True,
+                "status": "fallback",
+                "message": (
+                    f"PII is encrypted, but with the application key — the selected "
+                    f"key manager ({selected}) is not reachable, so it is not being used."
+                ),
+                **details,
             }
         return {
             "status": "fallback",
-            "message": "PII encryption working with a local SECRET_KEY-wrapped data key (no cloud KMS configured)",
-            "project": project,
-            "key_ring": key_ring,
-            "key_name": key_id,
-            "location": location,
-            "kms_backend": backend,
-            "test_passed": True,
+            "message": "PII encryption working with a local application-key-wrapped data key (no cloud KMS configured)",
+            **details,
         }
-            
+
     except Exception as e:
         import logging
         logging.getLogger(__name__).error(f"KMS health check failed: {e}")
-        return {
-            "status": "error",
-            "message": "KMS check failed",
-            "project": os.getenv("GOOGLE_CLOUD_PROJECT")
-        }
+        return {"status": "error", "message": "KMS check failed"}
 
 
 async def check_secret_manager(db: AsyncSession) -> Dict[str, Any]:
-    """Test Google Secret Manager"""
+    """Whether the configured secret store -- whichever one -- can be reached."""
     try:
-        # Check for GCP project (from env OR database via Admin Console)
-        project = await get_config_value(db, "GOOGLE_CLOUD_PROJECT")
-        
-        # If GCP is configured via wizard, Secret Manager is available
-        has_gcp_credentials = await get_config_value(db, "GCP_SERVICE_ACCOUNT_JSON") is not None
-        
-        if not project:
-            return {
-                "status": "not_configured",
-                "message": "GCP project not configured (see Admin Console → Setup & Integration)",
-                "project": None
-            }
-        
-        # If credentials exist from wizard, SM is available even if USE_SECRET_MANAGER not set
-        if has_gcp_credentials:
-            return {
-                "status": "configured",
-                "message": "Secret Manager available via service account",
-                "project": project,
-                "note": "Credentials stored in database (encrypted)"
-            }
-        
-        from app.services.secret_manager import get_secrets_bundle
-        
-        # Try to fetch any secrets
-        await get_secrets_bundle("TEST_")  # Test connectivity
-        
+        from app.services.secret_manager import _secrets_provider
+        from app.services.storage_maintenance import store_reachable
+
+        provider = _secrets_provider()
+        label = {"azure": "Azure Key Vault", "aws": "AWS Secrets Manager"}.get(
+            provider, "Google Secret Manager")
+
+        if store_reachable():
+            details: Dict[str, Any] = {"status": "healthy", "store": provider,
+                                       "message": f"{label} accessible"}
+            if provider == "google":
+                details["project"] = await get_config_value(db, "GOOGLE_CLOUD_PROJECT")
+            elif provider == "azure":
+                details["vault"] = await get_config_value(db, "AZURE_KEYVAULT_URL")
+            elif provider == "aws":
+                details["region"] = await get_config_value(db, "AWS_REGION")
+            return details
+
+        # Not an error. The encrypted database is a supported store, and this is
+        # the normal state of a small self-hosted install.
         return {
-            "status": "healthy",
-            "message": "Secret Manager accessible",
-            "project": project,
-            "test_query": "SUCCESS"
+            "status": "not_configured",
+            "store": provider,
+            "message": (
+                f"{label} is not reachable — secrets are held in the encrypted "
+                f"database. They move across on their own once it is configured."
+            ),
         }
-        
+
     except Exception as e:
         import logging
-        logging.getLogger(__name__).error(f"Secret Manager health check failed: {e}")
-        return {
-            "status": "error",
-            "message": "Secret Manager check failed",
-            "project": os.getenv("GOOGLE_CLOUD_PROJECT")
-        }
+        logging.getLogger(__name__).error(f"Secret store health check failed: {e}")
+        return {"status": "error", "message": "Secret store check failed"}
 
 
 async def check_vertex_ai(db: AsyncSession) -> Dict[str, Any]:
@@ -378,8 +382,14 @@ async def health_check(
         "database": await check_database(db),
         "auth0": await check_auth0(db),
         "gcp_auth": await check_gcp_auth(db),
-        "google_kms": await check_google_kms(db),
-        "google_secret_manager": await check_secret_manager(db),
+        # Renamed from google_kms / google_secret_manager. The old keys named a
+        # vendor for a slot that has four options, and the dashboard rendered
+        # them under Google headings whatever the town was actually running.
+        # Not aliased alongside the new keys: classify_health derives the
+        # overall status from this dict, so a duplicated entry would weight
+        # these two checks twice.
+        "kms": await check_kms(db),
+        "secret_store": await check_secret_manager(db),
         "vertex_ai": await check_vertex_ai(db),
         "translation_api": await check_translation_api(db)
     }
@@ -566,8 +576,9 @@ async def trigger_uptime_check(
     services_to_check = [
         ("database", check_database),
         ("auth0", check_auth0),
-        ("google_kms", check_google_kms),
-        ("secret_manager", check_secret_manager),
+        # Series names, not display names -- see the note in main.py.
+        ("kms", check_kms),
+        ("secret_store", check_secret_manager),
         ("vertex_ai", check_vertex_ai),
         ("translation_api", check_translation_api),
     ]

--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -87,6 +87,27 @@ def public_visibility_filters():
     )
 
 
+def direct_link_filters():
+    """The rule for reaching ONE report by its id — a tracking link.
+
+    Deliberately does not filter on `is_public`. Unlisted means "kept out of the
+    town's public listing", not "hidden from the person who filed it": the
+    resident has the link, staff have the link, and the whole point of the
+    setting is that the report is still worked and still trackable.
+
+    Named and shared for the same reason as the listing rule above, and because
+    the two are easy to confuse. Adding `is_public` here would look like
+    tightening security and would in fact break every tracking link for every
+    unlisted report, silently -- the endpoint would 404 and the resident would
+    conclude their report had been deleted.
+
+    Two of the four by-id endpoints were also missing the soft-delete clause, so
+    a deleted request still served its comments. Folded in here so there is one
+    rule rather than four inline copies of most of it.
+    """
+    return (ServiceRequest.deleted_at.is_(None),)
+
+
 @router.get("/public/requests")
 async def list_public_requests(
     status: Optional[str] = Query(None, description="Filter by status"),
@@ -166,7 +187,7 @@ async def get_public_request_detail(request_id: str, db: AsyncSession = Depends(
             selectinload(ServiceRequest.assigned_department)
         ).where(
             ServiceRequest.service_request_id == request_id,
-            ServiceRequest.deleted_at.is_(None)
+            *direct_link_filters(),
         )
     )
     request = result.scalar_one_or_none()
@@ -202,7 +223,8 @@ async def get_public_comments(request_id: str, db: AsyncSession = Depends(get_db
     """Get external/public comments for a request - no auth required"""
     # Find the request
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:
@@ -229,7 +251,8 @@ async def add_public_comment(
     """Add a public comment to a request - no auth required, always external visibility"""
     # Find the request
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     sr = result.scalar_one_or_none()
     if not sr:
@@ -277,7 +300,8 @@ async def get_audit_log(
 ):
     """Get audit log for a request (staff only - full history)"""
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:
@@ -308,7 +332,8 @@ async def verify_audit_log(
     """
     from app.models import compute_request_audit_hash, compute_request_audit_hash_legacy
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:
@@ -351,7 +376,7 @@ async def get_public_audit_log(request_id: str, db: AsyncSession = Depends(get_d
     result = await db.execute(
         select(ServiceRequest).where(
             ServiceRequest.service_request_id == request_id,
-            ServiceRequest.deleted_at.is_(None)
+            *direct_link_filters(),
         )
     )
     request = result.scalar_one_or_none()
@@ -570,7 +595,7 @@ async def lookup_request_by_token(service_request_id: str, db: AsyncSession = De
     result = await db.execute(
         select(ServiceRequest).where(
             ServiceRequest.service_request_id == service_request_id,
-            ServiceRequest.deleted_at.is_(None)
+            *direct_link_filters(),
         )
     )
     request_obj = result.scalar_one_or_none()
@@ -1153,7 +1178,8 @@ async def delete_request(
 ):
     """Soft delete a service request with justification (staff/admin)"""
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:
@@ -1192,7 +1218,8 @@ async def restore_request(
 ):
     """Restore a soft-deleted service request (staff/admin)"""
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:
@@ -1231,7 +1258,8 @@ async def accept_ai_priority(
 ):
     """Accept AI-suggested priority score (copies to manual_priority_score)"""
     result = await db.execute(
-        select(ServiceRequest).where(ServiceRequest.service_request_id == request_id)
+        select(ServiceRequest).where(
+            ServiceRequest.service_request_id == request_id, *direct_link_filters())
     )
     request = result.scalar_one_or_none()
     if not request:

--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -683,119 +683,108 @@ async def verify_setup(
     return results
 
 
+@router.post("/backup-key")
+async def generate_backup_key(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)
+):
+    """Generate the backup passphrase, store it, and return it once.
+
+    The field used to say "Strong passphrase for AES-256 encryption" and leave
+    a town to invent one, which reliably produces either something guessable or
+    something nobody can find again. Generating it removes both failure modes.
+
+    The one part that cannot be automated is the copy kept somewhere else: a key
+    held only inside the system it protects is worth nothing the day that system
+    is gone, which is exactly the day a backup matters. So this returns the
+    value in the clear, once, for the page to show and have acknowledged -- and
+    stores it through the normal path, so it lands in the secret store like any
+    other credential.
+    """
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    from app.api.system import _persist_secret
+    from app.services.storage_maintenance import generated_backup_key
+
+    key = generated_backup_key()
+    await _persist_secret(db, "BACKUP_ENCRYPTION_KEY", key)
+
+    await AuditService.log_event(
+        db=db,
+        event_type="backup_key_generated",
+        success=True,
+        user_id=current_user.id,
+        username=current_user.username,
+        # Deliberately no key material, not even a prefix.
+        details={"length": len(key)},
+    )
+    return {"key": key}
+
+
+@router.get("/storage-status")
+async def storage_status(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db)
+):
+    """What, if anything, is not yet on the storage this town has chosen.
+
+    This exists so the setup page can say nothing at all in the normal case.
+    Secrets are vaulted and PII is re-wrapped on a schedule (see
+    `app.tasks.storage`), so the only thing worth showing a clerk is the case
+    where those jobs cannot finish -- a store that has stopped answering, or
+    rows whose old key is gone. Read-only, and `summary` swallows its own
+    errors, so this cannot fail a page load.
+    """
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    from app.services.storage_status import summary
+
+    return await summary(db)
+
+
 @router.post("/reencrypt-pii")
 async def reencrypt_pii(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
-    """
-    Re-encrypt all PII data using the current primary KMS key version.
+    """Re-wrap PII onto the current key immediately, instead of waiting.
 
-    After KMS key rotation, historical PII remains encrypted with old key versions.
-    This endpoint decrypts each value (KMS transparently handles old versions)
-    and re-encrypts with the current primary key version.
+    The nightly task does this unprompted and in batches, which is how it
+    normally happens; this stays for the operator who has just rotated a key and
+    wants it done now, and for support to be able to trigger a pass.
 
-    Also handles Fernet→KMS migration for dev data (gAAAA → kms:).
-
-    Admin only. Processes in batches of 100.
+    Rewritten to share that task's implementation. It previously required Google
+    Cloud KMS specifically -- a town on Azure or AWS got a 400 telling them to
+    "configure GCP first" -- and it loaded every request id in the database
+    before doing anything, including the rows that were already fine.
     """
     if current_user.role != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
 
-    from app.core.encryption import decrypt_pii, encrypt_pii, KMS_ENCRYPTED_PREFIX, ENCRYPTED_PREFIX, _is_kms_available
-    from app.models import ServiceRequest
+    from app.services.storage_maintenance import rewrap_pii as _rewrap
 
-    if not _is_kms_available():
-        raise HTTPException(
-            status_code=400,
-            detail="Google Cloud KMS is not configured. Configure GCP first."
-        )
+    totals = {"rows": 0, "fields": 0, "errors": 0}
+    for _ in range(20):
+        result = await _rewrap(db)
+        totals["rows"] += result.get("rows", 0)
+        totals["fields"] += result.get("fields", 0)
+        totals["errors"] += result.get("errors", 0)
+        if result.get("status") != "ok" or not result.get("remaining"):
+            break
 
-    # Count total rows with PII
-    count_result = await db.execute(
-        select(ServiceRequest.id).where(
-            (ServiceRequest._first_name_encrypted.isnot(None)) |
-            (ServiceRequest._last_name_encrypted.isnot(None)) |
-            (ServiceRequest._email_encrypted.isnot(None)) |
-            (ServiceRequest._phone_encrypted.isnot(None))
-        )
-    )
-    all_ids = [row[0] for row in count_result.all()]
-    total = len(all_ids)
-
-    reencrypted = 0
-    errors = 0
-    migrated_from_fernet = 0
-    batch_size = 100
-
-    for i in range(0, total, batch_size):
-        batch_ids = all_ids[i:i + batch_size]
-        batch_result = await db.execute(
-            select(ServiceRequest).where(ServiceRequest.id.in_(batch_ids))
-        )
-        rows = batch_result.scalars().all()
-
-        for row in rows:
-            try:
-                changed = False
-                pii_columns = [
-                    ("_first_name_encrypted", row._first_name_encrypted),
-                    ("_last_name_encrypted", row._last_name_encrypted),
-                    ("_email_encrypted", row._email_encrypted),
-                    ("_phone_encrypted", row._phone_encrypted),
-                ]
-
-                for col_name, encrypted_val in pii_columns:
-                    if not encrypted_val:
-                        continue
-
-                    is_fernet = encrypted_val.startswith(ENCRYPTED_PREFIX) and not encrypted_val.startswith(KMS_ENCRYPTED_PREFIX)
-
-                    # Decrypt (KMS handles old key versions transparently; Fernet uses app key)
-                    plaintext = decrypt_pii(encrypted_val)
-                    if not plaintext:
-                        continue  # Decryption failed, skip
-
-                    # Re-encrypt with current primary KMS key
-                    new_encrypted = encrypt_pii(plaintext)
-                    if new_encrypted != encrypted_val:
-                        setattr(row, col_name, new_encrypted)
-                        changed = True
-                        if is_fernet:
-                            migrated_from_fernet += 1
-
-                if changed:
-                    reencrypted += 1
-            except Exception as e:
-                logger.warning(f"Re-encryption failed for row {row.id}: {e}")
-                errors += 1
-
-        await db.commit()
-
-    # Audit log
     await AuditService.log_event(
         db=db,
         event_type="pii_reencryption",
         success=True,
         user_id=current_user.id,
         username=current_user.username,
-        details={
-            "total_rows": total,
-            "reencrypted": reencrypted,
-            "migrated_from_fernet": migrated_from_fernet,
-            "errors": errors,
-        }
+        details=totals,
     )
+    logger.info("PII re-wrap: %s rows, %s fields, %s errors",
+                totals["rows"], totals["fields"], totals["errors"])
 
-    logger.info(
-        f"PII re-encryption complete: {reencrypted}/{total} rows re-encrypted, "
-        f"{migrated_from_fernet} migrated from Fernet, {errors} errors"
-    )
-
-    return {
-        "total": total,
-        "reencrypted": reencrypted,
-        "migrated_from_fernet": migrated_from_fernet,
-        "errors": errors,
-    }
+    # `reencrypted` is kept in the response shape for existing callers.
+    return {"reencrypted": totals["rows"], **totals}
 

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -622,6 +622,23 @@ class CloudProfileRequest(BaseModel):
     apply_identity: bool = False
 
 
+@router.get("/providers/cloud-identity")
+async def cloud_identity(_: User = Depends(get_current_admin)):
+    """Whether this server already has an identity on its cloud.
+
+    When it does, the credential boxes for that cloud are not merely optional --
+    leaving them empty is the better answer. The token is issued minutes at a
+    time and rotated by the platform, so there is no long-lived secret to leak,
+    to vault, or to expire on a date nobody recorded.
+
+    Two of the three already behaved this way by accident: boto3 falls through
+    to the instance role and google-auth to Application Default Credentials when
+    nothing is configured. Nothing said so, so every town pasted a key anyway.
+    """
+    from app.services.cloud_identity import summary
+    return summary()
+
+
 @router.get("/providers/cloud-profile")
 async def get_cloud_profile(
     db: AsyncSession = Depends(get_db),

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -477,6 +477,190 @@ async def save_provider(
     }
 
 
+# ---- live tests for the capabilities that had none ---------------------------
+#
+# `test_provider` validated eight capabilities and could test three. Pressing
+# Save & Test on maps, email, text messages, encryption or photo redaction
+# returned "A live test is not available for this capability" -- a button whose
+# whole job is to tell you whether something works, telling five of eight cards
+# that it cannot.
+#
+# Two of the five turned out to be the most valuable tests on the page, because
+# they check the two things that fail without saying so: which key is actually
+# encrypting resident data, and whether the photo detector can answer at all.
+#
+# The rest need a real network call. Where one exists that does not send
+# anything to a resident, it is made. Where it does not -- a generic HTTP SMS
+# gateway cannot be exercised without sending a text -- the response says so and
+# is deliberately NOT recorded as a connector failure, because "we cannot check
+# this from here" is not the same as "this is broken", and a red badge that
+# never goes green teaches people to ignore badges.
+
+
+def _unverifiable(detail: str) -> dict:
+    """A result that is shown but not written to connector health."""
+    return {"ok": False, "detail": detail, "recorded": False}
+
+
+async def _test_maps() -> dict:
+    """Geocode a known address. Reads only, costs a fraction of a cent."""
+    import httpx
+
+    from app.services.secret_manager import get_secret
+
+    provider = (await get_secret("MAPS_PROVIDER")) or "google"
+    sample = "1600 Pennsylvania Ave NW, Washington DC"
+
+    async with httpx.AsyncClient(timeout=12.0) as client:
+        if provider == "google":
+            key = await get_secret("GOOGLE_MAPS_API_KEY")
+            if not key:
+                return {"ok": False, "detail": "No Google Maps API key is saved."}
+            r = await client.get("https://maps.googleapis.com/maps/api/geocode/json",
+                                 params={"address": sample, "key": key})
+            body = r.json()
+            status = body.get("status")
+            if status == "OK":
+                return {"ok": True, "detail": "Key accepted; a test address geocoded successfully."}
+            # Google's own words matter here: REQUEST_DENIED with "billing" is
+            # the single most common failure on this page and its remedy is
+            # nothing to do with the key.
+            return {"ok": False, "detail": f"Google returned {status}. {body.get('error_message', '')}".strip()}
+
+        if provider == "azure":
+            key = await get_secret("AZURE_MAPS_KEY")
+            if not key:
+                return {"ok": False, "detail": "No Azure Maps key is saved."}
+            r = await client.get("https://atlas.microsoft.com/search/address/json",
+                                 params={"api-version": "1.0", "subscription-key": key, "query": sample})
+            if r.status_code == 200:
+                return {"ok": True, "detail": "Key accepted; a test address geocoded successfully."}
+            return {"ok": False, "detail": f"Azure Maps returned HTTP {r.status_code}."}
+
+        if provider == "esri":
+            key = await get_secret("ARCGIS_API_KEY")
+            if not key:
+                return {"ok": False, "detail": "No ArcGIS API key is saved."}
+            locator = (await get_secret("ARCGIS_LOCATOR_URL")) or (
+                "https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer")
+            r = await client.get(f"{locator.rstrip('/')}/findAddressCandidates",
+                                 params={"SingleLine": sample, "f": "json", "token": key})
+            body = r.json() if r.status_code == 200 else {}
+            if "error" in body:
+                return {"ok": False, "detail": f"ArcGIS: {body['error'].get('message', 'rejected the key')}"}
+            if r.status_code == 200:
+                return {"ok": True, "detail": "Key accepted; the locator answered."}
+            return {"ok": False, "detail": f"ArcGIS returned HTTP {r.status_code}."}
+
+        if provider == "apple":
+            return _unverifiable(
+                "Apple Maps credentials can only be checked by signing a token in the "
+                "browser, so there is nothing to test from here. Open the resident "
+                "portal and confirm the map draws.")
+
+    return _unverifiable(f"No live test is available for {provider}.")
+
+
+async def _test_delivery(capability: str) -> dict:
+    """Email and text messages, without sending anything to a resident."""
+    import httpx
+
+    from app.services.secret_manager import get_secret
+
+    if capability == "email":
+        provider = (await get_secret("EMAIL_PROVIDER")) or "smtp"
+        if provider == "smtp":
+            import asyncio
+            import smtplib
+            host = await get_secret("SMTP_HOST")
+            user = await get_secret("SMTP_USER")
+            password = await get_secret("SMTP_PASSWORD")
+            if not host:
+                return {"ok": False, "detail": "No SMTP host is saved."}
+            port = int((await get_secret("SMTP_PORT")) or 587)
+
+            def _connect():
+                # Connect and authenticate only. Nothing is sent, so this is
+                # safe to press repeatedly.
+                if port == 465:
+                    server = smtplib.SMTP_SSL(host, port, timeout=12)
+                else:
+                    server = smtplib.SMTP(host, port, timeout=12)
+                    server.starttls()
+                with server:
+                    if user and password:
+                        server.login(user, password)
+                return True
+
+            await asyncio.get_event_loop().run_in_executor(None, _connect)
+            return {"ok": True, "detail": f"Connected to {host}:{port} and signed in. Nothing was sent."}
+
+        if provider == "ses":
+            import asyncio
+            from app.services.cloud_moderation import _aws_kwargs
+            kwargs = await _aws_kwargs()
+            if not kwargs:
+                return {"ok": False, "detail": "No AWS region or credentials are saved."}
+
+            def _quota():
+                import boto3
+                return boto3.client("ses", **kwargs).get_send_quota()
+
+            quota = await asyncio.get_event_loop().run_in_executor(None, _quota)
+            sent, cap = quota.get("SentLast24Hours", 0), quota.get("Max24HourSend", 0)
+            if cap and cap <= 200:
+                # The sandbox cap. Everything looks fine and residents receive
+                # nothing, so it is worth saying rather than passing green.
+                return {"ok": False, "detail": (
+                    f"Credentials work, but the 24-hour cap is {int(cap)} — this account is still "
+                    f"in the SES sandbox and will not deliver to unverified addresses. "
+                    f"Request production access.")}
+            return {"ok": True, "detail": f"SES reachable. {int(sent)} of {int(cap)} sent in the last 24 hours."}
+
+        return _unverifiable(
+            "Azure Communication Services has no check that avoids sending a real "
+            "message. Save, then send yourself a test from a request.")
+
+    provider = (await get_secret("SMS_PROVIDER")) or "none"
+    if provider == "none":
+        return {"ok": True, "detail": "Text messages are switched off, as configured."}
+
+    if provider == "twilio":
+        sid = await get_secret("TWILIO_ACCOUNT_SID")
+        token = await get_secret("TWILIO_AUTH_TOKEN")
+        if not (sid and token):
+            return {"ok": False, "detail": "Account SID or auth token is missing."}
+        async with httpx.AsyncClient(timeout=12.0) as client:
+            r = await client.get(f"https://api.twilio.com/2010-04-01/Accounts/{sid}.json",
+                                 auth=(sid, token))
+        if r.status_code == 200:
+            status = r.json().get("status", "active")
+            if status != "active":
+                return {"ok": False, "detail": f"Credentials work, but the Twilio account is {status}."}
+            return {"ok": True, "detail": "Twilio credentials accepted. Nothing was sent."}
+        if r.status_code == 401:
+            return {"ok": False, "detail": "Twilio rejected the Account SID or auth token."}
+        return {"ok": False, "detail": f"Twilio returned HTTP {r.status_code}."}
+
+    if provider == "sns":
+        import asyncio
+        from app.services.cloud_moderation import _aws_kwargs
+        kwargs = await _aws_kwargs()
+        if not kwargs:
+            return {"ok": False, "detail": "No AWS region or credentials are saved."}
+
+        def _attrs():
+            import boto3
+            return boto3.client("sns", **kwargs).get_sms_attributes()
+
+        await asyncio.get_event_loop().run_in_executor(None, _attrs)
+        return {"ok": True, "detail": "SNS reachable and authenticated. Nothing was sent."}
+
+    return _unverifiable(
+        f"There is no way to check {provider} without sending a real text message. "
+        f"Save, then send yourself one from a request to confirm delivery.")
+
+
 @router.post("/providers/{capability}/test")
 @_cost_limiter.limit("10/minute")  # live paid-API call — bound the cost
 async def test_provider(
@@ -546,6 +730,54 @@ async def test_provider(
                 return await _remember({"ok": False, "detail": "No identity provider is configured."})
             meta = await get_oidc_metadata(cfg)
             return await _remember({"ok": bool(meta.get("authorization_endpoint")), "detail": f"Discovered {cfg['provider']} endpoints at {cfg['issuer_base']}"})
+        if capability == "kms":
+            # The most valuable test on this page. A KMS that stops answering
+            # does not raise -- pii_crypto falls back to the application key and
+            # carries on -- so "is the key I selected the one encrypting
+            # resident data" is a question nothing else answers out loud.
+            from app.core import pii_crypto
+            from app.core.encryption import _kms_provider
+            selected = _kms_provider()
+            actual = pii_crypto.probe_backend()
+            if actual == selected:
+                label = {"google": "Google Cloud KMS", "azure": "Azure Key Vault",
+                         "aws": "AWS KMS", "local": "the application key"}.get(actual, actual)
+                return await _remember({"ok": True, "detail": f"Wrapped a test key with {label}."})
+            return await _remember({
+                "ok": False,
+                "detail": (
+                    f"Selected {selected}, but a test key was wrapped with "
+                    f"{actual}. Resident data is not being encrypted with the key "
+                    f"you chose — check the credentials and that the key still exists."
+                ),
+            })
+
+        if capability == "redaction":
+            # Also worth a real test: a detector with no credentials returns the
+            # same empty result as a photo with nobody in it.
+            from app.services.image_redaction import effective_provider, resolve_provider
+            selected = await resolve_provider()
+            if not selected:
+                return await _remember({"ok": True, "detail": "Photo redaction is switched off, as configured."})
+            actual, degraded_from = await effective_provider(selected)
+            if degraded_from == actual:
+                return await _remember({"ok": False, "detail": (
+                    "No detector is available, so photos would be stored without blurring. "
+                    "On-server detection needs no account — this usually means OpenCV is missing.")})
+            if degraded_from:
+                return await _remember({"ok": False, "detail": (
+                    f"{degraded_from} has no usable credentials, so blurring is falling back to "
+                    f"on-server detection. Photos are still redacted, less accurately.")})
+            return await _remember({"ok": True, "detail": f"{actual} is available and will blur faces and plates."})
+
+        if capability == "maps":
+            outcome = await _test_maps()
+            return await _remember(outcome) if outcome.get("recorded", True) else outcome
+
+        if capability in ("email", "sms"):
+            outcome = await _test_delivery(capability)
+            return await _remember(outcome) if outcome.get("recorded", True) else outcome
+
         raise HTTPException(status_code=400, detail="A live test is not available for this capability.")
     except HTTPException:
         raise

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Request, Query
+from fastapi import (APIRouter, BackgroundTasks, Depends, HTTPException, status, UploadFile,
+                     File, Request, Query)
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_
 from typing import Any, List, Optional, Dict
@@ -391,6 +392,7 @@ def _capability_catalog(capability: str) -> Dict:
 async def save_provider(
     capability: str,
     body: ProviderSaveRequest,
+    background: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     _: User = Depends(get_current_admin),
 ):
@@ -454,12 +456,20 @@ async def save_provider(
             "key": db_only[0],
             "severity": "info",
             "message": (
-                f"Saved, but stored in the encrypted database rather than "
+                f"Saved and encrypted in the database. "
                 f"{ {'azure': 'Azure Key Vault', 'aws': 'AWS Secrets Manager'}.get(_secrets_provider(), 'Google Secret Manager') }"
-                " — it is not reachable yet. Finish the cloud credentials above, then press"
-                " Save & Test here again to move them across."
+                " is not reachable yet — once you finish the cloud credentials above,"
+                " this moves across on its own. Nothing further to do here."
             ),
         })
+    else:
+        # The store took everything, which means it is reachable -- and this may
+        # be the moment it became reachable, if what was just saved were the
+        # cloud credentials themselves. Sweep anything entered earlier across
+        # now rather than leaving it for the hourly pass. Scheduled after the
+        # response so a slow store cannot make Save feel broken.
+        from app.services.storage_maintenance import vault_secrets as _vault
+        background.add_task(_vault)
     return {
         "ok": True,
         "provider": provider_id,

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -497,6 +497,95 @@ async def save_provider(
 # never goes green teaches people to ignore badges.
 
 
+async def _test_ai(db) -> dict:
+    from app.services.ai import get_ai_provider
+    provider = await get_ai_provider(db)
+    if not provider:
+        return {"ok": False, "detail": "No AI provider is configured. Enter the required fields and save first."}
+    result = await provider.complete_json('Reply with {"priority_score": 5}. This is a connection test.')
+    # Reachability and auth, not whether a trivial prompt produced parseable
+    # JSON. Providers set `_reachable` when the API answered at all.
+    reachable = isinstance(result, dict) and ("_error" not in result or bool(result.get("_reachable")))
+    if reachable:
+        return {"ok": True, "detail": f"{provider.provider}/{provider.model} reachable and authenticated"}
+    return {"ok": False, "detail": f"Call failed: {result.get('_error', 'unknown')[:200]}"}
+
+
+async def _test_translation(db) -> dict:
+    from app.services.translation_providers import get_translation_provider
+    provider = await get_translation_provider()
+    if not provider:
+        return {"ok": False, "detail": "No translation provider is configured."}
+    out = await provider.translate(["hello"], "en", "es")
+    return {"ok": bool(out), "detail": f"Translated sample → {out[0]}" if out else "No translation returned"}
+
+
+async def _test_identity(db) -> dict:
+    from app.services.identity import resolve_identity_config, get_oidc_metadata
+    cfg = await resolve_identity_config(db)
+    if not cfg:
+        return {"ok": False, "detail": "No identity provider is configured."}
+    meta = await get_oidc_metadata(cfg)
+    return {"ok": bool(meta.get("authorization_endpoint")),
+            "detail": f"Discovered {cfg['provider']} endpoints at {cfg['issuer_base']}"}
+
+
+async def _test_kms(db=None) -> dict:
+    """Wrap a throwaway key and see which service actually did it.
+
+    The most valuable check on the page. A KMS that stops answering does not
+    raise -- pii_crypto falls back to the application key and carries on -- so
+    "is the key I selected the one encrypting resident data" is a question
+    nothing else asks out loud. `probe_backend` rather than `active_backend`,
+    because the latter reads the data key this process cached at startup and
+    would answer for the world as it was then.
+    """
+    from app.core import pii_crypto
+    from app.core.encryption import _kms_provider
+
+    selected = _kms_provider()
+    actual = pii_crypto.probe_backend()
+    if actual == selected:
+        label = {"google": "Google Cloud KMS", "azure": "Azure Key Vault",
+                 "aws": "AWS KMS", "local": "the application key"}.get(actual, actual)
+        return {"ok": True, "detail": f"Wrapped a test key with {label}."}
+    return {"ok": False, "detail": (
+        f"Selected {selected}, but a test key was wrapped with {actual}. Resident "
+        f"data is not being encrypted with the key you chose — check the "
+        f"credentials and that the key still exists.")}
+
+
+async def _test_redaction(db=None) -> dict:
+    """Can the chosen detector answer, and is it the chosen one?
+
+    A detector with no credentials returns the same empty result as a photo
+    with nobody in it, so this is the only place the difference is visible.
+    """
+    from app.services.image_redaction import effective_provider, resolve_provider
+
+    selected = await resolve_provider()
+    if not selected:
+        return {"ok": True, "detail": "Photo redaction is switched off, as configured."}
+    actual, degraded_from = await effective_provider(selected)
+    if degraded_from == actual:
+        return {"ok": False, "detail": (
+            "No detector is available, so photos would be stored without blurring. "
+            "On-server detection needs no account — this usually means OpenCV is missing.")}
+    if degraded_from:
+        return {"ok": False, "detail": (
+            f"{degraded_from} has no usable credentials, so blurring is falling back to "
+            f"on-server detection. Photos are still redacted, less accurately.")}
+    return {"ok": True, "detail": f"{actual} is available and will blur faces and plates."}
+
+
+async def _test_email(db=None) -> dict:
+    return await _test_delivery("email")
+
+
+async def _test_sms(db=None) -> dict:
+    return await _test_delivery("sms")
+
+
 def _unverifiable(detail: str) -> dict:
     """A result that is shown but not written to connector health."""
     return {"ok": False, "detail": detail, "recorded": False}
@@ -661,6 +750,23 @@ async def _test_delivery(capability: str) -> dict:
         f"Save, then send yourself one from a request to confirm delivery.")
 
 
+# One table, so the set of capabilities the endpoint accepts and the set it can
+# actually test cannot drift apart. They did: the accept-list was widened when
+# maps, email, SMS, encryption and redaction got catalogs, and five of eight
+# cards then answered "a live test is not available for this capability" -- a
+# button whose whole job is to say whether something works, saying it could not.
+_CAPABILITY_TESTS = {
+    "ai": _test_ai,
+    "translation": _test_translation,
+    "identity": _test_identity,
+    "maps": lambda db=None: _test_maps(),
+    "email": _test_email,
+    "sms": _test_sms,
+    "kms": _test_kms,
+    "redaction": _test_redaction,
+}
+
+
 @router.post("/providers/{capability}/test")
 @_cost_limiter.limit("10/minute")  # live paid-API call — bound the cost
 async def test_provider(
@@ -702,83 +808,19 @@ async def test_provider(
             pass
         return outcome
 
-    try:
-        if capability == "ai":
-            from app.services.ai import get_ai_provider
-            provider = await get_ai_provider(db)
-            if not provider:
-                return await _remember({"ok": False, "detail": "No AI provider is configured. Enter the required fields and save first."})
-            result = await provider.complete_json('Reply with {"priority_score": 5}. This is a connection test.')
-            # A connection test verifies reachability + auth, not that the model
-            # emits parseable JSON. Providers flag `_reachable` when the API
-            # responded (200) even if a trivial prompt yielded no usable output.
-            reachable = isinstance(result, dict) and ("_error" not in result or bool(result.get("_reachable")))
-            if reachable:
-                return await _remember({"ok": True, "detail": f"{provider.provider}/{provider.model} reachable and authenticated"})
-            return await _remember({"ok": False, "detail": f"Call failed: {result.get('_error', 'unknown')[:200]}"})
-        if capability == "translation":
-            from app.services.translation_providers import get_translation_provider
-            provider = await get_translation_provider()
-            if not provider:
-                return await _remember({"ok": False, "detail": "No translation provider is configured."})
-            out = await provider.translate(["hello"], "en", "es")
-            return await _remember({"ok": bool(out), "detail": f"Translated sample → {out[0]}" if out else "No translation returned"})
-        if capability == "identity":
-            from app.services.identity import resolve_identity_config, get_oidc_metadata
-            cfg = await resolve_identity_config(db)
-            if not cfg:
-                return await _remember({"ok": False, "detail": "No identity provider is configured."})
-            meta = await get_oidc_metadata(cfg)
-            return await _remember({"ok": bool(meta.get("authorization_endpoint")), "detail": f"Discovered {cfg['provider']} endpoints at {cfg['issuer_base']}"})
-        if capability == "kms":
-            # The most valuable test on this page. A KMS that stops answering
-            # does not raise -- pii_crypto falls back to the application key and
-            # carries on -- so "is the key I selected the one encrypting
-            # resident data" is a question nothing else answers out loud.
-            from app.core import pii_crypto
-            from app.core.encryption import _kms_provider
-            selected = _kms_provider()
-            actual = pii_crypto.probe_backend()
-            if actual == selected:
-                label = {"google": "Google Cloud KMS", "azure": "Azure Key Vault",
-                         "aws": "AWS KMS", "local": "the application key"}.get(actual, actual)
-                return await _remember({"ok": True, "detail": f"Wrapped a test key with {label}."})
-            return await _remember({
-                "ok": False,
-                "detail": (
-                    f"Selected {selected}, but a test key was wrapped with "
-                    f"{actual}. Resident data is not being encrypted with the key "
-                    f"you chose — check the credentials and that the key still exists."
-                ),
-            })
-
-        if capability == "redaction":
-            # Also worth a real test: a detector with no credentials returns the
-            # same empty result as a photo with nobody in it.
-            from app.services.image_redaction import effective_provider, resolve_provider
-            selected = await resolve_provider()
-            if not selected:
-                return await _remember({"ok": True, "detail": "Photo redaction is switched off, as configured."})
-            actual, degraded_from = await effective_provider(selected)
-            if degraded_from == actual:
-                return await _remember({"ok": False, "detail": (
-                    "No detector is available, so photos would be stored without blurring. "
-                    "On-server detection needs no account — this usually means OpenCV is missing.")})
-            if degraded_from:
-                return await _remember({"ok": False, "detail": (
-                    f"{degraded_from} has no usable credentials, so blurring is falling back to "
-                    f"on-server detection. Photos are still redacted, less accurately.")})
-            return await _remember({"ok": True, "detail": f"{actual} is available and will blur faces and plates."})
-
-        if capability == "maps":
-            outcome = await _test_maps()
-            return await _remember(outcome) if outcome.get("recorded", True) else outcome
-
-        if capability in ("email", "sms"):
-            outcome = await _test_delivery(capability)
-            return await _remember(outcome) if outcome.get("recorded", True) else outcome
-
+    check = _CAPABILITY_TESTS.get(capability)
+    if check is None:
+        # Cannot happen while the accept-list is derived from this table, and
+        # a test asserts that it is. Kept as a real branch rather than an
+        # assertion because a 400 is a better failure than a 500.
         raise HTTPException(status_code=400, detail="A live test is not available for this capability.")
+
+    try:
+        outcome = await check(db)
+        # An outcome we could not verify is shown but not written to connector
+        # health: "we cannot check this from here" is not "this is broken", and
+        # a red badge that can never go green teaches people to ignore badges.
+        return outcome if outcome.get("recorded") is False else await _remember(outcome)
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -321,17 +321,31 @@ _PROVIDER_SELECT_KEY = {
 }
 
 
-async def _persist_secret(db: AsyncSession, key_name: str, value: str):
-    """Write a secret to the configured store (Secret Manager / Key Vault when
-    available) and always keep an encrypted DB copy — same path as /secrets."""
+async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
+    """Write a secret to the configured store and keep an encrypted DB copy.
+
+    Returns whether the external store took it. That return value matters: when
+    the store is not reachable yet, set_secret returns False and logs at DEBUG,
+    which nothing raises the level for -- so the secret quietly lived only in
+    the database and the town had no way to know. It is a real ordering trap,
+    because the credentials that make Secret Manager reachable are themselves
+    entered on this page: anything saved before them lands in the database and
+    stays there until somebody happens to run the migration.
+
+    The caller surfaces this rather than swallowing it.
+    """
     from app.core.encryption import encrypt
     from app.core.managed import reject_platform_key_writes
     from app.services.secret_manager import set_secret, clear_cache
     reject_platform_key_writes(key_name)
+    # These two are deliberately database-only: they are what makes the secret
+    # store reachable in the first place, so storing them in it is circular.
     bootstrap_keys = {"GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT"}
+    stored_externally = key_name in bootstrap_keys
     if value and key_name not in bootstrap_keys:
         try:
             if await set_secret(key_name, value):
+                stored_externally = True
                 clear_cache()
         except Exception as e:
             from app.core.sanitize import sanitize_for_log
@@ -345,6 +359,7 @@ async def _persist_secret(db: AsyncSession, key_name: str, value: str):
     else:
         db.add(SystemSecret(key_name=key_name, key_value=enc, is_configured=bool(value)))
     await db.commit()
+    return stored_externally
 
 
 class ProviderSaveRequest(BaseModel):
@@ -414,9 +429,16 @@ async def save_provider(
     await _persist_secret(db, _PROVIDER_SELECT_KEY[capability], provider_id)
     if capability == "ai" and body.model:
         await _persist_secret(db, "AI_MODEL", body.model)
+    # Track where each credential actually landed. A False here is not an
+    # error -- the encrypted database is a supported store -- but it is
+    # something the town has to be told, because the usual cause is saving
+    # this card before the credentials that make the secret store reachable,
+    # and the fix (enter those, then re-save) is only obvious if you know.
+    db_only: List[str] = []
     for key, value in (body.settings or {}).items():
         if value:  # blank = keep existing
-            await _persist_secret(db, key, value)
+            if not await _persist_secret(db, key, value):
+                db_only.append(key)
     from app.services.secret_manager import clear_cache
     clear_cache()
     # Shape findings are advisory and never block: a rule is a heuristic about
@@ -425,10 +447,23 @@ async def save_provider(
     # discoverable, the first is a dead end.
     from app.services.credential_checks import inspect_settings
     findings = inspect_settings(body.settings)
+    warnings = [{"key": f.key, "severity": f.severity, "message": f.message} for f in findings]
+    if db_only:
+        from app.services.secret_manager import _secrets_provider
+        warnings.append({
+            "key": db_only[0],
+            "severity": "info",
+            "message": (
+                f"Saved, but stored in the encrypted database rather than "
+                f"{ {'azure': 'Azure Key Vault', 'aws': 'AWS Secrets Manager'}.get(_secrets_provider(), 'Google Secret Manager') }"
+                " — it is not reachable yet. Finish the cloud credentials above, then press"
+                " Save & Test here again to move them across."
+            ),
+        })
     return {
         "ok": True,
         "provider": provider_id,
-        "warnings": [{"key": f.key, "severity": f.severity, "message": f.message} for f in findings],
+        "warnings": warnings,
     }
 
 

--- a/backend/app/core/azure_keyvault.py
+++ b/backend/app/core/azure_keyvault.py
@@ -47,8 +47,60 @@ def _b64url_decode(s: str) -> bytes:
 
 
 def is_configured() -> bool:
+    """A vault URL, plus some way to prove who we are.
+
+    The second half used to require a client secret. On an Azure VM, App Service
+    or Container App there is a managed identity attached to the compute, and
+    using it is both less work -- nothing to enter -- and better: the token is
+    issued minutes at a time and rotated by the platform, so no long-lived
+    secret exists to leak, and none expires on a date nobody wrote down.
+    Requiring a client secret meant a town on Azure had to create the worst
+    credential of the three clouds while the platform was already offering it
+    the best one.
+    """
+    if not _cfg("AZURE_KEYVAULT_URL"):
+        return False
+    if _managed_identity_endpoint():
+        return True
     return bool(_cfg("AZURE_TENANT_ID") and _cfg("AZURE_KEYVAULT_CLIENT_ID")
-                and _cfg("AZURE_KEYVAULT_CLIENT_SECRET") and _cfg("AZURE_KEYVAULT_URL"))
+                and _cfg("AZURE_KEYVAULT_CLIENT_SECRET"))
+
+
+def _managed_identity_endpoint() -> Optional[str]:
+    """Where to ask for a token, if this host has an identity of its own.
+
+    App Service and Container Apps inject IDENTITY_ENDPOINT with a matching
+    header secret; VMs and scale sets use the link-local IMDS address. Both are
+    reachable only from inside Azure, so their presence is the detection.
+    """
+    return os.getenv("IDENTITY_ENDPOINT") or os.getenv("MSI_ENDPOINT")
+
+
+def _managed_identity_token(scope: str):
+    """(token, ttl_seconds) from the attached identity, or None."""
+    endpoint = _managed_identity_endpoint()
+    header_secret = os.getenv("IDENTITY_HEADER") or os.getenv("MSI_SECRET")
+    try:
+        if endpoint:
+            resp = httpx.get(
+                endpoint,
+                params={"api-version": "2019-08-01", "resource": scope},
+                headers={"X-IDENTITY-HEADER": header_secret} if header_secret else {},
+                timeout=15.0,
+            )
+        else:
+            resp = httpx.get(
+                "http://169.254.169.254/metadata/identity/oauth2/token",
+                params={"api-version": "2018-02-01", "resource": scope},
+                headers={"Metadata": "true"},
+                timeout=15.0,
+            )
+        resp.raise_for_status()
+        body = resp.json()
+        return body["access_token"], int(body.get("expires_in", 3600))
+    except Exception as e:
+        logger.debug(f"Managed identity token request failed: {e}")
+        return None
 
 
 def _get_token() -> Optional[str]:
@@ -57,6 +109,21 @@ def _get_token() -> Optional[str]:
     client_secret = _cfg("AZURE_KEYVAULT_CLIENT_SECRET")
     authority = _cfg("AZURE_AUTHORITY") or "login.microsoftonline.com"
     scope = _cfg("AZURE_KEYVAULT_SCOPE") or "https://vault.azure.net"
+
+    # The attached identity wins when there is one, rather than serving as a
+    # fallback. A town with both keeps working after the client secret expires,
+    # which is the failure this is most useful against.
+    if _managed_identity_endpoint():
+        cache_key = ("managed", scope)
+        cached = _token_cache.get(cache_key)
+        if cached and cached[1] - 60 > time.time():
+            return cached[0]
+        result = _managed_identity_token(scope)
+        if result:
+            token, ttl = result
+            _token_cache[cache_key] = (token, time.time() + ttl)
+            return token
+
     if not all([tenant, client_id, client_secret]):
         return None
 

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -7,7 +7,8 @@ celery_app = Celery(
     "township_311",
     broker=settings.redis_url,
     backend=settings.redis_url,
-    include=["app.tasks.service_requests", "app.tasks.integrations", "app.tasks.road_data"]
+    include=["app.tasks.service_requests", "app.tasks.integrations", "app.tasks.road_data",
+             "app.tasks.storage"]
 )
 
 celery_app.conf.update(
@@ -91,6 +92,19 @@ celery_app.conf.update(
         "weekly-staff-digest": {
             "task": "app.tasks.service_requests.send_weekly_digest",
             "schedule": 60 * 60 * 24 * 7,  # Every 7 days
+            "options": {"queue": "default"}
+        },
+        # Storage hygiene that used to be two buttons on the setup page. Both
+        # verify before they change anything and are no-ops with nothing to do,
+        # so nobody has to work out whether they apply.
+        "hourly-secret-vaulting": {
+            "task": "app.tasks.storage.vault_secrets",
+            "schedule": 60 * 60,  # Every hour
+            "options": {"queue": "default"}
+        },
+        "nightly-pii-rewrap": {
+            "task": "app.tasks.storage.rewrap_pii",
+            "schedule": 60 * 60 * 24,  # Every 24 hours
             "options": {"queue": "default"}
         },
         # Refresh the live AI model lists so the picker stays current and can

--- a/backend/app/core/managed.py
+++ b/backend/app/core/managed.py
@@ -13,20 +13,37 @@ from app.core.config import get_settings
 # The state owns infrastructure keys (injected by the orchestrator); the town
 # owns provider/integration/branding keys. Must stay in sync with the
 # orchestrator's secrets_policy module in the centralizedhosting repo.
-PLATFORM_MANAGED_KEYS = {
+#
+# Written out by hand originally, and Google-shaped as a result: it named the
+# GCP project, service account and KMS key path, and of Azure only the vault
+# URL. Every AWS infrastructure key was absent, as were Azure's credentials and
+# both provider selectors. On a state-hosted deployment running on AWS or Azure,
+# a town admin could therefore overwrite AWS_KMS_KEY_ID, KMS_PROVIDER or
+# SECRETS_PROVIDER and repoint the state's encryption and secret storage at
+# something of their own. That is a privilege boundary, not a preference.
+#
+# So the infrastructure half is no longer hand-listed. DB_REQUIRED_KEYS is
+# already the authoritative set of "credentials for the secret store, plus the
+# KMS selection and key path", derived from the readers and pinned by
+# test_secret_migration_safety. Anything that belongs to the platform's storage
+# arrangement belongs to the platform in managed mode, and the two cannot drift
+# apart again.
+# Set at import. secret_manager imports nothing from app at module level, so
+# there is no cycle -- and a plain frozenset is worth more than cleverness here:
+# an earlier draft used a lazily-resolving frozenset subclass, which answered
+# `in` correctly and returned empty for `set()` and iteration, because CPython
+# reads the underlying storage directly for those. A guard that is right only
+# for the operation you happened to test is worse than no guard.
+from app.services.secret_manager import DB_REQUIRED_KEYS
+
+PLATFORM_MANAGED_KEYS = frozenset({
     "SECRET_KEY",
     "DATABASE_URL",
     "DB_PASSWORD",
     "REDIS_URL",
     "PROVISIONING_TOKEN",
-    "GOOGLE_CLOUD_PROJECT",
-    "GCP_SERVICE_ACCOUNT_JSON",
-    "KMS_KEY_RING",
-    "KMS_KEY_ID",
-    "KMS_LOCATION",
-    "AZURE_KEYVAULT_URL",
     "DOMAIN",
-}
+}) | frozenset(DB_REQUIRED_KEYS)
 
 PLATFORM_MANAGED_PREFIXES = ("BACKUP_",)
 

--- a/backend/app/core/pii_crypto.py
+++ b/backend/app/core/pii_crypto.py
@@ -258,6 +258,35 @@ def active_backend() -> str:
     return {_WRAP_GOOGLE: "google", _WRAP_AZURE: "azure", _WRAP_AWS: "aws", _WRAP_LOCAL: "local"}.get(tag, "unknown")
 
 
+def probe_backend() -> str:
+    """Which key manager would wrap a data key *right now*.
+
+    `active_backend()` reports the data key this process cached at startup, so
+    in a worker that has been up for a week it describes the world as of a week
+    ago. That is the right answer for "what is in use" and the wrong one for "is
+    the key still working" -- and the difference is the whole deletion window,
+    the only stretch in which the answer can still change the outcome.
+
+    This wraps a throwaway key instead, discards it, and reports the tag. One
+    real call to the key service, and it deliberately does not touch `_active`
+    or either cache: a probe must not change what it is probing.
+
+    Returns "unknown" if the wrap fails outright -- which is itself a positive
+    finding, since a KMS in that state is not encrypting anything.
+    """
+    try:
+        dek = AESGCM.generate_key(bit_length=256)
+        tag = _wrap_dek(dek)[:1]
+        return {_WRAP_GOOGLE: "google", _WRAP_AZURE: "azure",
+                _WRAP_AWS: "aws", _WRAP_LOCAL: "local"}.get(tag, "unknown")
+    except Exception:
+        # REQUIRE_KMS raises here rather than falling back, which is the point
+        # of that setting. Either way the honest answer is that the configured
+        # key is not usable.
+        logger.debug("KMS probe failed", exc_info=True)
+        return "unknown"
+
+
 def clear_caches() -> None:
     """Drop the active DEK and all caches — call after rotating the KMS key so
     new writes re-wrap and reads re-unwrap against the current key."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -184,7 +184,7 @@ async def lifespan(app: FastAPI):
     import asyncio
     from app.db.session import SessionLocal
     from app.api.health import (
-        check_database, check_auth0, check_google_kms,
+        check_database, check_auth0, check_kms,
         check_secret_manager, check_vertex_ai, check_translation_api,
         record_uptime_check
     )
@@ -199,8 +199,13 @@ async def lifespan(app: FastAPI):
                     services_to_check = [
                         ("database", check_database),
                         ("auth0", check_auth0),
-                        ("google_kms", check_google_kms),
-                        ("secret_manager", check_secret_manager),
+                        # Renamed from "google_kms": key management is
+                        # pluggable, and the old name asserted a vendor. The
+                        # uptime series restarts under the new name; these are
+                        # five-minute samples for a recent-availability figure,
+                        # not a long-term record.
+                        ("kms", check_kms),
+                        ("secret_store", check_secret_manager),
                         ("vertex_ai", check_vertex_ai),
                         ("translation_api", check_translation_api),
                     ]

--- a/backend/app/services/cloud_identity.py
+++ b/backend/app/services/cloud_identity.py
@@ -1,0 +1,164 @@
+"""Whether this server already has an identity on the cloud it is using.
+
+The largest part of setup, by a wide margin, is credentials. A town on Google
+pastes a service-account JSON file; on AWS an access key and secret; on Azure a
+tenant id, a client id and a client secret. Those are the values a clerk is most
+likely to mis-copy, they are the ones that have to be vaulted afterwards, and
+the Azure one expires on a date nobody records.
+
+None of them is necessary when the application runs on the cloud it is talking
+to. Every provider attaches an identity to the compute itself -- a service
+account on GCE/Cloud Run/GKE, an instance role on EC2/ECS, a managed identity on
+an Azure VM or App Service -- and the SDKs pick it up from a metadata endpoint
+with nothing configured. The credential is issued minutes at a time and rotated
+by the platform.
+
+So this is not a shortcut with a security cost. It is the arrangement a
+government security review asks for -- no long-lived credential exists to be
+leaked, mailed, committed, or left behind by a departing employee -- and it
+happens to be the one where a clerk types nothing at all.
+
+Two of the three already worked here by accident: boto3 falls through to the
+instance role when no access key is set, and google-auth falls through to
+Application Default Credentials. Nothing said so, so nobody knew to leave the
+boxes empty. This module detects the situation and lets the page say it.
+
+Detection is a metadata probe with a short timeout, cached: the endpoints are
+link-local addresses that either answer immediately or are not there at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# The probes hit link-local addresses that are either present or absent, so a
+# slow answer means "not here" rather than "wait longer".
+_PROBE_TIMEOUT = 1.5
+
+# Detection is stable for the lifetime of a deployment -- compute does not
+# acquire an attached identity halfway through an afternoon -- but not cached
+# forever, so an operator who attaches one does not have to restart.
+_CACHE_TTL = 300
+_cache: Dict[str, Any] = {"at": 0.0, "value": None}
+
+
+def _google() -> Optional[Dict[str, str]]:
+    """GCE, Cloud Run, GKE and App Engine all expose the same metadata server."""
+    import httpx
+
+    try:
+        resp = httpx.get(
+            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email",
+            headers={"Metadata-Flavor": "Google"},
+            timeout=_PROBE_TIMEOUT,
+        )
+        if resp.status_code == 200 and "@" in resp.text:
+            return {"provider": "google", "identity": resp.text.strip()}
+    except Exception:
+        pass
+    return None
+
+
+def _aws() -> Optional[Dict[str, str]]:
+    """EC2 and ECS differ: ECS injects a URI into the environment, EC2 uses the
+    link-local address and, under IMDSv2, requires a token first."""
+    import httpx
+
+    relative = os.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    if relative:
+        return {"provider": "aws", "identity": "task role"}
+
+    try:
+        token = httpx.put(
+            "http://169.254.169.254/latest/api/token",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "60"},
+            timeout=_PROBE_TIMEOUT,
+        )
+        headers = {"X-aws-ec2-metadata-token": token.text} if token.status_code == 200 else {}
+        resp = httpx.get(
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+            headers=headers,
+            timeout=_PROBE_TIMEOUT,
+        )
+        if resp.status_code == 200 and resp.text.strip():
+            return {"provider": "aws", "identity": resp.text.strip().splitlines()[0]}
+    except Exception:
+        pass
+    return None
+
+
+def _azure() -> Optional[Dict[str, str]]:
+    """App Service and Container Apps set IDENTITY_ENDPOINT; VMs and VM scale
+    sets use the same link-local address as AWS on a different path."""
+    import httpx
+
+    endpoint = os.getenv("IDENTITY_ENDPOINT") or os.getenv("MSI_ENDPOINT")
+    if endpoint:
+        return {"provider": "azure", "identity": "managed identity"}
+
+    try:
+        resp = httpx.get(
+            "http://169.254.169.254/metadata/instance",
+            params={"api-version": "2021-02-01"},
+            headers={"Metadata": "true"},
+            timeout=_PROBE_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            return {"provider": "azure", "identity": "managed identity"}
+    except Exception:
+        pass
+    return None
+
+
+def detect(force: bool = False) -> Optional[Dict[str, str]]:
+    """The attached identity, or None if this server has none.
+
+    Never raises: it drives an advisory panel and a set of "you can leave this
+    empty" hints, and a failed probe should read as "no identity" rather than
+    breaking the page.
+    """
+    now = time.time()
+    if not force and _cache["value"] is not None and now - _cache["at"] < _CACHE_TTL:
+        return _cache["value"] or None
+
+    found = None
+    try:
+        # Ordered by how cheaply each fails. Google's hostname does not resolve
+        # off GCP; the other two share a link-local address, so probing Azure's
+        # path on EC2 returns 404 rather than hanging.
+        found = _google() or _azure() or _aws()
+    except Exception as exc:
+        logger.debug("cloud identity probe failed: %s", exc)
+
+    _cache.update({"at": now, "value": found or {}})
+    return found
+
+
+def summary() -> Dict[str, Any]:
+    """What the setup page needs to decide whether to ask for credentials."""
+    identity = detect()
+    if not identity:
+        return {"attached": False, "provider": None, "identity": None, "skippable_keys": []}
+    return {
+        "attached": True,
+        "provider": identity["provider"],
+        "identity": identity["identity"],
+        # The page greys these out and says why, rather than leaving a clerk to
+        # guess whether an empty box is an oversight.
+        "skippable_keys": SKIPPABLE.get(identity["provider"], []),
+    }
+
+
+# Credentials the attached identity replaces. Everything else on a card -- key
+# names, regions, endpoints -- still has to be entered, because those identify
+# *which* resource to use rather than proving who is asking.
+SKIPPABLE = {
+    "google": ["GCP_SERVICE_ACCOUNT_JSON", "VERTEX_AI_SERVICE_ACCOUNT_KEY"],
+    "aws": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"],
+    "azure": ["AZURE_KEYVAULT_CLIENT_SECRET", "AZURE_KEYVAULT_CLIENT_ID", "AZURE_TENANT_ID"],
+}

--- a/backend/app/services/delivery_providers.py
+++ b/backend/app/services/delivery_providers.py
@@ -234,9 +234,31 @@ REDACTION_CATALOG: Dict[str, Dict[str, Any]] = {
     },
     "azure": {
         "name": "Azure AI Vision",
-        "description": "Microsoft's detector, using your Azure credentials.",
+        # Google and AWS reuse credentials entered elsewhere -- vision_annotate
+        # takes the GCP service account, _aws_kwargs takes the AWS keys. Azure
+        # does not: `_azure_face_creds` and `_azure_vision_creds` read four keys
+        # of their own, because Face and Vision are separate resources with
+        # separate endpoints and separate keys.
+        #
+        # Those four were read by the dispatch code and offered by no card, so
+        # selecting Azure here stored a provider choice, reported success, and
+        # then found no credentials and blurred nothing -- with no error and
+        # nowhere on the page to fix it.
+        "description": (
+            "Microsoft's detector. Needs two Azure resources of its own — AI Face for faces and "
+            "AI Vision for plates — which are not the same endpoint and not the same key."
+        ),
         "boundary": "Azure — Government available",
-        "credential_fields": list(_REDACTION_TOGGLES),
+        "credential_fields": list(_REDACTION_TOGGLES) + [
+            {"key": "AZURE_FACE_ENDPOINT", "label": "Face endpoint", "required": False},
+            {"key": "AZURE_FACE_KEY", "label": "Face key", "required": False, "secret": True},
+            {"key": "AZURE_VISION_ENDPOINT", "label": "Vision endpoint", "required": False},
+            {"key": "AZURE_VISION_KEY", "label": "Vision key", "required": False, "secret": True},
+        ],
+        "field_help": {
+            "AZURE_FACE_ENDPOINT": "Only needed if you are blurring faces. Microsoft gates the Face API behind a Limited Access review — detection is the least restricted operation, but the subscription still has to be approved before it will serve traffic.",
+            "AZURE_VISION_ENDPOINT": "Only needed if you are blurring plates. Plates are found by reading text in the photo.",
+        },
     },
     "local": {
         "name": "On this server (no cloud)",

--- a/backend/app/services/delivery_providers.py
+++ b/backend/app/services/delivery_providers.py
@@ -209,7 +209,12 @@ KMS_CATALOG: Dict[str, Dict[str, Any]] = {
 # endpoint writes and what image_redaction._flag parses ("1/true/yes/on/enabled").
 
 REDACTION_PROVIDER_KEY = "REDACTION_PROVIDER"
-DEFAULT_REDACTION_PROVIDER = "google"
+# Local, so the card names the detector that is actually running. It was
+# "google", which meant a fresh install displayed Google Cloud Vision while
+# resolve_provider() -- finding no Google credentials and no other signal --
+# returned None and blurred nothing. The page and the behaviour disagreed, and
+# the page was the reassuring one.
+DEFAULT_REDACTION_PROVIDER = "local"
 
 _REDACTION_TOGGLES = [
     {"key": "REDACT_FACES", "label": "Blur faces (true/false)", "required": False},

--- a/backend/app/services/image_redaction.py
+++ b/backend/app/services/image_redaction.py
@@ -1000,19 +1000,96 @@ async def _local_detect(raw: bytes, width: int, height: int,
 
 
 # --------------------------------------------------------------------------
-# entry points
+# is the chosen detector actually able to answer?
 # --------------------------------------------------------------------------
+#
+# Every cloud detector returns an empty result when it has no credentials, and
+# an empty result is also what a photo of an empty street returns. Callers
+# cannot tell them apart -- `vision_annotate` says so in its own docstring:
+# "Returns {} when Google is not configured, so callers can treat 'no
+# credentials' the same as 'nothing detected'."
+#
+# For content moderation that conflation is tolerable. For redaction it is the
+# difference between a photo with nobody in it and a photo of somebody's face
+# published on a municipal website. `redact_image` already named this in its
+# docstring -- "a town whose Vision credentials quietly expired will publish
+# unblurred faces and only find out from the admin console" -- and concluded the
+# honest fix was to surface it loudly.
+#
+# There is a better answer than surfacing it, which that note did not consider:
+# fall back to the detector that needs no credentials. Local detection finds
+# less than the cloud, but it runs anywhere with nothing configured, so the
+# choice is no longer between publishing an unblurred face and refusing the
+# resident's report. Degrade, blur what we can, and say so.
+
+
+async def _usable(provider: str) -> bool:
+    """Whether this detector has what it needs to answer. Never raises."""
+    try:
+        if provider == "local":
+            import cv2  # noqa: F401
+            return True
+        if provider == "google":
+            from app.services.cloud_moderation import _google_token_and_project
+            token, _ = await _google_token_and_project()
+            return bool(token)
+        if provider == "aws":
+            from app.services.cloud_moderation import _aws_kwargs
+            return bool(await _aws_kwargs())
+        if provider == "azure":
+            face_endpoint, face_key = await _azure_face_creds()
+            vision_endpoint, vision_key = await _azure_vision_creds()
+            # Either half is enough to be worth calling: Face covers faces,
+            # Vision covers plates, and a town may deliberately have only one
+            # because Face is behind Microsoft's Limited Access review.
+            return bool((face_endpoint and face_key) or (vision_endpoint and vision_key))
+    except Exception as exc:
+        from app.core.sanitize import sanitize_for_log
+        logger.info("[Redaction] could not check %s credentials: %s",
+                    provider, sanitize_for_log(str(exc)))
+    return False
+
+
+async def effective_provider(provider: str) -> Tuple[str, Optional[str]]:
+    """(detector to actually use, the one it replaced or None).
+
+    A cloud detector that cannot answer becomes local rather than nothing. The
+    second element is what the caller records and what the health check reports,
+    because a town that selected Azure and is silently running on OpenCV needs
+    to be told -- it is getting worse detection than it thinks it paid for.
+    """
+    if await _usable(provider):
+        return provider, None
+    if provider != "local" and await _usable("local"):
+        logger.warning(
+            "[Redaction] %s has no usable credentials; falling back to on-server "
+            "detection so photos are still blurred. Fix the credentials or change "
+            "the provider on the Photo Redaction card.", provider,
+        )
+        return "local", provider
+    # Local is unavailable too -- OpenCV missing from the image. Nothing can
+    # blur, and that must not look like "no faces in this photo".
+    logger.error(
+        "[Redaction] no detector is usable (selected %s, and on-server detection "
+        "is unavailable). Photos are being stored WITHOUT redaction.", provider,
+    )
+    return provider, provider
+
 
 async def redact_image(media: str, provider: str, faces: bool, plates: bool) -> RedactionResult:
     """Redact one photo. Never raises.
 
     Fails *open* -- an unredactable photo is stored as submitted rather than
-    dropped -- and records why in `skipped_reason`. That direction is
-    deliberate but it is the weaker of the two: a town whose Vision credentials
-    quietly expired will publish unblurred faces and only find out from the
-    admin console. The alternative, refusing the report, punishes the resident
-    for the town's misconfiguration, so the honest fix is surfacing the failure
-    loudly, not dropping the photo.
+    dropped, because refusing the report punishes the resident for the town's
+    misconfiguration.
+
+    But "unredactable" is now much rarer than it was. A cloud detector with no
+    usable credentials falls back to on-server detection rather than returning
+    nothing, so the case this docstring used to describe -- "a town whose Vision
+    credentials quietly expired will publish unblurred faces" -- no longer
+    happens while OpenCV is present. When even that is unavailable the photo is
+    stored unredacted, and `skipped_reason` says `no-detector` rather than
+    `no-detections`, so the two are distinguishable by everything downstream.
     """
     decoded = _decode(media)
     if not decoded:
@@ -1022,6 +1099,14 @@ async def redact_image(media: str, provider: str, faces: bool, plates: bool) -> 
     width, height = image_size(raw)
     if width <= 0 or height <= 0:
         return RedactionResult(media, skipped_reason="unreadable-image")
+
+    provider, degraded_from = await effective_provider(provider)
+    if degraded_from == provider:
+        # Nothing can blur. Keep the photo -- dropping it helps nobody -- but do
+        # not let this be reported as "we looked and there was no one there".
+        cleaned = strip_exif(raw)
+        payload = _encode(cleaned, "image/jpeg") if cleaned is not None else media
+        return RedactionResult(payload, changed=False, skipped_reason="no-detector")
 
     found = await detect(provider, raw, width, height, faces, plates)
     if not found:

--- a/backend/app/services/image_redaction.py
+++ b/backend/app/services/image_redaction.py
@@ -605,12 +605,29 @@ async def _flag(key: str, default: bool) -> bool:
 
 
 async def resolve_provider() -> Optional[str]:
-    """Which detector to use, or None for "redaction is off".
+    """Which detector to use, or None only when a town has switched it off.
 
     Falls through to the moderation provider and then the AI provider, so a town
     that has already pasted one set of cloud credentials gets redaction without
-    configuring a second thing. `local` is never chosen implicitly -- OpenCV
-    quality is low enough that it should be a decision, not a default.
+    configuring a second thing.
+
+    `local` used to be excluded from that fall-through, on the reasoning that
+    OpenCV quality is low enough to deserve a decision rather than a default.
+    The reasoning compares local against a cloud detector. The actual
+    alternative, on a deployment with no cloud credentials, is **no detection at
+    all** -- and against that, imperfect detection wins every time.
+
+    It also contradicted `settings()` twelve lines below, which turns faces and
+    plates on by default and says why: "publishing a stranger's face on a
+    municipal website is a harm a town incurs by doing nothing, and the default
+    should not be the harmful one." Both toggles defaulted on, and then the
+    provider resolved to None and neither did anything. A fresh install stored
+    every resident photo unmodified while the Photo Redaction card displayed
+    Google Cloud Vision, because the catalog default said so.
+
+    So local is now the floor. Off is still reachable -- explicitly, by choosing
+    it -- which is the difference between a town deciding not to blur and a town
+    not knowing it wasn't.
     """
     from app.services.secret_manager import get_secret
 
@@ -627,7 +644,11 @@ async def resolve_provider() -> Optional[str]:
         return None
 
     ai = ((await get_secret("AI_PROVIDER")) or "").strip().lower()
-    return {"vertex": "google", "azure": "azure", "bedrock": "aws"}.get(ai)
+    derived = {"vertex": "google", "azure": "azure", "bedrock": "aws"}.get(ai)
+    # Nothing indicates a cloud. Detection on this server needs no account and
+    # no key, and sends no photo anywhere, so there is no reason for the answer
+    # to be "none".
+    return derived or "local"
 
 
 async def settings() -> Tuple[Optional[str], bool, bool]:

--- a/backend/app/services/proactive_health.py
+++ b/backend/app/services/proactive_health.py
@@ -213,6 +213,64 @@ async def _redis_check() -> Dict[str, Any]:
         return _check("redis", "Cache (Redis)", "unknown", None, "Could not reach Redis.")
 
 
+async def _kms_check() -> Dict[str, Any]:
+    """Is resident data still being encrypted with the key the town chose?
+
+    This is the only check here whose failure is not recoverable by fixing it
+    later, which is why it is critical rather than warning.
+
+    A cloud KMS key that stops answering -- scheduled for deletion, permissions
+    revoked, credentials expired -- does not raise anything. `_wrap_dek` falls
+    back to the application key and carries on: new reports save fine, and the
+    rows written under the old key quietly stop being readable. The gap can run
+    for weeks, and if the cause was a scheduled deletion, the window to cancel
+    it closes inside that time. After that the data is gone for good.
+
+    So this compares what the town selected against what actually wrapped the
+    data key just now. Those agreeing is the only evidence that the arrangement
+    still works; a settings page showing a key name proves nothing, because the
+    key name is still there when the key is not.
+    """
+    try:
+        from app.core import pii_crypto
+        from app.core.encryption import _kms_provider
+
+        selected = _kms_provider()
+        if selected not in ("google", "azure", "aws"):
+            # No cloud KMS chosen. Encrypting with the application key is then
+            # the configured behaviour, not a fault.
+            return _check("kms", "Resident data encryption", "ok", "local",
+                          "Resident data is encrypted with the application key, as configured.")
+
+        # A live wrap, not `active_backend()`. That reads the data key this
+        # process cached at startup, so a worker that has been running since
+        # before the key broke would answer with the state of the world an
+        # arbitrary time ago -- and would keep saying "ok" through the entire
+        # deletion window, which is the one stretch where saying otherwise
+        # matters. Wrapping a throwaway key costs one KMS call every fifteen
+        # minutes and answers the question as of now.
+        actual = pii_crypto.probe_backend()
+        if actual == selected:
+            return _check("kms", "Resident data encryption", "ok", actual,
+                          f"Resident data is being encrypted with your {actual} key.")
+
+        return _check(
+            "kms", "Resident data encryption", "critical", actual,
+            f"Your {selected} key is not being used — new resident data is being "
+            f"encrypted with the application key instead.",
+            action=(
+                "Act today. Check that the key still exists and has not been scheduled "
+                "for deletion, and that its credentials have not expired. Records saved "
+                "before this started may already be unreadable, and if a deletion is "
+                "pending it can only be cancelled inside the waiting period."
+            ),
+        )
+    except Exception:
+        logger.debug("KMS health probe failed", exc_info=True)
+        return _check("kms", "Resident data encryption", "unknown", None,
+                      "Could not determine which key is encrypting resident data.")
+
+
 async def collect_checks(db) -> List[Dict[str, Any]]:
     """Run all proactive checks. Never raises; failed probes return 'unknown'."""
     checks = [
@@ -221,6 +279,7 @@ async def collect_checks(db) -> List[Dict[str, Any]]:
         await _db_connection_check(db),
         await _backup_age_check(),
         await _redis_check(),
+        await _kms_check(),
     ]
     return checks
 

--- a/backend/app/services/proactive_health.py
+++ b/backend/app/services/proactive_health.py
@@ -271,6 +271,62 @@ async def _kms_check() -> Dict[str, Any]:
                       "Could not determine which key is encrypting resident data.")
 
 
+async def _redaction_check() -> Dict[str, Any]:
+    """Is the detector a town chose the one actually blurring its photos?
+
+    Redaction fails more quietly than anything else here. A cloud detector with
+    no credentials returns an empty result, and so does a photo of an empty
+    street -- the two are the same value. Photos get stored, the card stays
+    green, and nobody finds out until a resident's face is on the public map.
+
+    The dispatch now degrades to on-server detection rather than to nothing, so
+    the harm is contained. But degraded is still not what the town selected: it
+    is paying for Azure and getting OpenCV, which finds fewer faces. That is
+    worth a warning rather than silence.
+    """
+    try:
+        from app.services.image_redaction import (
+            _usable, effective_provider, resolve_provider,
+        )
+
+        selected = await resolve_provider()
+        if not selected:
+            return _check("redaction", "Photo redaction", "ok", "off",
+                          "Photo redaction is switched off, as configured.")
+
+        actual, degraded_from = await effective_provider(selected)
+
+        if degraded_from == actual:
+            return _check(
+                "redaction", "Photo redaction", "critical", "none",
+                "No detector is available — resident photos are being stored "
+                "without blurring faces or licence plates.",
+                action=(
+                    "Check the Photo Redaction card. On-server detection needs no "
+                    "account and works anywhere, so this usually means the image is "
+                    "missing OpenCV rather than that a credential is wrong."
+                ),
+            )
+
+        if degraded_from:
+            return _check(
+                "redaction", "Photo redaction", "warning", actual,
+                f"Blurring is running on this server because {degraded_from} has no "
+                f"usable credentials. Photos are still redacted, less accurately.",
+                action=(
+                    f"Fix the {degraded_from} credentials on the Photo Redaction card, "
+                    f"or choose on-server detection so the page matches what is running."
+                ),
+            )
+
+        return _check("redaction", "Photo redaction", "ok", actual,
+                      f"Faces and plates are being blurred using {actual}.")
+    except Exception:
+        logger.debug("Redaction health probe failed", exc_info=True)
+        return _check("redaction", "Photo redaction", "unknown", None,
+                      "Could not determine which detector is redacting photos.")
+
+
 async def collect_checks(db) -> List[Dict[str, Any]]:
     """Run all proactive checks. Never raises; failed probes return 'unknown'."""
     checks = [
@@ -280,6 +336,7 @@ async def collect_checks(db) -> List[Dict[str, Any]]:
         await _backup_age_check(),
         await _redis_check(),
         await _kms_check(),
+        await _redaction_check(),
     ]
     return checks
 

--- a/backend/app/services/secret_manager.py
+++ b/backend/app/services/secret_manager.py
@@ -212,6 +212,38 @@ def _get_secret_from_gcp(secret_name: str, force_refresh: bool = False) -> Optio
         return None
 
 
+# Keys that must keep their encrypted database copy, and must never be scrubbed
+# out of it after a migration.
+#
+# Two reasons, and both end in the same silent failure.
+#
+# Circularity: the Azure Key Vault and AWS credentials below are the credentials
+# *for* the secret store. Moving them into the store they unlock leaves nothing
+# able to open it -- which is why GCP's two were already excluded, and the other
+# clouds' equivalents were not.
+#
+# Reader mismatch: KMS configuration is read by encryption._get_config_sync and
+# aws_kms._cfg, which look at the environment and then the database and never
+# consult Secret Manager at all. Migrating those keys therefore succeeded, and
+# verified, and then scrubbed the only copy anything could read. PII encryption
+# would quietly fall back to wrapping with the application SECRET_KEY -- no
+# error, no log above DEBUG, and nothing on the page to say the KMS a town
+# selected had stopped being used.
+DB_REQUIRED_KEYS = frozenset({
+    # Google bootstrap -- unlocks Secret Manager itself.
+    "GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT",
+    # Azure Key Vault's own credentials.
+    "AZURE_KEYVAULT_URL", "AZURE_KEYVAULT_KEY", "AZURE_KEYVAULT_CLIENT_ID",
+    "AZURE_KEYVAULT_CLIENT_SECRET", "AZURE_KEYVAULT_API_VERSION",
+    "AZURE_KEYVAULT_SCOPE", "AZURE_TENANT_ID", "AZURE_AUTHORITY",
+    # AWS Secrets Manager / KMS credentials.
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+    "AWS_REGION", "AWS_SECRETS_PREFIX", "AWS_KMS_KEY_ID",
+    # KMS selection and key path, read only by the synchronous readers.
+    "KMS_PROVIDER", "KMS_LOCATION", "KMS_KEY_RING", "KMS_KEY_ID",
+})
+
+
 async def get_secret(key_name: str) -> Optional[str]:
     """
     Get a single secret value.
@@ -516,10 +548,7 @@ async def migrate_to_secret_manager() -> Dict[str, Any]:
     scrubbed = []
     
     # Keys that should NOT be migrated (they're needed to access Secret Manager itself)
-    bootstrap_keys = {
-        "GCP_SERVICE_ACCOUNT_JSON",
-        "GOOGLE_CLOUD_PROJECT",
-    }
+    bootstrap_keys = set(DB_REQUIRED_KEYS)
     
     try:
         async with SessionLocal() as db:
@@ -570,10 +599,11 @@ async def migrate_to_secret_manager() -> Dict[str, Any]:
                 except Exception as e:
                     failed.append({"key": key_name, "error": f"verification failed: {str(e)}"})
             
-            # Only scrub VERIFIED secrets from database
+            # Only scrub VERIFIED secrets from database, and never one that a
+            # synchronous reader depends on -- see DB_REQUIRED_KEYS.
             if verified:
                 for secret in secrets:
-                    if secret.key_name in verified:
+                    if secret.key_name in verified and secret.key_name not in DB_REQUIRED_KEYS:
                         # Clear the encrypted value but keep the record
                         secret.key_value = None
                         scrubbed.append(secret.key_name)

--- a/backend/app/services/secret_manager.py
+++ b/backend/app/services/secret_manager.py
@@ -337,12 +337,19 @@ async def _get_secret_from_db(key_name: str) -> Optional[str]:
 async def get_secrets_bundle(prefix: str) -> Dict[str, str]:
     """
     Get all secrets with a given prefix.
-    
+
     Example: get_secrets_bundle("SMTP_") returns all SMTP settings.
+
+    Only Google's path is bundle-shaped -- Key Vault and Secrets Manager store
+    one secret per key, with no prefix query -- so for those this falls through
+    to the database, which holds only the keys that could not be migrated. It is
+    therefore not a safe way to read credentials on those stores, and nothing
+    does: `get_secret` is the supported reader and handles all three. Kept for
+    the Google bundle-inspection case only.
     """
     result = {}
-    
-    if _is_gcp_available():
+
+    if _secrets_provider() == "google" and _is_gcp_available():
         # Map prefix to bundle name
         if prefix.startswith("AUTH0"):
             bundle = _get_secret_from_gcp("secret-auth")

--- a/backend/app/services/secret_manager.py
+++ b/backend/app/services/secret_manager.py
@@ -241,6 +241,11 @@ DB_REQUIRED_KEYS = frozenset({
     "AWS_REGION", "AWS_SECRETS_PREFIX", "AWS_KMS_KEY_ID",
     # KMS selection and key path, read only by the synchronous readers.
     "KMS_PROVIDER", "KMS_LOCATION", "KMS_KEY_RING", "KMS_KEY_ID",
+    # Which store to use, read by _secrets_provider() -- env, then database,
+    # never the store itself, because it is the answer to which store that is.
+    # Scrubbing it silently reverts a town on Azure or AWS to the Google
+    # default, at which point nothing can read any of its secrets.
+    "SECRETS_PROVIDER",
 })
 
 
@@ -522,25 +527,32 @@ async def set_secret(key_name: str, value: str) -> bool:
 
 async def migrate_to_secret_manager() -> Dict[str, Any]:
     """
-    Migrate all secrets from database to Google Secret Manager.
-    
-    SAFETY: Only scrubs secrets from database AFTER verifying they can be
-    read back from GCP. This prevents data loss if the write fails.
-    
+    Migrate all secrets from the database into the configured secret store.
+
+    Works against whichever store is selected -- Google Secret Manager, Azure
+    Key Vault or AWS Secrets Manager. It was previously gated on Google alone,
+    so a town on Azure or AWS had its credentials written to the vault by the
+    save path and its database copies left behind forever.
+
+    SAFETY: Only scrubs secrets from the database AFTER verifying they can be
+    read back from the store. This prevents data loss if the write fails.
+
     Returns a summary of migrated secrets.
     """
     from app.db.session import SessionLocal
     from app.models import SystemSecret
     from app.core.encryption import decrypt_safe
     from sqlalchemy import select
-    
-    if not _is_gcp_available():
+
+    from app.services.storage_maintenance import store_reachable
+
+    if not store_reachable():
         return {
             "status": "skipped",
             "reason": "Secret Manager not available",
             "migrated": 0
         }
-    
+
     migrated = []
     verified = []
     failed = []

--- a/backend/app/services/storage_maintenance.py
+++ b/backend/app/services/storage_maintenance.py
@@ -1,0 +1,231 @@
+"""Keeping stored data on the storage a town has chosen, without being asked.
+
+Two maintenance jobs used to be buttons on the setup page: "Vault Local Secrets
+to GCP Identity" and "Re-encrypt All PII Data (after key rotation)". Both are
+real work. Neither is work a clerk can be expected to recognise the need for --
+the second one is parenthetically conditioned on a key rotation, which is an
+event nobody who reads that sentence has knowingly performed.
+
+Both are also safe to run unprompted, which is the part that makes this
+possible:
+
+  * Vaulting writes every secret to the configured store, reads each one back to
+    confirm it landed, and only then clears the database copy -- and never
+    clears one of `DB_REQUIRED_KEYS`, whose readers cannot see the store. A run
+    with nothing to move is a no-op; a run against an unreachable store stops
+    before it deletes anything.
+
+  * Re-wrapping is hygiene rather than a repair. A `pii2:` value carries the
+    wrapped data key that produced it, and `pii_crypto._dek_for` unwraps by the
+    tag in its first byte, so a row wrapped by last year's key still decrypts
+    today. Rewriting it under the current key is worth doing -- it is what lets
+    a town retire an old key, and what moves rows that silently fell back to the
+    application key while a KMS was unreachable -- but nothing is broken while
+    it is pending, so it can take as long as it takes.
+
+So they run on a schedule instead, in batches, idempotently. The setup page
+keeps a status line for the case where something is genuinely stuck, and no
+buttons.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# How many rows one re-wrap pass touches. Each row is four AES operations and no
+# KMS traffic at all -- the data key is unwrapped once and cached -- so this is
+# bounded by the database round trip. Kept modest anyway: the job runs nightly
+# and finishing next week is an acceptable outcome for hygiene work.
+REWRAP_BATCH = 500
+
+
+def _pii_columns():
+    from app.models import ServiceRequest
+    return (
+        ServiceRequest._first_name_encrypted,
+        ServiceRequest._last_name_encrypted,
+        ServiceRequest._email_encrypted,
+        ServiceRequest._phone_encrypted,
+    )
+
+
+def store_reachable() -> bool:
+    """Whether the configured secret store can be contacted right now."""
+    try:
+        from app.services.secret_manager import _is_gcp_available, _secrets_provider
+
+        provider = _secrets_provider()
+        if provider == "azure":
+            from app.core import azure_keyvault
+            return azure_keyvault.is_configured()
+        if provider == "aws":
+            from app.core import aws_secretsmanager
+            return aws_secretsmanager.is_configured()
+        return _is_gcp_available()
+    except Exception as exc:
+        logger.debug("storage maintenance: store reachability check failed: %s", exc)
+        return False
+
+
+async def vault_secrets(force: bool = False) -> Dict[str, Any]:
+    """Move any database-held secrets into the configured store.
+
+    Returns the migration summary, or a `skipped` result when there is no store
+    to move them to. Never raises: this is called from a scheduled task and from
+    a fire-and-forget hook after a provider is saved, and neither has anywhere
+    useful to report an exception to.
+    """
+    try:
+        if not force and not store_reachable():
+            return {"status": "skipped", "reason": "no secret store configured", "migrated": 0}
+
+        from app.services.secret_manager import migrate_to_secret_manager
+
+        result = await migrate_to_secret_manager()
+        moved = result.get("scrubbed") or 0
+        if moved:
+            logger.info("Vaulted %s secrets into the configured secret store", moved)
+        return result
+    except Exception as exc:
+        logger.warning("Automatic secret vaulting failed (will retry): %s", exc)
+        return {"status": "error", "error": str(exc), "migrated": 0}
+
+
+async def _stale_segments(db, column, current: str) -> List[str]:
+    """The distinct wrapped-data-key segments in `column` not on the current key.
+
+    Every row encrypted by one process shares one wrapped-key string, so this is
+    a handful of values however many rows there are -- which is what makes it
+    affordable to ask the question before doing any work.
+    """
+    from sqlalchemy import func, select
+
+    from app.services.storage_status import WRAP_TAGS
+
+    segment = func.split_part(column, ":", 2)
+    rows = (await db.execute(
+        select(segment).where(column.isnot(None)).group_by(segment)
+    )).all()
+
+    stale = []
+    for (wrapped_b64,) in rows:
+        if not wrapped_b64:
+            continue  # Not a pii2 value; handled by the legacy clause below.
+        try:
+            tag = WRAP_TAGS.get(base64.b64decode(wrapped_b64 + "==")[:1])
+        except Exception:
+            tag = None
+        if tag != current:
+            stale.append(wrapped_b64)
+    return stale
+
+
+def rewrap_value(value: Optional[str]) -> Optional[str]:
+    """The re-encrypted form of one stored value, or None to leave it alone.
+
+    Returns None in three cases that must all behave identically from the
+    caller's side: nothing stored, nothing changed, and -- the one that matters
+    -- the value could not be decrypted. A row whose wrapping key is gone is the
+    only way this code can destroy data, and it would do so by writing an
+    encryption of the empty string over the last copy of somebody's phone
+    number. So an undecryptable value is left exactly as it is, on the chance
+    that the key comes back.
+
+    Split out from the batch loop so that guarantee can be tested without a
+    database.
+    """
+    if not value:
+        return None
+
+    from app.core.encryption import decrypt_pii, encrypt_pii
+
+    plaintext = decrypt_pii(value)
+    if not plaintext:
+        raise ValueError("value could not be decrypted; leaving it untouched")
+    replacement = encrypt_pii(plaintext)
+    return replacement if replacement != value else None
+
+
+async def rewrap_pii(db, limit: int = REWRAP_BATCH) -> Dict[str, Any]:
+    """Re-encrypt up to `limit` rows that are not on the current key.
+
+    Selects only rows that need it, so a town with nothing outstanding runs one
+    cheap query and stops. Safe to run repeatedly and safe to interrupt: each
+    row is independent, and a row left unconverted is still readable.
+    """
+    out: Dict[str, Any] = {"status": "ok", "rows": 0, "fields": 0, "errors": 0, "remaining": 0}
+    try:
+        from sqlalchemy import func, or_, select
+
+        from app.core.encryption import PII_V2_PREFIX, _kms_provider
+        from app.models import ServiceRequest
+
+        current = _kms_provider()
+        columns = _pii_columns()
+
+        clauses = []
+        for column in columns:
+            stale = await _stale_segments(db, column, current)
+            # Either it predates the envelope format, or its wrapped key is one
+            # of the stale ones. Both re-encrypt the same way.
+            column_clause = [column.isnot(None) & ~column.like(f"{PII_V2_PREFIX}%")]
+            if stale:
+                column_clause.append(func.split_part(column, ":", 2).in_(stale))
+            clauses.append(or_(*column_clause))
+
+        rows = (await db.execute(
+            select(ServiceRequest).where(or_(*clauses)).order_by(ServiceRequest.id).limit(limit)
+        )).scalars().all()
+
+        if not rows:
+            return out
+
+        for row in rows:
+            touched = False
+            for column in columns:
+                name = column.key
+                try:
+                    replacement = rewrap_value(getattr(row, name, None))
+                except Exception as exc:
+                    logger.debug("re-wrap failed for request %s %s: %s", row.id, name, exc)
+                    out["errors"] += 1
+                    continue
+                if replacement is not None:
+                    setattr(row, name, replacement)
+                    out["fields"] += 1
+                    touched = True
+            if touched:
+                out["rows"] += 1
+
+        await db.commit()
+
+        if out["rows"]:
+            logger.info("Re-wrapped %s requests (%s fields) onto the current key",
+                        out["rows"], out["fields"])
+
+        # Whether to come back sooner than the next nightly run.
+        out["remaining"] = limit if len(rows) == limit else 0
+    except Exception as exc:
+        logger.warning("Automatic PII re-wrap failed (will retry): %s", exc)
+        out["status"] = "error"
+        out["error"] = str(exc)
+    return out
+
+
+def generated_backup_key() -> str:
+    """A backup passphrase, so nobody has to invent one.
+
+    The old field asked a town to make up a passphrase for AES-256 backup
+    encryption, which produces either something guessable or something lost. The
+    one thing that cannot be automated here is keeping a copy somewhere other
+    than this server: a key held only inside the system it protects is no key at
+    all once that system is gone. So this generates it, and the page shows it
+    once and asks for an acknowledgement that it has been written down.
+    """
+    import secrets
+
+    return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")

--- a/backend/app/services/storage_status.py
+++ b/backend/app/services/storage_status.py
@@ -1,0 +1,134 @@
+"""Whether the stored data matches the storage a town has chosen.
+
+Three maintenance actions used to sit on the setup page as buttons a clerk had
+to know when to press: "Vault Local Secrets to GCP Identity", "Re-encrypt All
+PII Data (after key rotation)", and inventing a backup passphrase. Each is a
+real operation, and each was phrased as a thing you do rather than a question
+you can answer.
+
+The system already knows the answer. A secret sitting in the database when a
+store is configured is a fact you can count; PII wrapped with a key the town no
+longer uses is a byte tag you can read. So the page can say "12 keys are still
+in the database" and offer one button, instead of asking somebody to work out
+whether "vaulting local secrets" applies to them.
+
+Everything here is read-only and never raises: it drives an advisory panel, and
+a status check that 500s would be worse than no panel at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# The first byte of a wrapped data key records which service wrapped it. Kept in
+# step with pii_crypto's _WRAP_* constants.
+WRAP_TAGS = {b"g": "google", b"a": "azure", b"w": "aws", b"l": "local"}
+
+
+async def secrets_outside_the_store(db) -> Dict[str, Any]:
+    """How many secrets still have a database copy that could be moved.
+
+    Excludes the keys that must keep one -- the credentials for the store
+    itself, and the KMS settings whose only readers look at the database. Those
+    are not work outstanding; they are supposed to be there.
+    """
+    result: Dict[str, Any] = {"count": 0, "store": None, "reachable": False}
+    try:
+        from sqlalchemy import select
+
+        from app.models import SystemSecret
+        from app.services.secret_manager import DB_REQUIRED_KEYS, _secrets_provider
+        from app.services.storage_maintenance import store_reachable
+
+        result["store"] = _secrets_provider()
+        # The same check the migration gates on, so the page cannot say work is
+        # pending that the scheduled job has already decided it cannot do.
+        result["reachable"] = store_reachable()
+
+        rows = (await db.execute(
+            select(SystemSecret.key_name).where(SystemSecret.key_value.isnot(None))
+        )).all()
+        result["count"] = sum(1 for (key,) in rows if key not in DB_REQUIRED_KEYS)
+    except Exception as exc:
+        logger.debug("storage status: could not count database secrets: %s", exc)
+    return result
+
+
+async def pii_wrapped_with_other_keys(db) -> Dict[str, Any]:
+    """How many records are wrapped with a key other than the one in use.
+
+    A stored value looks like `pii2:<wrapped-dek>:<nonce>:<ciphertext>`, and the
+    first byte inside that base64 wrapped-dek records which service wrapped it.
+    Every row encrypted under the same key shares the same wrapped-dek string,
+    so this groups by that segment rather than reading every row -- a town with
+    a hundred thousand requests has two or three distinct values, not a hundred
+    thousand.
+
+    `local` is counted separately because it is the state a town reaches without
+    choosing it: a KMS that was unreachable when a report came in falls back to
+    the application key silently, and this is the only place that becomes
+    visible.
+    """
+    out: Dict[str, Any] = {"total": 0, "stale": 0, "on_application_key": 0,
+                           "legacy": 0, "current": None}
+    try:
+        import base64
+
+        from sqlalchemy import func, select
+
+        from app.core.encryption import _kms_provider
+        from app.models import ServiceRequest
+
+        current = _kms_provider()
+        out["current"] = current
+
+        for column in (ServiceRequest._email_encrypted, ServiceRequest._phone_encrypted):
+            # split_part is 1-indexed: part 2 is the wrapped DEK.
+            segment = func.split_part(column, ":", 2)
+            rows = (await db.execute(
+                select(segment, func.count())
+                .where(column.isnot(None))
+                .group_by(segment)
+            )).all()
+
+            for wrapped_b64, count in rows:
+                out["total"] += count
+                if not wrapped_b64:
+                    # No pii2: prefix -- the older Fernet format, which
+                    # re-encrypting migrates.
+                    out["legacy"] += count
+                    out["stale"] += count
+                    continue
+                try:
+                    tag = WRAP_TAGS.get(base64.b64decode(wrapped_b64 + "==")[:1])
+                except Exception:
+                    tag = None
+                if tag is None:
+                    out["legacy"] += count
+                    out["stale"] += count
+                    continue
+                if tag == "local":
+                    out["on_application_key"] += count
+                if tag != current:
+                    out["stale"] += count
+    except Exception as exc:
+        logger.debug("storage status: could not count wrapped PII: %s", exc)
+    return out
+
+
+async def summary(db) -> Dict[str, Any]:
+    """Everything the setup page needs to decide whether to say anything."""
+    secrets = await secrets_outside_the_store(db)
+    pii = await pii_wrapped_with_other_keys(db)
+    return {
+        "secrets": secrets,
+        "pii": pii,
+        # The page shows nothing at all unless one of these is true, so a town
+        # with nothing outstanding is never asked to think about any of it.
+        "needs_attention": bool(
+            (secrets["count"] and secrets["reachable"]) or pii["stale"]
+        ),
+    }

--- a/backend/app/tasks/storage.py
+++ b/backend/app/tasks/storage.py
@@ -1,0 +1,83 @@
+"""Scheduled storage hygiene: vaulting secrets and re-wrapping PII.
+
+These replace two buttons on the setup page. See
+`app.services.storage_maintenance` for why both are safe to run unattended --
+in short, vaulting verifies a read-back before it deletes anything, and PII on
+an older key is still readable, so neither job is load-bearing at the moment it
+runs.
+
+Both are written to be dull: no retries, no chaining, no partial state carried
+between runs. If a pass does nothing because a store was briefly unreachable,
+the next pass does it.
+"""
+
+import asyncio
+import logging
+
+from app.core.celery_app import celery_app
+from app.db.session import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+
+def _run(coro):
+    from app.db.session import engine
+
+    async def _runner():
+        try:
+            return await coro
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_runner())
+
+
+@celery_app.task(name="app.tasks.storage.vault_secrets")
+def vault_secrets():
+    """Hourly: move any secret still held in the database into the store.
+
+    Hourly rather than nightly because the window it closes is the one right
+    after somebody finishes setup -- credentials entered before the cloud
+    account was connected sit in the database until this runs, and "by tomorrow"
+    is a long time for that to be true of a town's Twilio token.
+    """
+    from app.services.storage_maintenance import vault_secrets as _vault
+
+    try:
+        return _run(_vault())
+    except Exception as exc:
+        logger.warning("[storage] secret vaulting pass failed: %s", exc)
+        return {"status": "error", "error": str(exc)}
+
+
+@celery_app.task(name="app.tasks.storage.rewrap_pii")
+def rewrap_pii():
+    """Nightly: move PII onto the current key, a batch at a time.
+
+    Keeps going within one run while there is more to do, up to a ceiling, so a
+    town that has just connected a KMS converts in a few nights rather than a
+    few hundred. The ceiling exists so this cannot become an all-night job on a
+    large database; whatever is left is picked up tomorrow.
+    """
+    from app.services.storage_maintenance import rewrap_pii as _rewrap
+
+    MAX_BATCHES = 20
+
+    async def _go():
+        totals = {"status": "ok", "rows": 0, "fields": 0, "errors": 0, "batches": 0}
+        async with SessionLocal() as db:
+            for _ in range(MAX_BATCHES):
+                result = await _rewrap(db)
+                totals["rows"] += result.get("rows", 0)
+                totals["fields"] += result.get("fields", 0)
+                totals["errors"] += result.get("errors", 0)
+                totals["batches"] += 1
+                if result.get("status") != "ok" or not result.get("remaining"):
+                    break
+        return totals
+
+    try:
+        return _run(_go())
+    except Exception as exc:
+        logger.warning("[storage] PII re-wrap pass failed: %s", exc)
+        return {"status": "error", "error": str(exc)}

--- a/backend/tests/test_capability_configured.py
+++ b/backend/tests/test_capability_configured.py
@@ -179,14 +179,17 @@ def test_the_rejection_does_not_echo_the_path_segment():
 
 
 def test_the_allow_list_covers_every_capability_the_endpoint_handles():
-    """If a new branch is added to test_provider, the allow-list must admit it,
-    or the capability becomes unreachable behind a 400."""
-    import inspect
+    """If a new check is added, the allow-list must admit it, or the capability
+    becomes unreachable behind a 400.
 
+    This used to scrape `if capability == "` lines out of test_provider's
+    source. That broke the day the endpoint was refactored into a dispatch
+    table -- the property it cared about got *stronger*, and the test failed
+    anyway, because it was asserting the shape of the code rather than the
+    thing the code has to be true about. Reads the table now.
+    """
     from app.api import system
 
-    src = inspect.getsource(system.test_provider)
-    handled = {line.split('"')[1] for line in src.splitlines()
-               if line.strip().startswith('if capability == "')}
-    assert handled, "expected to find the per-capability branches"
+    handled = set(system._CAPABILITY_TESTS)
+    assert handled, "expected to find the per-capability checks"
     assert handled <= set(system._PROVIDER_SELECT_KEY), handled - set(system._PROVIDER_SELECT_KEY)

--- a/backend/tests/test_cloud_identity.py
+++ b/backend/tests/test_cloud_identity.py
@@ -1,0 +1,150 @@
+"""Using the identity the cloud already attached, instead of asking for a key.
+
+The largest single burden in setup is credentials: a service-account JSON on
+Google, an access key on AWS, a client secret on Azure. They are the values most
+often mis-copied, the ones that then have to be vaulted, and -- on Azure -- the
+one that expires on a date nobody records.
+
+None of them is needed when the application runs on the cloud it is calling.
+Every provider attaches an identity to the compute, and the SDKs pick it up with
+nothing configured. This is not a shortcut with a security cost: no long-lived
+credential exists to be leaked, mailed, committed, or left behind by a departing
+employee. It happens to also be the version where a clerk types nothing.
+
+Two of the three already worked here, by accident and unannounced. These tests
+cover making it deliberate.
+"""
+
+import pytest
+
+from app.services import cloud_identity as ci
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    ci._cache.update({"at": 0.0, "value": None})
+    yield
+    ci._cache.update({"at": 0.0, "value": None})
+
+
+def test_no_attached_identity_is_a_clean_negative(monkeypatch):
+    """A self-hosted town on its own hardware. Every probe fails, and the
+    answer has to be "no" rather than an exception on a settings page."""
+    monkeypatch.setattr(ci, "_google", lambda: None)
+    monkeypatch.setattr(ci, "_azure", lambda: None)
+    monkeypatch.setattr(ci, "_aws", lambda: None)
+
+    result = ci.summary()
+    assert result == {"attached": False, "provider": None,
+                      "identity": None, "skippable_keys": []}
+
+
+@pytest.mark.parametrize("provider,keys", [
+    ("google", "GCP_SERVICE_ACCOUNT_JSON"),
+    ("aws", "AWS_SECRET_ACCESS_KEY"),
+    ("azure", "AZURE_KEYVAULT_CLIENT_SECRET"),
+])
+def test_an_attached_identity_names_the_keys_it_replaces(monkeypatch, provider, keys):
+    """The page greys those boxes out and says why. Without the list a clerk
+    sees an empty required-looking field and pastes a key anyway, which is the
+    situation this is meant to end."""
+    monkeypatch.setattr(ci, "_google", lambda: None)
+    monkeypatch.setattr(ci, "_azure", lambda: None)
+    monkeypatch.setattr(ci, "_aws", lambda: None)
+    monkeypatch.setattr(ci, f"_{provider}",
+                        lambda: {"provider": provider, "identity": "test"})
+
+    result = ci.summary()
+    assert result["attached"] is True
+    assert result["provider"] == provider
+    assert keys in result["skippable_keys"]
+
+
+def test_only_the_proof_of_identity_is_skippable():
+    """Key names, regions and endpoints identify *which* resource to use. They
+    are not credentials and the attached identity does not supply them --
+    marking them skippable would leave a town with no key configured at all."""
+    everything = {k for keys in ci.SKIPPABLE.values() for k in keys}
+    for must_still_be_asked in (
+        "KMS_KEY_ID", "KMS_KEY_RING", "KMS_LOCATION", "AWS_REGION",
+        "AWS_KMS_KEY_ID", "AZURE_KEYVAULT_URL", "AZURE_KEYVAULT_KEY",
+        "GOOGLE_CLOUD_PROJECT",
+    ):
+        assert must_still_be_asked not in everything, must_still_be_asked
+
+
+def test_a_probe_that_hangs_does_not_hang_the_page():
+    """The probes hit link-local addresses that either answer at once or are
+    not there. A generous timeout would stall a settings page for every town
+    that is not on a cloud, which is most of them."""
+    assert ci._PROBE_TIMEOUT <= 2
+
+
+def test_detection_is_cached_but_not_forever():
+    """Compute does not acquire an identity halfway through an afternoon, so
+    probing on every request is waste -- but an operator who attaches one
+    should not have to restart the server to be believed."""
+    assert 0 < ci._CACHE_TTL <= 3600
+
+
+def test_the_negative_result_is_cached_too(monkeypatch):
+    """The expensive case is the town with no cloud at all: three probes that
+    each have to time out. Caching only successes would pay that on every
+    page load."""
+    calls = []
+
+    def _count():
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(ci, "_google", _count)
+    monkeypatch.setattr(ci, "_azure", _count)
+    monkeypatch.setattr(ci, "_aws", _count)
+
+    ci.detect()
+    first = len(calls)
+    ci.detect()
+    assert len(calls) == first, "a negative result must be cached"
+
+
+# ---------------------------------------------------------------------------
+# Azure was the one that made a secret mandatory
+# ---------------------------------------------------------------------------
+
+def test_azure_accepts_a_managed_identity_instead_of_a_client_secret(monkeypatch):
+    """is_configured() required tenant + client id + client secret, so a town
+    on Azure had to create the worst credential of the three clouds when the
+    platform was already offering it the best one."""
+    pytest.importorskip("httpx")
+    from app.core import azure_keyvault as akv
+
+    monkeypatch.setattr(akv, "_cfg", lambda k: "https://v.vault.azure.net/" if k == "AZURE_KEYVAULT_URL" else None)
+    monkeypatch.setenv("IDENTITY_ENDPOINT", "http://localhost/token")
+    assert akv.is_configured() is True
+
+
+def test_azure_still_requires_a_vault_url(monkeypatch):
+    """The identity proves who is asking. It does not say which vault."""
+    pytest.importorskip("httpx")
+    from app.core import azure_keyvault as akv
+
+    monkeypatch.setattr(akv, "_cfg", lambda k: None)
+    monkeypatch.setenv("IDENTITY_ENDPOINT", "http://localhost/token")
+    assert akv.is_configured() is False
+
+
+def test_azure_without_an_identity_still_needs_the_full_secret(monkeypatch):
+    """Off Azure, nothing has changed: the client-credentials flow is the only
+    way in, and a partial set must not read as configured."""
+    pytest.importorskip("httpx")
+    from app.core import azure_keyvault as akv
+
+    monkeypatch.delenv("IDENTITY_ENDPOINT", raising=False)
+    monkeypatch.delenv("MSI_ENDPOINT", raising=False)
+    values = {"AZURE_KEYVAULT_URL": "https://v.vault.azure.net/",
+              "AZURE_TENANT_ID": "t", "AZURE_KEYVAULT_CLIENT_ID": "c"}
+    monkeypatch.setattr(akv, "_cfg", lambda k: values.get(k))
+    assert akv.is_configured() is False
+
+    values["AZURE_KEYVAULT_CLIENT_SECRET"] = "s"
+    assert akv.is_configured() is True

--- a/backend/tests/test_dispatch_keys_are_enterable.py
+++ b/backend/tests/test_dispatch_keys_are_enterable.py
@@ -1,0 +1,104 @@
+"""Every credential the dispatch code reads must have a box on the page.
+
+The recurring failure on this platform is a setting that stores fine, reads
+back fine, and silently does nothing. This is its purest form: code asks
+`get_secret("AZURE_FACE_KEY")`, no card offers that key, so selecting the
+provider saves a choice, reports success, and then finds nothing and does
+nothing -- with no error and nowhere to go to fix it.
+
+That is exactly what photo redaction did. Google and AWS reuse credentials
+entered elsewhere, so nobody noticed that Azure does not: it reads four keys of
+its own, and the catalog offered two toggles. A town could pick Azure, tick both
+boxes, save, and have every resident photo stored unblurred.
+
+The test is written against the dispatch code rather than a hand-listed set, so
+adding a `get_secret("NEW_KEY")` to a provider path fails here instead of
+shipping a switch that does nothing.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+# Dispatch modules whose secrets a town enters on the setup page.
+DISPATCH_SOURCES = ("app/services/image_redaction.py",)
+
+# Keys that are legitimately not per-provider credential fields.
+EXEMPT = {
+    # Which provider to use -- written by the provider picker, not typed.
+    "REDACTION_PROVIDER", "MODERATION_PROVIDER", "AI_PROVIDER", "EMAIL_PROVIDER",
+    "SMS_PROVIDER", "KMS_PROVIDER", "SECRETS_PROVIDER", "TRANSLATION_PROVIDER",
+    "IDENTITY_PROVIDER", "MAPS_PROVIDER",
+}
+
+
+def _keys_read(path: Path):
+    try:
+        source = path.read_text()
+    except OSError:
+        return set()
+    return set(re.findall(r'get_secret\(\s*"([A-Z0-9_]+)"', source))
+
+
+def _all_catalog_keys():
+    """Every key any provider card can accept, across every catalog."""
+    keys = set()
+    sources = (
+        ("app.services.ai.registry", "AI_CATALOG"),
+        ("app.services.translation_providers", "TRANSLATION_CATALOG"),
+        ("app.services.identity", "IDENTITY_CATALOG"),
+        ("app.services.map_provider", "MAP_CATALOG"),
+    )
+    for module, name in sources:
+        try:
+            catalog = getattr(__import__(module, fromlist=[name]), name)
+        except Exception:
+            continue
+        for entry in catalog.values():
+            keys |= {f["key"] for f in entry.get("credential_fields", [])}
+    from app.services.delivery_providers import _CATALOGS
+    for catalog in _CATALOGS.values():
+        for entry in catalog.values():
+            keys |= {f["key"] for f in entry.get("credential_fields", [])}
+    return keys
+
+
+def test_every_secret_the_dispatch_code_reads_has_somewhere_to_be_entered():
+    enterable = _all_catalog_keys()
+    assert enterable, "expected to load at least one provider catalog"
+
+    unreachable = {}
+    for relative in DISPATCH_SOURCES:
+        for key in _keys_read(BACKEND / relative) - EXEMPT - enterable:
+            unreachable.setdefault(relative, []).append(key)
+
+    assert not unreachable, (
+        "these secrets are read by dispatch code but no provider card offers "
+        f"them, so nothing can ever set them: {unreachable}"
+    )
+
+
+def test_azure_redaction_offers_its_four_keys():
+    """Named explicitly because this is the instance that was broken, and
+    because the two endpoints are easy to collapse into one by mistake -- Face
+    and Vision are separate Azure resources with separate keys."""
+    from app.services.delivery_providers import REDACTION_CATALOG
+
+    offered = {f["key"] for f in REDACTION_CATALOG["azure"]["credential_fields"]}
+    for key in ("AZURE_FACE_ENDPOINT", "AZURE_FACE_KEY",
+                "AZURE_VISION_ENDPOINT", "AZURE_VISION_KEY"):
+        assert key in offered, key
+
+
+def test_the_providers_that_reuse_credentials_do_not_ask_again():
+    """Google and AWS take the service account and access keys entered
+    elsewhere. Asking for them a second time here would be two boxes writing one
+    secret, and whichever was filled last would win."""
+    from app.services.delivery_providers import REDACTION_CATALOG
+
+    for provider in ("google", "aws", "local"):
+        offered = {f["key"] for f in REDACTION_CATALOG[provider]["credential_fields"]}
+        assert offered == {"REDACT_FACES", "REDACT_PLATES"}, (provider, offered)

--- a/backend/tests/test_kms_azure.py
+++ b/backend/tests/test_kms_azure.py
@@ -36,7 +36,14 @@ def test_azure_kms_wrap_roundtrip(monkeypatch):
             return AESGCM(_kek).decrypt(nonce, ct, b"azurekv").decode("ascii")
 
     monkeypatch.setattr(enc, "_kms_provider", lambda: "azure")
+    # Both the package attribute and sys.modules. `_wrap_dek` reaches the real
+    # module via `from app.core import azure_keyvault`, which reads the
+    # attribute off the already-imported package and never consults sys.modules
+    # -- so patching sys.modules alone only worked while nothing earlier in the
+    # run had imported it. Order-dependent, and it passed only by luck.
+    import app.core
     monkeypatch.setitem(__import__("sys").modules, "app.core.azure_keyvault", _FakeAzureKeyVault)
+    monkeypatch.setattr(app.core, "azure_keyvault", _FakeAzureKeyVault, raising=False)
     pii.clear_caches()
 
     token = pii.encrypt("resident@example.gov")

--- a/backend/tests/test_kms_health_alert.py
+++ b/backend/tests/test_kms_health_alert.py
@@ -1,0 +1,113 @@
+"""The alert for the one failure that cannot be undone.
+
+Every other proactive check warns about something recoverable -- a full disk, a
+stale backup. This one warns about a key that has stopped answering, and it is
+different in kind: nothing raises when that happens. `_wrap_dek` falls back to
+the application key, new reports save normally, and the rows written under the
+old key quietly stop being readable.
+
+If the cause is a scheduled deletion, the window to cancel it is 7 to 30 days.
+Silence for that long is the difference between an inconvenience and permanent
+loss of every resident's contact details. So the alert has to fire, it has to be
+critical, and -- the part that is easy to get wrong -- it has to ask the key
+service rather than a cache.
+"""
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from app.services import proactive_health as ph
+
+
+def _run(coro):
+    import asyncio
+    return asyncio.run(coro)
+
+
+def test_a_key_that_stopped_answering_is_critical(monkeypatch):
+    """Selected Azure, actually wrapping with the application key. Recoverable
+    only while the deletion window is open, so it does not get to be a warning."""
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "azure")
+    monkeypatch.setattr(pii_crypto, "probe_backend", lambda: "local")
+
+    check = _run(ph._kms_check())
+    assert check["status"] == "critical"
+    assert "azure" in check["message"]
+    assert check["action"], "a critical check with no action is just bad news"
+
+
+def test_a_working_key_is_quiet(monkeypatch):
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "google")
+    monkeypatch.setattr(pii_crypto, "probe_backend", lambda: "google")
+
+    assert _run(ph._kms_check())["status"] == "ok"
+
+
+def test_no_cloud_kms_is_not_an_alert(monkeypatch):
+    """A self-hosted town with no cloud account encrypts with the application
+    key by choice. Paging them about it every fifteen minutes forever would
+    train them to ignore the alert that matters."""
+    from app.core import encryption
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "local")
+    assert _run(ph._kms_check())["status"] == "ok"
+
+
+def test_the_probe_does_not_read_a_cache(monkeypatch):
+    """The failure mode this check exists for lasts weeks, and a Celery worker
+    stays up for weeks. Reading the data key cached at startup would report the
+    state of the world before the key broke, for the entire deletion window."""
+    import inspect
+
+    # Comments strip out first: this file explains the distinction at length,
+    # and matching the prose would pass while the code did the wrong thing.
+    code = "\n".join(
+        line for line in inspect.getsource(ph._kms_check).splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert "probe_backend()" in code
+    assert "active_backend()" not in code
+
+
+def test_the_probe_does_not_disturb_what_it_measures(monkeypatch):
+    """A health check that swapped the process's data key would re-encrypt
+    nothing but would make every later reading of `active_backend` wrong."""
+    from app.core import pii_crypto
+
+    pii_crypto.clear_caches()
+    before = pii_crypto._get_active_dek()
+    pii_crypto.probe_backend()
+    assert pii_crypto._get_active_dek() == before
+
+
+def test_the_probe_survives_a_key_service_that_raises(monkeypatch):
+    """REQUIRE_KMS makes _wrap_dek raise instead of falling back. The probe has
+    to answer, not propagate -- it runs inside a scheduled task."""
+    from app.core import pii_crypto
+
+    def _boom(_):
+        raise RuntimeError("key is pending deletion")
+
+    monkeypatch.setattr(pii_crypto, "_wrap_dek", _boom)
+    assert pii_crypto.probe_backend() == "unknown"
+
+
+def test_the_check_is_actually_collected():
+    """An alert nobody runs is not an alert."""
+    import inspect
+
+    assert "_kms_check()" in inspect.getsource(ph.collect_checks)
+
+
+def test_a_critical_check_escalates_and_emails():
+    """The scheduled scan emails admins on escalation into warning/critical.
+    Confirming the wiring, since this check's whole value is being noticed
+    without anybody opening a dashboard."""
+    assert ph.is_worse("critical", "ok")
+    assert ph.is_worse("critical", "warning")
+    assert ph.rollup_status([{"status": "ok"}, {"status": "critical"}]) == "critical"

--- a/backend/tests/test_managed_boundary.py
+++ b/backend/tests/test_managed_boundary.py
@@ -1,0 +1,95 @@
+"""What the state owns, and what the town owns, on a hosted deployment.
+
+Managed mode is the answer to "can a town do no setup at all" -- a state agency
+runs the infrastructure and the town gets an instance. That only holds if the
+boundary is real: the town's admin has full rights over their own instance, so
+the guard on platform keys is the only thing standing between them and the
+state's encryption.
+
+It was hand-listed, and Google-shaped as a result. It named the GCP project,
+service account and KMS key path, and of Azure only the vault URL. Every AWS
+infrastructure key was missing, as were Azure's credentials and both provider
+selectors -- so on a state-hosted deployment running on AWS or Azure, a town
+admin could overwrite AWS_KMS_KEY_ID, KMS_PROVIDER or SECRETS_PROVIDER and
+repoint the state's encryption at a key of their own.
+
+Derived from DB_REQUIRED_KEYS now rather than listed, so it cannot drift again.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sqlalchemy")
+
+from app.core.managed import PLATFORM_MANAGED_KEYS, is_platform_managed
+from app.services.secret_manager import DB_REQUIRED_KEYS
+
+
+def test_every_storage_key_belongs_to_the_platform():
+    """DB_REQUIRED_KEYS is the authoritative set of "credentials for the secret
+    store, plus the KMS selection and key path", derived from the readers. In
+    managed mode the state owns the storage arrangement, so it owns all of
+    them -- there is no member of that set a town admin should be able to
+    change."""
+    assert not (DB_REQUIRED_KEYS - PLATFORM_MANAGED_KEYS)
+
+
+@pytest.mark.parametrize("key", [
+    "AWS_KMS_KEY_ID", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION",
+    "AZURE_KEYVAULT_CLIENT_SECRET", "AZURE_TENANT_ID", "AZURE_KEYVAULT_KEY",
+    "KMS_PROVIDER", "SECRETS_PROVIDER",
+])
+def test_the_keys_that_were_missing(key):
+    """Named individually because each was a live hole, and because a
+    regression here is silent: the write succeeds and the state finds out when
+    its own key stops being used."""
+    assert is_platform_managed(key), key
+
+
+@pytest.mark.parametrize("key", [
+    "SECRET_KEY", "DATABASE_URL", "DB_PASSWORD", "REDIS_URL",
+    "PROVISIONING_TOKEN", "DOMAIN",
+])
+def test_the_platform_still_owns_the_host_level_settings(key):
+    assert is_platform_managed(key), key
+
+
+@pytest.mark.parametrize("key", [
+    "TWILIO_AUTH_TOKEN", "GOOGLE_MAPS_API_KEY", "AUTH0_CLIENT_SECRET",
+    "SMTP_PASSWORD", "ACS_ACCESS_KEY", "REDACT_FACES",
+])
+def test_the_town_still_owns_its_own_services(key):
+    """The point of managed mode is that the state runs the plumbing and the
+    town runs its 311 service. Locking a town out of its own Twilio account
+    would make the arrangement useless."""
+    assert not is_platform_managed(key), key
+
+
+def test_backups_belong_to_the_platform():
+    """Prefix rule, not a listed key: the state takes the backups on a hosted
+    deployment, and a town pointing them at its own bucket would move resident
+    PII outside the arrangement the state is accountable for."""
+    assert is_platform_managed("BACKUP_S3_BUCKET")
+    assert is_platform_managed("BACKUP_ENCRYPTION_KEY")
+
+
+def test_the_set_answers_the_same_way_however_it_is_read():
+    """An earlier draft made this a lazily-resolving frozenset subclass. It
+    answered `in` correctly and returned empty for `set()` and iteration,
+    because CPython reads the underlying storage directly for those. A guard
+    that is right only for the operation you happened to test is worse than no
+    guard, so this checks the other readings too."""
+    assert len(PLATFORM_MANAGED_KEYS) == len(set(PLATFORM_MANAGED_KEYS))
+    assert len(list(PLATFORM_MANAGED_KEYS)) == len(PLATFORM_MANAGED_KEYS)
+    assert "AWS_KMS_KEY_ID" in set(PLATFORM_MANAGED_KEYS)
+
+
+def test_the_guard_is_off_when_managed_mode_is_off():
+    """Self-hosted is the default and must be untouched: a town running its own
+    instance owns every key on the page."""
+    from app.core.managed import reject_platform_key_writes
+    from app.core.config import get_settings
+
+    if get_settings().managed_mode:
+        pytest.skip("this environment has managed mode on")
+    reject_platform_key_writes("AWS_KMS_KEY_ID")  # must not raise

--- a/backend/tests/test_no_auto_update.py
+++ b/backend/tests/test_no_auto_update.py
@@ -1,0 +1,50 @@
+"""Nothing on a town's server updates itself.
+
+A Watchtower container shipped in the default compose file, pulling new images
+at 3am daily. The README described it as optional; no `profiles:` key made it
+so, and `docker compose up -d` started it.
+
+Its scope was also wrong. `WATCHTOWER_LABEL_ENABLE` was unset, so it acted on
+every container it could pull rather than on the application. On a source-built
+install the app services are `build:` with no registry, so Watchtower could not
+touch them -- but PostGIS, Redis and Caddy are pulled by tag, so those upgraded
+unattended. Exactly inverted: the database engine changed itself overnight on a
+municipal server while the application stayed put.
+
+Removed. Updates are now something a person decides to do, which is also the
+answer a state reviewer wants to the question "can anyone outside our
+organisation change what is running here".
+
+This test exists because the container is one line to add back, and it would be
+added back for a good reason -- unattended security patches are genuinely
+valuable for a town with no IT. If that argument wins later, it needs a profile
+and a label scope, not a re-paste.
+"""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = [ROOT / "docker-compose.yml", ROOT / "docker-compose.prod.yml",
+           ROOT / "docker-compose.demo.yml"]
+
+
+def test_no_compose_file_ships_an_auto_updater():
+    for path in COMPOSE:
+        if not path.exists():
+            continue
+        text = path.read_text().lower()
+        assert "watchtower" not in text, (
+            f"{path.name} ships an auto-updater. If this is deliberate it needs a "
+            f"compose profile so it is genuinely opt-in, and WATCHTOWER_LABEL_ENABLE "
+            f"with labels on the app services only -- otherwise it upgrades Postgres."
+        )
+
+
+def test_the_readme_tells_a_town_how_to_update_instead():
+    """Removing the automatic path without documenting the manual one would
+    leave towns on old, vulnerable versions -- worse than what was there."""
+    readme = (ROOT / "README.md").read_text()
+    assert "docker compose pull" in readme
+    assert "Take a backup first" in readme

--- a/backend/tests/test_provider_dispatch.py
+++ b/backend/tests/test_provider_dispatch.py
@@ -101,21 +101,38 @@ import sys
 import types
 
 
-async def test_get_secret_routes_to_azure_key_vault(monkeypatch):
-    fake = types.ModuleType("app.core.azure_keyvault")
+def _fake_store(monkeypatch, name: str, value_for: str, value: str):
+    """Stand a fake secret store in for a real one, both ways round.
+
+    `from app.core import azure_keyvault` reads the attribute off the already
+    imported `app.core` package before it ever consults sys.modules, so patching
+    sys.modules alone only worked while nothing else in the run had imported the
+    real module first. That made these two tests pass or fail depending on
+    collection order -- they passed for a year because no other test happened to
+    import app.core.azure_keyvault, and started failing the day one did.
+
+    Patching both the package attribute and sys.modules makes the substitution
+    hold regardless of what ran before.
+    """
+    import app.core
+
+    fake = types.ModuleType(f"app.core.{name}")
     fake.is_configured = lambda: True
-    fake.get_secret = lambda name: "azure-value" if name == "INTEGRATION_SDL_API_KEY" else None
-    monkeypatch.setitem(sys.modules, "app.core.azure_keyvault", fake)
+    fake.get_secret = lambda key: value if key == value_for else None
+    monkeypatch.setitem(sys.modules, f"app.core.{name}", fake)
+    monkeypatch.setattr(app.core, name, fake, raising=False)
+    return fake
+
+
+async def test_get_secret_routes_to_azure_key_vault(monkeypatch):
+    _fake_store(monkeypatch, "azure_keyvault", "INTEGRATION_SDL_API_KEY", "azure-value")
     monkeypatch.setattr(sm, "_secrets_provider", lambda: "azure")
 
     assert await sm.get_secret("INTEGRATION_SDL_API_KEY") == "azure-value"
 
 
 async def test_get_secret_routes_to_aws_secrets_manager(monkeypatch):
-    fake = types.ModuleType("app.core.aws_secretsmanager")
-    fake.is_configured = lambda: True
-    fake.get_secret = lambda name: "aws-value" if name == "INTEGRATION_CITYWORKS_API_KEY" else None
-    monkeypatch.setitem(sys.modules, "app.core.aws_secretsmanager", fake)
+    _fake_store(monkeypatch, "aws_secretsmanager", "INTEGRATION_CITYWORKS_API_KEY", "aws-value")
     monkeypatch.setattr(sm, "_secrets_provider", lambda: "aws")
 
     assert await sm.get_secret("INTEGRATION_CITYWORKS_API_KEY") == "aws-value"

--- a/backend/tests/test_provider_test_button.py
+++ b/backend/tests/test_provider_test_button.py
@@ -1,0 +1,98 @@
+"""Save & Test has to actually test.
+
+`test_provider` validated eight capabilities and could test three. Pressing the
+button on maps, email, text messages, encryption or photo redaction returned
+"A live test is not available for this capability" -- a control whose entire job
+is to say whether something works, telling five of eight cards that it cannot.
+The validation list was widened when those capabilities got catalogs; the tests
+behind it were not.
+
+Two of the five turn out to be the most valuable checks on the page, because
+they cover the two things that fail without saying so: which key is actually
+encrypting resident data, and whether the photo detector can answer at all.
+"""
+
+import inspect
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from app.api import system
+
+
+def _source():
+    return inspect.getsource(system.test_provider)
+
+
+def test_every_capability_the_endpoint_accepts_has_a_branch():
+    """The bug, stated directly: the accept-list and the implemented-list were
+    allowed to drift, and nothing noticed."""
+    source = _source()
+    missing = [
+        cap for cap in system._PROVIDER_SELECT_KEY
+        if f'capability == "{cap}"' not in source
+        and f'capability in ("email", "sms")' not in source or cap not in ("email", "sms")
+    ]
+    missing = [c for c in missing if f'"{c}"' not in source]
+    assert not missing, f"accepted but never tested: {sorted(missing)}"
+
+
+def test_encryption_is_tested_by_wrapping_a_key_not_by_reading_settings():
+    """A key name in a settings box proves nothing -- the name is still there
+    when the key is gone. Only a wrap says the arrangement still works."""
+    source = _source()
+    assert "probe_backend()" in source
+    assert "active_backend()" not in source, "that reads a process cache, not the key service"
+
+
+def test_encryption_fails_the_test_when_the_wrong_key_is_in_use():
+    """Selected Azure, wrapping with the application key. Everything still
+    encrypts, so nothing errors -- which is exactly why the button has to say
+    so rather than reporting a pass."""
+    source = _source()
+    assert "actual == selected" in source
+    assert "not being encrypted with the key" in source
+
+
+def test_redaction_reports_a_degraded_detector_as_a_failure():
+    """Falling back to on-server blurring contains the harm but is not what the
+    town chose, and a green tick would hide it."""
+    source = _source()
+    assert "degraded_from" in source
+
+
+@pytest.mark.parametrize("fn,provider,marker", [
+    ("_test_maps", "google", "maps.googleapis.com"),
+    ("_test_maps", "azure", "atlas.microsoft.com"),
+    ("_test_maps", "esri", "findAddressCandidates"),
+    ("_test_delivery", "twilio", "api.twilio.com"),
+    ("_test_delivery", "ses", "get_send_quota"),
+    ("_test_delivery", "sns", "get_sms_attributes"),
+])
+def test_the_live_checks_call_the_provider(fn, provider, marker):
+    """Each of these makes a real call that reads rather than sends, so the
+    button is safe to press repeatedly and still means something."""
+    assert marker in inspect.getsource(getattr(system, fn)), (fn, provider)
+
+
+def test_nothing_a_resident_would_receive_is_sent():
+    """A test button that texts somebody is a test button people stop pressing."""
+    source = inspect.getsource(system._test_delivery)
+    for sending in ("send_email", "sendmail", "SendMessage", "publish(", "send_raw_email"):
+        assert sending not in source, sending
+
+
+def test_the_ses_sandbox_is_reported_rather_than_passed():
+    """SES credentials work perfectly inside the sandbox and deliver nothing to
+    residents. A green tick there is worse than no button."""
+    assert "sandbox" in inspect.getsource(system._test_delivery)
+
+
+def test_an_unverifiable_provider_is_not_recorded_as_a_failure():
+    """A generic HTTP SMS gateway cannot be exercised without sending a text.
+    "We cannot check this from here" is not "this is broken", and a red badge
+    that can never go green teaches people to ignore badges."""
+    assert inspect.getsource(system._unverifiable).count("recorded") >= 1
+    source = _source()
+    assert 'outcome.get("recorded", True)' in source, "unverifiable results must skip _remember"

--- a/backend/tests/test_provider_test_button.py
+++ b/backend/tests/test_provider_test_button.py
@@ -1,18 +1,20 @@
-"""Save & Test has to actually test.
+"""Save & Test has to actually test — checked by calling it, not by reading it.
 
-`test_provider` validated eight capabilities and could test three. Pressing the
+The endpoint validated eight capabilities and could test three. Pressing the
 button on maps, email, text messages, encryption or photo redaction returned
 "A live test is not available for this capability" -- a control whose entire job
-is to say whether something works, telling five of eight cards that it cannot.
-The validation list was widened when those capabilities got catalogs; the tests
+is to say whether something works, saying it could not, on five of eight cards.
+The accept-list was widened when those capabilities got catalogs; the branches
 behind it were not.
 
-Two of the five turn out to be the most valuable checks on the page, because
-they cover the two things that fail without saying so: which key is actually
-encrypting resident data, and whether the photo detector can answer at all.
+Every check is now a named function behind one dispatch table, which is what
+makes these tests assertions about behaviour rather than string searches
+through a large endpoint. The earlier version of this file was the latter, and
+it would have passed against code that was wrong in any way the strings did not
+happen to mention.
 """
 
-import inspect
+import asyncio
 
 import pytest
 
@@ -21,78 +23,214 @@ pytest.importorskip("fastapi")
 from app.api import system
 
 
-def _source():
-    return inspect.getsource(system.test_provider)
+def _run(coro):
+    return asyncio.run(coro)
 
 
-def test_every_capability_the_endpoint_accepts_has_a_branch():
-    """The bug, stated directly: the accept-list and the implemented-list were
-    allowed to drift, and nothing noticed."""
-    source = _source()
-    missing = [
-        cap for cap in system._PROVIDER_SELECT_KEY
-        if f'capability == "{cap}"' not in source
-        and f'capability in ("email", "sms")' not in source or cap not in ("email", "sms")
-    ]
-    missing = [c for c in missing if f'"{c}"' not in source]
-    assert not missing, f"accepted but never tested: {sorted(missing)}"
+# ---------------------------------------------------------------------------
+# The drift that caused it
+# ---------------------------------------------------------------------------
+
+def test_every_accepted_capability_has_a_check():
+    """The bug, as data rather than prose: two lists that had to agree, kept
+    apart, and nothing noticing when one moved."""
+    assert set(system._PROVIDER_SELECT_KEY) == set(system._CAPABILITY_TESTS)
 
 
-def test_encryption_is_tested_by_wrapping_a_key_not_by_reading_settings():
-    """A key name in a settings box proves nothing -- the name is still there
-    when the key is gone. Only a wrap says the arrangement still works."""
-    source = _source()
-    assert "probe_backend()" in source
-    assert "active_backend()" not in source, "that reads a process cache, not the key service"
+def test_every_check_is_callable_and_async():
+    for capability, check in system._CAPABILITY_TESTS.items():
+        assert callable(check), capability
+        assert asyncio.iscoroutinefunction(check) or callable(check(None).close() or check), capability
 
 
-def test_encryption_fails_the_test_when_the_wrong_key_is_in_use():
-    """Selected Azure, wrapping with the application key. Everything still
-    encrypts, so nothing errors -- which is exactly why the button has to say
-    so rather than reporting a pass."""
-    source = _source()
-    assert "actual == selected" in source
-    assert "not being encrypted with the key" in source
+# ---------------------------------------------------------------------------
+# Encryption — the check that catches a silent fallback
+# ---------------------------------------------------------------------------
+
+def test_encryption_passes_when_the_selected_key_did_the_wrapping(monkeypatch):
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "azure")
+    monkeypatch.setattr(pii_crypto, "probe_backend", lambda: "azure")
+
+    result = _run(system._test_kms())
+    assert result["ok"] is True
+    assert "Azure Key Vault" in result["detail"]
 
 
-def test_redaction_reports_a_degraded_detector_as_a_failure():
-    """Falling back to on-server blurring contains the harm but is not what the
-    town chose, and a green tick would hide it."""
-    source = _source()
-    assert "degraded_from" in source
+def test_encryption_fails_when_something_else_did_the_wrapping(monkeypatch):
+    """Selected Azure, wrapped with the application key. Nothing errors --
+    encryption still happens -- which is exactly why the button must say so."""
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "azure")
+    monkeypatch.setattr(pii_crypto, "probe_backend", lambda: "local")
+
+    result = _run(system._test_kms())
+    assert result["ok"] is False
+    assert "azure" in result["detail"] and "local" in result["detail"]
 
 
-@pytest.mark.parametrize("fn,provider,marker", [
-    ("_test_maps", "google", "maps.googleapis.com"),
-    ("_test_maps", "azure", "atlas.microsoft.com"),
-    ("_test_maps", "esri", "findAddressCandidates"),
-    ("_test_delivery", "twilio", "api.twilio.com"),
-    ("_test_delivery", "ses", "get_send_quota"),
-    ("_test_delivery", "sns", "get_sms_attributes"),
-])
-def test_the_live_checks_call_the_provider(fn, provider, marker):
-    """Each of these makes a real call that reads rather than sends, so the
-    button is safe to press repeatedly and still means something."""
-    assert marker in inspect.getsource(getattr(system, fn)), (fn, provider)
+def test_encryption_asks_the_key_service_rather_than_a_cache(monkeypatch):
+    """active_backend() reports the data key this process wrapped at startup.
+    In a worker up for a week it describes the world as it was a week ago, and
+    would keep passing through an entire key-deletion window."""
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: "google")
+    monkeypatch.setattr(pii_crypto, "active_backend",
+                        lambda: (_ for _ in ()).throw(AssertionError("read the cache")))
+    monkeypatch.setattr(pii_crypto, "probe_backend", lambda: "google")
+
+    assert _run(system._test_kms())["ok"] is True
 
 
-def test_nothing_a_resident_would_receive_is_sent():
-    """A test button that texts somebody is a test button people stop pressing."""
-    source = inspect.getsource(system._test_delivery)
-    for sending in ("send_email", "sendmail", "SendMessage", "publish(", "send_raw_email"):
-        assert sending not in source, sending
+# ---------------------------------------------------------------------------
+# Photo redaction
+# ---------------------------------------------------------------------------
+
+def test_redaction_passes_when_the_chosen_detector_works(monkeypatch):
+    from app.services import image_redaction as ir
+
+    async def _resolve():
+        return "google"
+
+    async def _effective(p):
+        return "google", None
+
+    monkeypatch.setattr(ir, "resolve_provider", _resolve)
+    monkeypatch.setattr(ir, "effective_provider", _effective)
+
+    assert _run(system._test_redaction())["ok"] is True
 
 
-def test_the_ses_sandbox_is_reported_rather_than_passed():
-    """SES credentials work perfectly inside the sandbox and deliver nothing to
-    residents. A green tick there is worse than no button."""
-    assert "sandbox" in inspect.getsource(system._test_delivery)
+def test_redaction_fails_when_it_has_quietly_degraded(monkeypatch):
+    """Falling back to on-server blurring contains the harm. It is still not
+    what the town chose, and a green tick would hide it."""
+    from app.services import image_redaction as ir
+
+    async def _resolve():
+        return "azure"
+
+    async def _effective(p):
+        return "local", "azure"
+
+    monkeypatch.setattr(ir, "resolve_provider", _resolve)
+    monkeypatch.setattr(ir, "effective_provider", _effective)
+
+    result = _run(system._test_redaction())
+    assert result["ok"] is False
+    assert "azure" in result["detail"]
 
 
-def test_an_unverifiable_provider_is_not_recorded_as_a_failure():
-    """A generic HTTP SMS gateway cannot be exercised without sending a text.
+def test_redaction_fails_loudly_when_nothing_can_blur(monkeypatch):
+    from app.services import image_redaction as ir
+
+    async def _resolve():
+        return "azure"
+
+    async def _effective(p):
+        return "azure", "azure"
+
+    monkeypatch.setattr(ir, "resolve_provider", _resolve)
+    monkeypatch.setattr(ir, "effective_provider", _effective)
+
+    result = _run(system._test_redaction())
+    assert result["ok"] is False
+    assert "without blurring" in result["detail"]
+
+
+def test_redaction_switched_off_is_not_a_failure(monkeypatch):
+    from app.services import image_redaction as ir
+
+    async def _resolve():
+        return None
+
+    monkeypatch.setattr(ir, "resolve_provider", _resolve)
+    assert _run(system._test_redaction())["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Delivery — nothing a resident would receive
+# ---------------------------------------------------------------------------
+
+def _secrets(**values):
+    async def _get(key):
+        return values.get(key)
+    return _get
+
+
+def test_texting_switched_off_is_not_a_failure(monkeypatch):
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(SMS_PROVIDER="none"))
+    assert _run(system._test_delivery("sms"))["ok"] is True
+
+
+def test_twilio_without_credentials_says_which_are_missing(monkeypatch):
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(SMS_PROVIDER="twilio"))
+    result = _run(system._test_delivery("sms"))
+    assert result["ok"] is False
+    assert "SID" in result["detail"]
+
+
+def test_smtp_without_a_host_says_so(monkeypatch):
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(EMAIL_PROVIDER="smtp"))
+    result = _run(system._test_delivery("email"))
+    assert result["ok"] is False
+    assert "SMTP host" in result["detail"]
+
+
+def test_a_provider_with_no_safe_check_is_not_recorded_as_broken(monkeypatch):
+    """A generic HTTP gateway cannot be exercised without sending a real text.
     "We cannot check this from here" is not "this is broken", and a red badge
     that can never go green teaches people to ignore badges."""
-    assert inspect.getsource(system._unverifiable).count("recorded") >= 1
-    source = _source()
-    assert 'outcome.get("recorded", True)' in source, "unverifiable results must skip _remember"
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(SMS_PROVIDER="http"))
+
+    result = _run(system._test_delivery("sms"))
+    assert result["recorded"] is False
+
+
+def test_an_unrecorded_outcome_skips_the_health_write():
+    """The endpoint must honour that flag, or the distinction is decorative."""
+    import inspect
+    source = inspect.getsource(system.test_provider)
+    assert 'outcome.get("recorded") is False' in source
+
+
+def test_no_check_sends_anything_to_a_resident(monkeypatch):
+    """A test button that texts somebody is a test button people stop pressing.
+
+    Asserted by running every delivery path with no credentials and confirming
+    none of them reaches a send: each returns a dict rather than raising, and
+    the send helpers are not imported at module scope where they could be."""
+    from app.services import secret_manager
+
+    for provider in ("none", "twilio", "sns", "acs", "http"):
+        monkeypatch.setattr(secret_manager, "get_secret", _secrets(SMS_PROVIDER=provider))
+        assert isinstance(_run(system._test_delivery("sms")), dict), provider
+    for provider in ("smtp", "ses", "acs"):
+        monkeypatch.setattr(secret_manager, "get_secret", _secrets(EMAIL_PROVIDER=provider))
+        assert isinstance(_run(system._test_delivery("email")), dict), provider
+
+
+# ---------------------------------------------------------------------------
+# Maps
+# ---------------------------------------------------------------------------
+
+def test_maps_without_a_key_says_which_key(monkeypatch):
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(MAPS_PROVIDER="google"))
+    result = _run(system._test_maps())
+    assert result["ok"] is False
+    assert "Google Maps API key" in result["detail"]
+
+
+def test_apple_maps_is_unverifiable_rather_than_failing(monkeypatch):
+    """It needs a token signed in the browser, so there is genuinely nothing to
+    check from the server."""
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "get_secret", _secrets(MAPS_PROVIDER="apple"))
+    assert _run(system._test_maps())["recorded"] is False

--- a/backend/tests/test_redaction_default.py
+++ b/backend/tests/test_redaction_default.py
@@ -1,0 +1,103 @@
+"""A fresh install must blur photos, and must say what it is doing.
+
+Before this, a deployment with no cloud credentials did neither.
+`resolve_provider()` fell through Google, then the moderation provider, then the
+AI provider, and returned None -- because `local` was deliberately excluded from
+the fall-through on the reasoning that OpenCV quality is low enough to deserve a
+decision rather than a default.
+
+That reasoning compares local against a cloud detector. The real alternative,
+on a deployment with no cloud account, is no detection at all. Every resident
+photo was stored unmodified: faces of neighbours and passers-by, licence plates
+of parked cars, in a public record.
+
+And the page said otherwise. The catalog default was "google", so the Photo
+Redaction card displayed Google Cloud Vision as the provider while the runtime
+had redaction switched off entirely. The behaviour and the interface disagreed,
+and the interface was the reassuring one.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from app.services import image_redaction as ir
+
+
+def _resolve(**secrets):
+    """resolve_provider() with a given set of configured secrets."""
+    async def _fake(key):
+        return secrets.get(key)
+
+    from app.services import secret_manager
+    original = secret_manager.get_secret
+    secret_manager.get_secret = _fake
+    try:
+        return asyncio.run(ir.resolve_provider())
+    finally:
+        secret_manager.get_secret = original
+
+
+def test_a_bare_install_blurs():
+    """The case that was broken. Nothing configured, no cloud account, and the
+    answer has to be a detector that runs here rather than None."""
+    assert _resolve() == "local"
+
+
+def test_both_toggles_are_on_for_a_bare_install():
+    """settings() already defaulted these to True and documented why. They were
+    inert because the provider resolved to None first."""
+    async def _fake(key):
+        return None
+
+    from app.services import secret_manager
+    original = secret_manager.get_secret
+    secret_manager.get_secret = _fake
+    try:
+        provider, faces, plates = asyncio.run(ir.settings())
+    finally:
+        secret_manager.get_secret = original
+
+    assert provider == "local"
+    assert faces is True
+    assert plates is True
+
+
+def test_the_card_names_the_detector_that_is_actually_running():
+    """The catalog default fed the UI. Showing Google Cloud Vision on an install
+    with no Google account is the half of this bug that made it invisible."""
+    from app.services.delivery_providers import normalize_provider
+    assert normalize_provider("redaction", None) == "local"
+
+
+def test_a_town_can_still_turn_it_off_deliberately():
+    """Local is the floor, not a lock. The distinction that matters is between
+    a town deciding not to blur and a town not knowing it wasn't."""
+    assert _resolve(REDACTION_PROVIDER="none") is None
+    assert _resolve(REDACTION_PROVIDER="off") is None
+    assert _resolve(REDACTION_PROVIDER="disabled") is None
+
+
+def test_an_explicit_choice_still_wins():
+    assert _resolve(REDACTION_PROVIDER="azure") == "azure"
+    assert _resolve(REDACTION_PROVIDER="google") == "google"
+
+
+def test_a_town_with_cloud_credentials_still_gets_the_better_detector():
+    """The fall-through exists so somebody who already pasted one set of cloud
+    credentials gets redaction without configuring a second thing. Making local
+    the floor must not shadow that."""
+    assert _resolve(MODERATION_PROVIDER="google") == "google"
+    assert _resolve(AI_PROVIDER="vertex") == "google"
+    assert _resolve(AI_PROVIDER="bedrock") == "aws"
+    assert _resolve(AI_PROVIDER="azure") == "azure"
+
+
+def test_local_detection_needs_no_credential():
+    """The reason this is a safe floor: nothing to configure, nothing to pay
+    for, and no resident photo leaves the building."""
+    from app.services.delivery_providers import REDACTION_CATALOG
+    offered = {f["key"] for f in REDACTION_CATALOG["local"]["credential_fields"]}
+    assert offered == {"REDACT_FACES", "REDACT_PLATES"}

--- a/backend/tests/test_redaction_fallback.py
+++ b/backend/tests/test_redaction_fallback.py
@@ -1,0 +1,108 @@
+"""A detector that cannot answer must not look like a photo with nobody in it.
+
+Every cloud detector returns an empty result when it has no credentials, and so
+does a photo of an empty street. `vision_annotate` says as much in its own
+docstring -- "callers can treat 'no credentials' the same as 'nothing
+detected'." For content moderation that conflation is tolerable. For redaction
+it is the difference between an empty street and somebody's face on a municipal
+website.
+
+`redact_image` had already named this: "a town whose Vision credentials quietly
+expired will publish unblurred faces and only find out from the admin console",
+and concluded the fix was to surface it loudly. Surfacing is not the best
+available answer. Falling back to the detector that needs no credentials is --
+it blurs less well than the cloud, but it blurs, and the choice is no longer
+between publishing a face and refusing the resident's report.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from app.services import image_redaction as ir
+
+
+def _effective(usable):
+    """effective_provider() with a given set of working detectors."""
+    async def _fake(provider):
+        return provider in usable
+
+    original = ir._usable
+    ir._usable = _fake
+    try:
+        return asyncio.run(ir.effective_provider(_effective.selected))
+    finally:
+        ir._usable = original
+
+
+def _run(selected, usable):
+    _effective.selected = selected
+    return _effective(usable)
+
+
+def test_a_cloud_detector_without_credentials_degrades_rather_than_disappearing():
+    """The bug. Azure selected, no keys entered -- previously every photo was
+    stored unblurred and the card stayed green."""
+    provider, degraded_from = _run("azure", usable={"local"})
+    assert provider == "local"
+    assert degraded_from == "azure"
+
+
+@pytest.mark.parametrize("cloud", ["google", "aws", "azure"])
+def test_every_cloud_detector_degrades_the_same_way(cloud):
+    provider, degraded_from = _run(cloud, usable={"local"})
+    assert (provider, degraded_from) == ("local", cloud)
+
+
+def test_a_working_detector_is_left_alone():
+    """The fallback must not shadow a correctly configured cloud detector --
+    it finds more than OpenCV does, which is why a town paid for it."""
+    provider, degraded_from = _run("google", usable={"google", "local"})
+    assert provider == "google"
+    assert degraded_from is None
+
+
+def test_local_selected_and_working_is_not_a_degradation():
+    provider, degraded_from = _run("local", usable={"local"})
+    assert provider == "local"
+    assert degraded_from is None
+
+
+def test_when_nothing_can_blur_it_is_reported_as_such():
+    """OpenCV missing from the image too. The photo is still kept -- dropping it
+    punishes the resident for the town's problem -- but this must not be
+    reported as "we looked and there was nobody there"."""
+    provider, degraded_from = _run("azure", usable=set())
+    assert degraded_from == provider, "caller detects total failure by this equality"
+
+
+def test_redact_image_distinguishes_no_detector_from_no_detections():
+    """Everything downstream reads skipped_reason. `no-detections` means we
+    looked; `no-detector` means we could not. Collapsing them is how the
+    original bug stayed invisible."""
+    import inspect
+    source = inspect.getsource(ir.redact_image)
+    assert '"no-detector"' in source
+    assert '"no-detections"' in source
+
+
+def test_the_fallback_is_actually_used_by_the_redaction_path():
+    """A helper nothing calls is a comment."""
+    import inspect
+    assert "effective_provider(" in inspect.getsource(ir.redact_image)
+
+
+def test_the_health_check_reports_a_degraded_detector():
+    """Degrading contains the harm; it does not make it fine. A town paying for
+    Azure and silently running on OpenCV is getting worse detection than it
+    thinks, and should be told."""
+    from app.services import proactive_health as ph
+    import inspect
+
+    source = inspect.getsource(ph._redaction_check)
+    assert "degraded_from" in source
+    assert '"warning"' in source
+    assert '"critical"' in source
+    assert "_redaction_check()" in inspect.getsource(ph.collect_checks)

--- a/backend/tests/test_registration_form_contract.py
+++ b/backend/tests/test_registration_form_contract.py
@@ -1,0 +1,99 @@
+"""The registration form must send only what somebody typed.
+
+Pinpoint makes no automatic calls to its maintainers. COMPLIANCE.md now states
+one voluntary exception -- a form an administrator fills in and submits -- and
+the value of that disclosure rests entirely on the payload matching it. A
+version string added to the request later, however reasonably, would turn a
+documented exception into an undocumented one, and nobody reviewing the
+application for a town would have any reason to re-read the file.
+
+So the shape is pinned here rather than trusted to review. This is a frontend
+component checked from the backend suite for the same reason as the setup-step
+content: it is the only suite that runs on every change.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPONENT = ROOT / "frontend/src/components/StayInformed.tsx"
+COMPLIANCE = ROOT / "COMPLIANCE.md"
+
+# Everything the form is allowed to transmit: the typed fields, the two consent
+# booleans, and the anti-spam field that is submitted empty.
+ALLOWED = {
+    "organization", "contact_name", "contact_email", "contact_role",
+    "deployment_url", "region", "usage",
+    "consent_updates", "consent_public_listing",
+    "website",
+}
+
+
+@pytest.fixture(scope="module")
+def source():
+    if not COMPONENT.exists():
+        pytest.skip("frontend not present in this checkout")
+    return COMPONENT.read_text()
+
+
+def test_the_payload_carries_nothing_that_was_not_typed(source):
+    """The claim in COMPLIANCE.md, as a test. Adding a field to FormState is the
+    natural way this would be broken, so the check is on FormState itself rather
+    than on the fetch call."""
+    block = re.search(r"interface FormState \{(.*?)\n\}", source, re.S)
+    assert block, "expected a FormState interface"
+    declared = set(re.findall(r"^\s{4}(\w+):", block.group(1), re.M))
+    assert declared == ALLOWED, (
+        f"payload changed. unexpected: {sorted(declared - ALLOWED)}, "
+        f"missing: {sorted(ALLOWED - declared)}. If this is intentional, "
+        f"COMPLIANCE.md has to change in the same commit."
+    )
+
+
+def test_the_request_body_is_the_form_and_nothing_else(source):
+    """`JSON.stringify(form)` and not `{...form, extra}`. A spread with anything
+    appended is the other way a diagnostic could arrive without the interface
+    changing."""
+    assert "JSON.stringify(form)" in source
+    assert "...form" not in source
+
+
+def test_nothing_is_sent_without_a_submit(source):
+    """One fetch, in the submit handler. A useEffect that posted on mount would
+    make every claim in this file and in COMPLIANCE.md false."""
+    assert source.count("fetch(") == 1
+    submit = re.search(r"async function submit\(.*?\n    \}", source, re.S)
+    assert submit and "fetch(" in submit.group(0), "the only fetch must be in submit()"
+
+
+def test_the_request_carries_no_cookies(source):
+    """`credentials` unset means omit for a cross-origin request. Setting it to
+    include would send whatever cookies a town's domain happens to hold to a
+    third party, for no benefit -- the endpoint is unauthenticated."""
+    assert "credentials:" not in source
+
+
+def test_a_failed_submission_degrades_to_the_link(source):
+    """A municipal network that blocks outbound traffic has not done anything
+    wrong. Showing it an error would read as a fault in the platform, and the
+    fallback is the same form on the website."""
+    assert "'fallback'" in source
+    assert "REGISTRATION_FORM_URL" in source
+
+
+def test_dismissal_is_permanent_and_the_way_back_is_not(source):
+    """Two flags. One would mean "Not now" removes the only path back to the
+    form, which is not what an optional prompt should do."""
+    assert "MODAL_KEY" in source and "BANNER_KEY" in source
+
+
+def test_compliance_documents_the_exception(source):
+    """The disclosure is the point -- an undocumented outbound call would be
+    worse than no form. Checked against the field list so the two cannot drift."""
+    text = COMPLIANCE.read_text()
+    assert "registration" in text.lower()
+    assert "StayInformed.tsx" in text
+    for phrase in ("browser", "Submit"):
+        assert phrase in text

--- a/backend/tests/test_secret_migration_safety.py
+++ b/backend/tests/test_secret_migration_safety.py
@@ -1,0 +1,103 @@
+"""Secrets the migration must never scrub out of the database.
+
+`migrate_to_secret_manager` writes every configured secret to Secret Manager,
+verifies it reads back, and then clears the encrypted database copy. That is the
+right shape -- except that it excluded only the two Google bootstrap keys, and
+two other groups cannot survive it.
+
+Circularity. `AZURE_KEYVAULT_CLIENT_SECRET`, `AWS_ACCESS_KEY_ID` and the rest
+are the credentials *for* the secret store. Moving them into the store they
+unlock leaves nothing able to open it. Google's pair was already excluded for
+exactly this reason; the other two clouds' equivalents were not.
+
+Reader mismatch, which is the worse one. KMS configuration is read by
+`encryption._get_config_sync` and `aws_kms._cfg` -- both look at the environment,
+then the database, and never consult Secret Manager. So migrating `KMS_KEY_ID`
+succeeded, verified against GCP, and then scrubbed the only copy anything could
+actually read. `pii_crypto` would fall back to wrapping the data key with the
+application SECRET_KEY: no exception, nothing logged above DEBUG, and no
+indication on the page that the KMS a town had selected was no longer in use.
+
+This was reachable only by hand until photo redaction and PII encryption got
+cards, which is what makes it worth a test rather than a comment.
+"""
+
+import re
+
+import pytest
+
+from app.services.secret_manager import DB_REQUIRED_KEYS
+
+SYNC_READER_SOURCES = (
+    "app/core/encryption.py",
+    "app/core/aws_kms.py",
+    "app/core/azure_keyvault.py",
+    "app/core/aws_secretsmanager.py",
+)
+
+
+def _keys_read_synchronously():
+    """Every key fetched through a reader that cannot see Secret Manager."""
+    keys = set()
+    for path in SYNC_READER_SOURCES:
+        try:
+            source = open(path).read()
+        except OSError:
+            continue
+        keys |= set(re.findall(r'(?:_get_config_sync|_cfg)\("([A-Z0-9_]+)"\)', source))
+    return keys
+
+
+def test_every_synchronously_read_key_keeps_its_database_copy():
+    """The migration cannot move a key whose only reader looks in the database.
+
+    Written against the readers rather than a hand-listed set, so adding a
+    `_cfg("NEW_KEY")` to the KMS code fails here instead of silently becoming
+    scrubbable.
+    """
+    sync_keys = _keys_read_synchronously()
+    assert sync_keys, "expected to find synchronously-read config keys"
+    unprotected = sync_keys - DB_REQUIRED_KEYS
+    assert not unprotected, (
+        "these are read only from env/database but would be scrubbed after "
+        f"migration: {sorted(unprotected)}"
+    )
+
+
+def test_the_secret_stores_own_credentials_are_protected():
+    """Storing the key to the safe inside the safe."""
+    for key in (
+        "GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT",
+        "AZURE_KEYVAULT_URL", "AZURE_KEYVAULT_CLIENT_SECRET", "AZURE_TENANT_ID",
+        "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+    ):
+        assert key in DB_REQUIRED_KEYS, key
+
+
+def test_the_kms_selection_and_key_path_are_protected():
+    """Losing these does not fail loudly -- it downgrades PII encryption to the
+    application key without saying so."""
+    for key in ("KMS_PROVIDER", "KMS_LOCATION", "KMS_KEY_RING", "KMS_KEY_ID", "AWS_KMS_KEY_ID"):
+        assert key in DB_REQUIRED_KEYS, key
+
+
+def test_ordinary_provider_secrets_are_still_migrated():
+    """The point of the migration survives: things with an async reader move."""
+    for key in (
+        "AUTH0_CLIENT_SECRET", "TWILIO_AUTH_TOKEN", "SMTP_PASSWORD",
+        "GOOGLE_MAPS_API_KEY", "ACS_ACCESS_KEY",
+    ):
+        assert key not in DB_REQUIRED_KEYS, key
+
+
+def test_the_migration_consults_the_set_in_both_places():
+    """It has to skip the write *and* the scrub. Skipping only the write would
+    still leave the scrub loop clearing a key it had not migrated."""
+    pytest.importorskip("sqlalchemy")
+    import inspect
+
+    from app.services import secret_manager
+
+    src = inspect.getsource(secret_manager.migrate_to_secret_manager)
+    assert "bootstrap_keys = set(DB_REQUIRED_KEYS)" in src
+    assert "not in DB_REQUIRED_KEYS" in src, "the scrub loop must check it too"

--- a/backend/tests/test_secret_migration_safety.py
+++ b/backend/tests/test_secret_migration_safety.py
@@ -33,6 +33,11 @@ SYNC_READER_SOURCES = (
     "app/core/aws_kms.py",
     "app/core/azure_keyvault.py",
     "app/core/aws_secretsmanager.py",
+    # Reads SECRETS_PROVIDER the same way -- env, then database. It was missing
+    # from this list, and so was the key: the migration would have scrubbed the
+    # only record of which store a town had chosen, defaulting them back to
+    # Google and leaving nothing able to read anything.
+    "app/services/secret_manager.py",
 )
 
 

--- a/backend/tests/test_secret_store_ordering.py
+++ b/backend/tests/test_secret_store_ordering.py
@@ -1,0 +1,65 @@
+"""Where a provider credential actually lands, and whether anyone is told.
+
+The credentials that make the secret store reachable -- the Google Cloud project
+and service-account JSON, or the Key Vault / AWS equivalents -- are entered on
+the same page as everything else. So there is an ordering trap: save an Auth0
+secret before those, and `set_secret` finds no store, returns False, and logs at
+DEBUG. Nothing raises that logger above WARNING, so the line went nowhere.
+
+`_persist_secret` only ever warned on an *exception*, never on that False, and
+returned nothing. The secret sat in the encrypted database, the card showed a
+green tick, and the town's secret store stayed empty -- discoverable only by
+someone who knew to run the migration endpoint.
+
+The encrypted database is a supported store, so this is not an error. It is
+something the town has to be told, because the fix is trivial and invisible:
+enter the cloud credentials, then press Save & Test again.
+"""
+
+import inspect
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from app.api import system
+
+
+def test_persist_secret_reports_whether_the_store_took_it():
+    """It used to return None, so the caller could not have known either way."""
+    src = inspect.getsource(system._persist_secret)
+    assert "-> bool" in src
+    assert "return stored_externally" in src
+
+
+def test_the_bootstrap_keys_stay_out_of_the_secret_store():
+    """Storing the credentials that unlock the store inside the store is
+    circular -- they have to be readable before it is reachable."""
+    src = inspect.getsource(system._persist_secret)
+    assert "GCP_SERVICE_ACCOUNT_JSON" in src and "GOOGLE_CLOUD_PROJECT" in src
+    assert "stored_externally = key_name in bootstrap_keys" in src
+
+
+def test_saving_a_provider_tracks_credentials_that_only_reached_the_database():
+    src = inspect.getsource(system.save_provider)
+    assert "db_only" in src, "the save path must notice a database-only write"
+    # And must act on it rather than collecting it and moving on.
+    assert "if db_only:" in src
+
+
+def test_the_town_is_told_which_store_it_landed_in():
+    """Naming the store matters: 'not saved to the secret store' is alarming and
+    wrong, and the message has to say which one was expected."""
+    src = inspect.getsource(system.save_provider)
+    assert "encrypted database" in src
+    for store in ("Azure Key Vault", "AWS Secrets Manager", "Google Secret Manager"):
+        assert store in src, store
+
+
+def test_it_is_advisory_rather_than_a_failure():
+    """The encrypted database really is a supported store. Failing the save
+    would turn a working configuration into a dead end."""
+    src = inspect.getsource(system.save_provider)
+    assert '"severity": "info"' in src
+    # The response still reports success.
+    assert '"ok": True' in src

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -1,0 +1,156 @@
+"""The setup instructions must name credential keys that actually exist.
+
+`setupStepsContent.tsx` is prose about somebody else's console, and prose cannot
+be tested. What can be tested is the part of it that is load-bearing: each step
+declares `fields: ['SOME_KEY']`, and the card renders exactly those inputs
+beneath that step. A key invented from memory renders a box that looks like
+every other box, accepts what a clerk types, and saves it to a name nothing
+reads -- which is indistinguishable, from the clerk's side, from a credential
+that does not work.
+
+That is not hypothetical. Three keys in an earlier draft of this file were
+wrong: TWILIO_FROM_NUMBER for TWILIO_PHONE_NUMBER, SMS_API_URL for
+SMS_HTTP_API_URL, and AZURE_KEY_VAULT_URL for AZURE_KEYVAULT_URL. All three were
+plausible, none existed, and nothing would have said so.
+
+So this parses the TSX and checks every declaration against the catalogs the
+save endpoint validates against -- the same dicts, not a copy of them.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+CONTENT = Path(__file__).resolve().parents[2] / "frontend/src/components/setupStepsContent.tsx"
+
+
+def _catalogs():
+    from app.services.ai.registry import AI_CATALOG
+    from app.services.delivery_providers import _CATALOGS
+    from app.services.identity import IDENTITY_CATALOG
+    from app.services.map_provider import MAP_CATALOG
+    from app.services.translation_providers import TRANSLATION_CATALOG
+
+    return {
+        "ai": AI_CATALOG,
+        "translation": TRANSLATION_CATALOG,
+        "identity": IDENTITY_CATALOG,
+        "maps": MAP_CATALOG,
+        **_CATALOGS,
+    }
+
+
+def _declarations():
+    """[(capability, provider, [field keys]), ...] as written in the TSX.
+
+    Each defineSteps call runs to the next one, so the fields between two calls
+    belong to the first -- which is what lets a plain scan attribute keys to
+    providers without parsing JSX.
+    """
+    source = CONTENT.read_text()
+    calls = list(re.finditer(r"defineSteps\(\s*'([a-z]+)'\s*,\s*'([a-z0-9]+)'", source))
+    out = []
+    for i, call in enumerate(calls):
+        end = calls[i + 1].start() if i + 1 < len(calls) else len(source)
+        body = source[call.start():end]
+        fields = []
+        for block in re.findall(r"fields:\s*\[([^\]]*)\]", body):
+            fields += re.findall(r"'([A-Z0-9_]+)'", block)
+        out.append((call.group(1), call.group(2), fields))
+    return out
+
+
+@pytest.fixture(scope="module")
+def declarations():
+    if not CONTENT.exists():
+        pytest.skip("frontend not present in this checkout")
+    found = _declarations()
+    assert found, "expected to parse defineSteps declarations out of the TSX"
+    return found
+
+
+def test_every_step_names_a_real_capability_and_provider(declarations):
+    """A typo'd provider id registers steps under a key nothing looks up, so the
+    card silently falls back to its plain field list and the instructions vanish
+    with no error anywhere."""
+    catalogs = _catalogs()
+    for capability, provider, _ in declarations:
+        assert capability in catalogs, f"unknown capability: {capability}"
+        assert provider in catalogs[capability], f"unknown provider: {capability}:{provider}"
+
+
+def test_every_declared_field_exists_in_that_providers_catalog(declarations):
+    """The failure this file is here for. The save endpoint rejects any key not
+    in the provider's credential_fields, so a wrong key here is a box whose
+    contents are refused -- or, worse, one whose contents are accepted under a
+    name no reader consults."""
+    catalogs = _catalogs()
+    problems = []
+    for capability, provider, fields in declarations:
+        entry = catalogs.get(capability, {}).get(provider)
+        if not entry:
+            continue
+        real = {f["key"] for f in entry.get("credential_fields", [])}
+        for key in fields:
+            if key not in real:
+                problems.append(f"{capability}:{provider} declares {key}; catalog has {sorted(real)}")
+    assert not problems, "\n".join(problems)
+
+
+def test_no_field_is_claimed_by_two_steps(declarations):
+    """The card renders each step's fields beneath it. A key in two steps renders
+    two inputs bound to one secret, and whichever the clerk fills second wins."""
+    for capability, provider, fields in declarations:
+        assert len(fields) == len(set(fields)), f"{capability}:{provider} repeats a field"
+
+
+def test_every_provider_with_credentials_has_instructions(declarations):
+    """The card falls back to a plain list of labelled boxes when a provider has
+    no steps, which is a supported state -- but for a provider whose credentials
+    come from a console menu three levels deep, a labelled box is not enough to
+    act on. Providers with no credentials at all (Off, the application key) are
+    exempt: there is nothing to instruct.
+    """
+    catalogs = _catalogs()
+    written = {(c, p) for c, p, _ in declarations}
+    missing = [
+        f"{capability}:{provider}"
+        for capability, catalog in catalogs.items()
+        for provider, entry in catalog.items()
+        if entry.get("credential_fields") and (capability, provider) not in written
+    ]
+    assert not missing, f"no setup steps written for: {sorted(missing)}"
+
+
+def test_the_instructions_cover_every_credential_box(declarations):
+    """A field no step claims still renders, at the end of the card, so nothing
+    becomes unreachable. But an orphaned box is one the instructions never
+    mention, which leaves a clerk to guess -- so a provider that has steps at all
+    should account for all of its fields.
+    """
+    catalogs = _catalogs()
+    orphans = []
+    for capability, provider, fields in declarations:
+        entry = catalogs.get(capability, {}).get(provider)
+        if not entry:
+            continue
+        real = {f["key"] for f in entry.get("credential_fields", [])}
+        for key in sorted(real - set(fields)):
+            orphans.append(f"{capability}:{provider} field {key} is in no step")
+    assert not orphans, "\n".join(orphans)
+
+
+def test_the_callback_url_matches_the_route_that_receives_it():
+    """Every identity provider is told to register the same redirect URI, and it
+    has to be the one `auth.py` actually builds. A mismatch is the worst failure
+    on this page: the password is accepted, the redirect is refused, and the
+    error a clerk sees says nothing about a URL."""
+    pytest.importorskip("fastapi")
+    import inspect
+
+    from app.api import auth
+
+    source = inspect.getsource(auth)
+    assert '"/api/auth/callback"' in source or "/api/auth/callback" in source
+    assert "/api/auth/callback" in CONTENT.read_text()

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -215,3 +215,55 @@ def test_the_guide_no_longer_asks_for_an_invented_backup_passphrase():
     source = GUIDE.read_text()
     assert "Choose a strong" not in source
     assert "Create backup passphrase" in source
+
+
+# ---------------------------------------------------------------------------
+# Pitfalls
+# ---------------------------------------------------------------------------
+
+def test_every_provider_warns_about_something(declarations):
+    """`trouble` is where the failures that do not announce themselves live.
+
+    Every path on this page has at least one: a key that Google issues without
+    billing and that renders a grey box; an Entra secret shown once with a
+    "Secret ID" next to it that is not the secret; an SES sandbox that accepts
+    the message and delivers nothing; a KMS key whose deletion cannot be undone
+    after the window closes. A provider with no warning almost always means
+    nobody has walked it rather than that it has no traps.
+
+    Redaction was the gap this caught: three of its four paths had no warning at
+    all, and one of them is the default every install now lands on.
+    """
+    import re
+
+    source = CONTENT.read_text()
+    calls = list(re.finditer(r"defineSteps\(\s*'([a-z]+)'\s*,\s*'([a-z0-9]+)'", source))
+    missing = []
+    for i, call in enumerate(calls):
+        end = calls[i + 1].start() if i + 1 < len(calls) else len(source)
+        if "trouble:" not in source[call.start():end]:
+            missing.append(f"{call.group(1)}:{call.group(2)}")
+    assert not missing, f"no pitfall warning written for: {missing}"
+
+
+def test_the_key_deletion_warnings_are_present():
+    """The one failure on this page that cannot be undone. Each cloud words it
+    differently and each has its own window, so this checks all three rather
+    than trusting one sentence to cover them."""
+    source = CONTENT.read_text()
+    for phrase in (
+        "lien",                       # google: project deletion is refused
+        "purge protection",           # azure: soft-deleted keys stay recoverable
+        "kms:ScheduleKeyDeletion",    # aws: explicit deny beats any allow
+        "unrecoverable",              # what happens if all of that fails
+    ):
+        assert phrase in source, phrase
+
+
+def test_redaction_says_how_to_prove_it_works():
+    """Redaction is the only capability whose failure is invisible from inside
+    the product: "found nobody" and "could not ask" both produce an unblurred
+    photo and a green card. The only proof is looking at one."""
+    source = CONTENT.read_text()
+    assert "VERIFY_WITH_A_PHOTO" in source
+    assert "UNCONFIGURED_DETECTOR" in source

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -22,7 +22,8 @@ from pathlib import Path
 
 import pytest
 
-CONTENT = Path(__file__).resolve().parents[2] / "frontend/src/components/setupStepsContent.tsx"
+ROOT = Path(__file__).resolve().parents[2]
+CONTENT = ROOT / "frontend/src/components/setupStepsContent.tsx"
 
 
 def _catalogs():
@@ -169,3 +170,48 @@ def test_the_callback_url_matches_the_route_that_receives_it():
     source = inspect.getsource(auth)
     assert '"/api/auth/callback"' in source or "/api/auth/callback" in source
     assert "/api/auth/callback" in CONTENT.read_text()
+
+
+# ---------------------------------------------------------------------------
+# One copy of the console walk, not two
+# ---------------------------------------------------------------------------
+
+GUIDE = ROOT / "frontend/src/components/SetupIntegrationsPage.tsx"
+
+# Sentences that only belong in a per-provider console walk. If the long-form
+# guide starts carrying these again, it has grown a second copy of instructions
+# that already live on the cards -- and the copies drift, which is not a
+# hypothetical: the guide told towns Okta's issuer was their org URL while the
+# card told them it was not, and it asked them to invent a backup passphrase
+# months after that field was replaced by a generated one.
+DUPLICATED_WALKS = (
+    "Create App Integration",
+    "New client secret",
+    "Certificates &amp; secrets",
+    "MapKit JS",
+    "Create Credentials",
+    "Regular Web Application",
+    "Application URIs",
+)
+
+
+def test_the_guide_does_not_repeat_the_cards_console_steps():
+    if not GUIDE.exists():
+        pytest.skip("frontend not present in this checkout")
+    source = GUIDE.read_text()
+    repeated = [phrase for phrase in DUPLICATED_WALKS if phrase in source]
+    assert not repeated, (
+        "the setup guide has grown its own copy of a vendor console walk: "
+        f"{repeated}. Those live in setupStepsContent.tsx, where the steps sit "
+        "directly above the boxes they fill."
+    )
+
+
+def test_the_guide_no_longer_asks_for_an_invented_backup_passphrase():
+    """The backup passphrase is generated and shown once. An instruction to
+    choose one sends a clerk looking for a field that is not there."""
+    if not GUIDE.exists():
+        pytest.skip("frontend not present in this checkout")
+    source = GUIDE.read_text()
+    assert "Choose a strong" not in source
+    assert "Create backup passphrase" in source

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -26,19 +26,33 @@ CONTENT = Path(__file__).resolve().parents[2] / "frontend/src/components/setupSt
 
 
 def _catalogs():
-    from app.services.ai.registry import AI_CATALOG
-    from app.services.delivery_providers import _CATALOGS
-    from app.services.identity import IDENTITY_CATALOG
-    from app.services.map_provider import MAP_CATALOG
-    from app.services.translation_providers import TRANSLATION_CATALOG
+    """The real catalogs, minus any that this environment cannot import.
 
-    return {
-        "ai": AI_CATALOG,
-        "translation": TRANSLATION_CATALOG,
-        "identity": IDENTITY_CATALOG,
-        "maps": MAP_CATALOG,
-        **_CATALOGS,
+    CI installs four packages, so `app.services.identity` -- which needs PyJWT
+    to verify tokens -- is not importable there. Skipping the whole module on
+    that basis would take the other twenty-four providers with it, so instead
+    each catalog is imported on its own and the checks run against whatever
+    loaded. A full install covers all of them; CI covers most.
+    """
+    catalogs = {}
+    sources = {
+        "ai": ("app.services.ai.registry", "AI_CATALOG"),
+        "translation": ("app.services.translation_providers", "TRANSLATION_CATALOG"),
+        "identity": ("app.services.identity", "IDENTITY_CATALOG"),
+        "maps": ("app.services.map_provider", "MAP_CATALOG"),
     }
+    for capability, (module, name) in sources.items():
+        try:
+            catalogs[capability] = getattr(__import__(module, fromlist=[name]), name)
+        except Exception:
+            continue
+    try:
+        from app.services.delivery_providers import _CATALOGS
+        catalogs.update(_CATALOGS)
+    except Exception:
+        pass
+    assert catalogs, "no provider catalog could be imported at all"
+    return catalogs
 
 
 def _declarations():
@@ -76,7 +90,8 @@ def test_every_step_names_a_real_capability_and_provider(declarations):
     with no error anywhere."""
     catalogs = _catalogs()
     for capability, provider, _ in declarations:
-        assert capability in catalogs, f"unknown capability: {capability}"
+        if capability not in catalogs:
+            continue  # catalog not importable here; see _catalogs
         assert provider in catalogs[capability], f"unknown provider: {capability}:{provider}"
 
 

--- a/backend/tests/test_storage_maintenance.py
+++ b/backend/tests/test_storage_maintenance.py
@@ -204,3 +204,99 @@ def test_the_scheduled_pass_never_raises(monkeypatch):
 
     monkeypatch.setattr(sm, "store_reachable", _explode)
     assert asyncio.run(sm.vault_secrets())["status"] in ("error", "skipped")
+
+
+# ---------------------------------------------------------------------------
+# No lock-in: the health dashboard must not be Google-shaped
+# ---------------------------------------------------------------------------
+
+class _NoDatabase:
+    """get_config_value falls back to a database query and swallows failures,
+    so this stands in for a session without needing one."""
+
+
+def _kms_check(monkeypatch, *, wrapped_by: str, selected: str):
+    import asyncio
+
+    from app.api import health
+    from app.core import encryption, pii_crypto
+
+    monkeypatch.setattr(encryption, "encrypt_pii", lambda v: "pii2:w:n:c")
+    monkeypatch.setattr(encryption, "decrypt_pii", lambda v: "health_check_test@example.com")
+    monkeypatch.setattr(pii_crypto, "active_backend", lambda: wrapped_by)
+    monkeypatch.setattr(encryption, "_kms_provider", lambda: selected)
+
+    return asyncio.run(health.check_kms(_NoDatabase()))
+
+
+@pytest.mark.parametrize("provider,label", [
+    ("google", "Google Cloud KMS"),
+    ("azure", "Azure Key Vault"),
+    ("aws", "AWS KMS"),
+])
+def test_every_key_manager_reports_healthy(monkeypatch, provider, label):
+    """The check used to open by looking for GOOGLE_CLOUD_PROJECT and return
+    "GCP project not configured" if it was absent -- so a town running Azure
+    Key Vault or AWS KMS, with envelope encryption working perfectly, saw a
+    failure on its health dashboard. A false alarm on a supported setup is
+    worse than no check."""
+    pytest.importorskip("fastapi")
+    result = _kms_check(monkeypatch, wrapped_by=provider, selected=provider)
+    assert result["status"] == "healthy"
+    assert result["kms_backend"] == provider
+    assert label in result["message"]
+
+
+def test_a_selected_but_unreachable_key_manager_is_reported(monkeypatch):
+    """The failure mode this check exists for. `_wrap_dek` falls back to the
+    application key when the chosen KMS is unreachable -- no exception, nothing
+    logged above DEBUG. Reporting plain "healthy" here would hide the one thing
+    an admin needs to know."""
+    pytest.importorskip("fastapi")
+    result = _kms_check(monkeypatch, wrapped_by="local", selected="azure")
+    assert result["status"] == "fallback"
+    assert "azure" in result["message"]
+    assert "not reachable" in result["message"]
+
+
+def test_no_cloud_kms_is_not_reported_as_a_problem(monkeypatch):
+    """A self-hosted install with no cloud account at all. Supported, and the
+    normal case for a small town."""
+    pytest.importorskip("fastapi")
+    result = _kms_check(monkeypatch, wrapped_by="local", selected="local")
+    assert result["status"] == "fallback"
+    assert "not reachable" not in result["message"]
+
+
+@pytest.mark.parametrize("provider,label", [
+    ("google", "Google Secret Manager"),
+    ("azure", "Azure Key Vault"),
+    ("aws", "AWS Secrets Manager"),
+])
+def test_the_secret_store_check_names_the_store_in_use(monkeypatch, provider, label):
+    pytest.importorskip("fastapi")
+    import asyncio
+
+    from app.api import health
+    from app.services import secret_manager
+
+    monkeypatch.setattr(secret_manager, "_secrets_provider", lambda: provider)
+    monkeypatch.setattr(sm, "store_reachable", lambda: True)
+
+    result = asyncio.run(health.check_secret_manager(_NoDatabase()))
+    assert result["status"] == "healthy"
+    assert result["store"] == provider
+    assert label in result["message"]
+
+
+def test_the_health_response_does_not_key_these_checks_by_vendor():
+    """They were `google_kms` and `google_secret_manager`, and the dashboard
+    rendered them under Google headings whatever the town was running."""
+    pytest.importorskip("fastapi")
+    import inspect
+
+    from app.api import health
+
+    src = inspect.getsource(health.health_check)
+    assert '"kms":' in src and '"secret_store":' in src
+    assert '"google_kms"' not in src

--- a/backend/tests/test_storage_maintenance.py
+++ b/backend/tests/test_storage_maintenance.py
@@ -1,0 +1,206 @@
+"""Storage hygiene that happens without anyone pressing a button.
+
+Two maintenance jobs used to be buttons on the setup page -- "Vault Local
+Secrets to GCP Identity" and "Re-encrypt All PII Data (after key rotation)".
+Neither is something a clerk can be expected to know applies to them, so both
+now run on a schedule. That turns three things into behaviour worth pinning:
+
+  * the schedule exists, because an automation nobody registered is just a
+    feature that was deleted;
+  * an undecryptable value is never overwritten, because that is the single
+    path by which this code could destroy the last copy of somebody's data;
+  * the migration is no longer gated on Google specifically, which is what left
+    towns on Azure and AWS with database copies of every credential forever.
+"""
+
+import base64
+
+import pytest
+
+from app.services import storage_maintenance as sm
+
+
+# ---------------------------------------------------------------------------
+# The one destructive path
+# ---------------------------------------------------------------------------
+
+def test_a_value_that_will_not_decrypt_is_left_alone(monkeypatch):
+    """The key that wrapped this row is gone. Re-encrypting the empty string
+    over it would replace a resident's phone number with nothing, permanently,
+    and it would look like a successful run."""
+    from app.core import encryption
+
+    monkeypatch.setattr(encryption, "decrypt_pii", lambda v: "")
+    monkeypatch.setattr(encryption, "encrypt_pii", lambda v: "SHOULD NOT BE WRITTEN")
+
+    with pytest.raises(ValueError):
+        sm.rewrap_value("pii2:whatever:nonce:ct")
+
+
+def test_an_unchanged_value_is_not_rewritten(monkeypatch):
+    """Already on the current key. Returning None keeps the row out of the
+    counts, so a second pass over a converted database reports zero rather than
+    reporting the same work again every night."""
+    from app.core import encryption
+
+    monkeypatch.setattr(encryption, "decrypt_pii", lambda v: "resident@example.gov")
+    monkeypatch.setattr(encryption, "encrypt_pii", lambda v: "same")
+
+    assert sm.rewrap_value("same") is None
+
+
+def test_empty_columns_are_skipped(monkeypatch):
+    """Most requests have no phone number; that is not work and not an error."""
+    def _boom(_):
+        raise AssertionError("should not have tried to decrypt an empty column")
+
+    from app.core import encryption
+    monkeypatch.setattr(encryption, "decrypt_pii", _boom)
+
+    assert sm.rewrap_value(None) is None
+    assert sm.rewrap_value("") is None
+
+
+def test_a_stale_value_is_returned_re_encrypted(monkeypatch):
+    from app.core import encryption
+
+    monkeypatch.setattr(encryption, "decrypt_pii", lambda v: "resident@example.gov")
+    monkeypatch.setattr(encryption, "encrypt_pii", lambda v: "pii2:new:n:c")
+
+    assert sm.rewrap_value("pii2:old:n:c") == "pii2:new:n:c"
+
+
+# ---------------------------------------------------------------------------
+# The generated backup passphrase
+# ---------------------------------------------------------------------------
+
+def test_the_backup_passphrase_is_a_real_key():
+    """It replaces a free-text box that asked a town to invent one. 256 bits,
+    because the thing it protects is a full database dump."""
+    key = sm.generated_backup_key()
+    assert len(base64.urlsafe_b64decode(key + "==")) == 32
+
+
+def test_backup_passphrases_are_not_repeated():
+    assert len({sm.generated_backup_key() for _ in range(50)}) == 50
+
+
+def test_the_backup_passphrase_survives_a_round_trip_through_a_url_and_a_shell():
+    """It gets copied into password managers, .env files and, inevitably, a
+    command line. urlsafe base64 with the padding stripped has no character
+    that any of those treat specially."""
+    key = sm.generated_backup_key()
+    assert key.isascii()
+    assert not (set(key) - set(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    ))
+
+
+# ---------------------------------------------------------------------------
+# The schedule, and what it replaced
+# ---------------------------------------------------------------------------
+
+def test_both_jobs_are_actually_scheduled():
+    pytest.importorskip("celery")
+    from app.core.celery_app import celery_app
+
+    schedule = celery_app.conf.beat_schedule
+    tasks = {entry["task"] for entry in schedule.values()}
+    assert "app.tasks.storage.vault_secrets" in tasks
+    assert "app.tasks.storage.rewrap_pii" in tasks
+
+
+def test_the_task_module_is_imported_by_the_worker():
+    """A beat entry naming a task nobody imported fails at run time, in a log
+    the town will not read, having quietly done nothing for months."""
+    pytest.importorskip("celery")
+    from app.core.celery_app import celery_app
+
+    assert "app.tasks.storage" in celery_app.conf.include
+
+
+def test_vaulting_runs_often_enough_to_matter():
+    """The window it closes opens the moment somebody finishes setup: anything
+    entered before the cloud account was connected sits in the database until
+    this fires. Daily would be a long time for that to be true of a live
+    Twilio token."""
+    pytest.importorskip("celery")
+    from app.core.celery_app import celery_app
+
+    entry = celery_app.conf.beat_schedule["hourly-secret-vaulting"]
+    assert entry["schedule"] <= 60 * 60
+
+
+# ---------------------------------------------------------------------------
+# Store-agnostic migration
+# ---------------------------------------------------------------------------
+
+def test_the_migration_is_not_gated_on_google():
+    """It checked `_is_gcp_available()`, so a town on Azure Key Vault or AWS
+    Secrets Manager could never move its database copies across -- the save
+    path wrote to the vault, and the database copy stayed behind forever with
+    nothing offering to remove it."""
+    pytest.importorskip("sqlalchemy")
+    import inspect
+
+    from app.services import secret_manager
+
+    src = inspect.getsource(secret_manager.migrate_to_secret_manager)
+    assert "store_reachable()" in src
+    assert "_is_gcp_available()" not in src
+
+
+def test_store_reachable_answers_for_each_backend(monkeypatch):
+    """One helper, three stores. It is the gate on a function that deletes
+    database rows, so a backend it does not know about must read as
+    unreachable rather than as fine."""
+    pytest.importorskip("sqlalchemy")
+    from app.services import secret_manager
+
+    monkeypatch.setattr(secret_manager, "_secrets_provider", lambda: "google")
+    monkeypatch.setattr(secret_manager, "_is_gcp_available", lambda: True)
+    assert sm.store_reachable() is True
+
+    monkeypatch.setattr(secret_manager, "_is_gcp_available", lambda: False)
+    assert sm.store_reachable() is False
+
+    monkeypatch.setattr(secret_manager, "_secrets_provider", lambda: "azure")
+    from app.core import azure_keyvault
+    monkeypatch.setattr(azure_keyvault, "is_configured", lambda: True)
+    assert sm.store_reachable() is True
+
+    monkeypatch.setattr(secret_manager, "_secrets_provider", lambda: "aws")
+    from app.core import aws_secretsmanager
+    monkeypatch.setattr(aws_secretsmanager, "is_configured", lambda: False)
+    assert sm.store_reachable() is False
+
+
+def test_vaulting_stops_before_it_touches_anything_when_no_store_is_configured(monkeypatch):
+    """Every town without a cloud account runs this hourly forever. It has to
+    be a no-op, not an attempt that fails somewhere inside."""
+    pytest.importorskip("sqlalchemy")
+    import asyncio
+
+    monkeypatch.setattr(sm, "store_reachable", lambda: False)
+
+    def _boom():
+        raise AssertionError("migration must not be attempted with no store")
+
+    from app.services import secret_manager
+    monkeypatch.setattr(secret_manager, "migrate_to_secret_manager", _boom)
+
+    result = asyncio.run(sm.vault_secrets())
+    assert result["status"] == "skipped"
+
+
+def test_the_scheduled_pass_never_raises(monkeypatch):
+    """It runs unattended. An exception escaping here is a Celery traceback
+    nobody sees, on an hourly cadence."""
+    pytest.importorskip("sqlalchemy")
+    import asyncio
+
+    def _explode():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(sm, "store_reachable", _explode)
+    assert asyncio.run(sm.vault_secrets())["status"] in ("error", "skipped")

--- a/backend/tests/test_unlisted_reports_reachable.py
+++ b/backend/tests/test_unlisted_reports_reachable.py
@@ -1,0 +1,72 @@
+"""An unlisted report must still be reachable by its own link.
+
+"Unlisted" means kept out of the town's public listing. It does not mean hidden
+from the person who filed it: they have the link, staff have the link, and the
+report is still worked. The listing rule and the by-id rule are therefore
+different, and confusing them breaks things in opposite directions --
+
+  * `is_public` missing from the listing rule republishes every report a
+    resident asked to keep unlisted;
+  * `is_public` added to the by-id rule 404s every tracking link for those same
+    reports, silently, and the resident concludes their report was deleted.
+
+Both rules are now named functions, and these tests compile the SQL they
+produce rather than reading the source, so a change to how the endpoints are
+written cannot make the test pass or fail on its own.
+"""
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("fastapi")
+
+from sqlalchemy import select
+
+from app.api.open311 import direct_link_filters, public_visibility_filters
+from app.models import ServiceRequest
+
+
+def _sql(filters):
+    return str(select(ServiceRequest.id).where(*filters).compile(
+        compile_kwargs={"literal_binds": True}))
+
+
+def test_the_public_listing_hides_unlisted_reports():
+    assert "is_public" in _sql(public_visibility_filters())
+
+
+def test_a_direct_link_does_not_hide_them():
+    """The bug this file exists for. Adding is_public here would look like
+    tightening security and would break every tracking link for every unlisted
+    report."""
+    assert "is_public" not in _sql(direct_link_filters())
+
+
+def test_both_rules_exclude_soft_deleted_records():
+    """Two of the four by-id endpoints were missing this, so a deleted request
+    still served its comments."""
+    assert "deleted_at IS NULL" in _sql(public_visibility_filters())
+    assert "deleted_at IS NULL" in _sql(direct_link_filters())
+
+
+def test_the_direct_rule_is_only_the_soft_delete_clause():
+    """Anything else added here narrows who can follow a link, which is the
+    failure mode. Stated as an equality so a new clause has to be argued for."""
+    sql = _sql(direct_link_filters())
+    assert sql.count("WHERE") == 1
+    assert sql.split("WHERE")[1].strip() == "service_requests.deleted_at IS NULL"
+
+
+def test_every_by_id_endpoint_uses_the_shared_rule():
+    """The rule was repeated inline at each endpoint, which is how two of them
+    came to disagree with the other two."""
+    import inspect
+
+    from app.api import open311
+
+    for name in ("get_public_request_detail", "get_public_comments",
+                 "get_public_audit_log", "lookup_request_by_token"):
+        fn = getattr(open311, name)
+        source = inspect.getsource(fn)
+        assert "direct_link_filters()" in source, name
+        assert "is_public" not in source, f"{name} filters is_public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,31 +63,6 @@ services:
     security_opt:
       - no-new-privileges:true
 
-  # Watchtower - Automatic container updates for security
-  watchtower:
-    image: containrrr/watchtower:latest
-    restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      WATCHTOWER_CLEANUP: "true"
-      WATCHTOWER_SCHEDULE: "0 0 3 * * *" # Update at 3am daily
-      WATCHTOWER_ROLLING_RESTART: "true"
-      WATCHTOWER_INCLUDE_STOPPED: "false"
-      DOCKER_API_VERSION: "1.44"
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-    deploy:
-      resources:
-        limits:
-          cpus: '0.1'
-          memory: 128M
-
   backend:
     build: ./backend
     restart: unless-stopped

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -312,8 +312,52 @@ the cached data key, because a long-running worker would otherwise keep
 reporting the state of the world from before the key broke — for the whole
 window. See `_kms_check` in `app/services/proactive_health.py`.
 
+### The controls guard the key, not the account
+
+Worth being precise, because it is easy to read the list below and conclude the
+problem is solved. Every control there stops somebody deleting the *key*. None
+of them survives losing the *account* that holds it, and the timelines are all
+quiet ones:
+
+| Path | What happens | Window |
+|---|---|---|
+| Azure subscription cancelled | Subscription deleted, resources with it | ~90 days after cancellation |
+| AWS account closed | Resources deleted after the post-closure period | 90 days |
+| Google project deleted | Takes the key ring; material erased | 30-day destruction window, erased within 45 days |
+
+A `kms:ScheduleKeyDeletion` deny does not apply, because closing an account is
+not that call. Purge protection protects a key inside a vault, not a vault
+inside a subscription that no longer exists.
+
+For a municipality this is the likelier ending than a mis-click: a card that
+expires between budget cycles, a subscription opened on a departing employee's
+personal account, a purchasing gap nobody notices until the disable notice
+arrives. The controls for it are unglamorous — the account in the town's name on
+a town payment method, more than one administrator, billing alerts to a shared
+address that is still monitored after somebody leaves.
+
+Two more paths that are *not* deletion and are recoverable, but break decryption
+identically and silently:
+
+- **An expiry set on the Azure key.** Key Vault keys support an `exp` attribute,
+  after which cryptographic operations are refused. Azure Policy actively
+  recommends setting one ("Key Vault keys should have an expiration date"), so a
+  well-meaning security review can break PII decryption without deleting
+  anything. The key still exists and the date can be extended.
+- **The Azure client secret expiring.** Same symptom, different cause, also
+  fixable in minutes once identified.
+
+In both cases the `_kms_check` alert fires, which is most of the value: the
+failure is recoverable but only if somebody knows it is happening.
+
 ### Prevention, in order of value
 
+0. **Protect the container.** Google: place a lien on the project
+   (`gcloud alpha resource-manager liens create --restrictions=resourcemanager.projects.delete`),
+   which blocks deletion until the lien is removed. Azure: add a `CanNotDelete`
+   lock on the vault — locks override user permissions, and an attempt to delete
+   the enclosing resource group fails whole rather than half-completing. AWS has
+   no equivalent for account closure; billing hygiene is the only control.
 1. **Deny the deletion, do not merely avoid it.** On AWS, add an explicit deny
    for `kms:ScheduleKeyDeletion` and `kms:DisableKey` in the key policy — an
    explicit deny cannot be overridden by any allow, including the account root.

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -276,3 +276,69 @@ Before giving a contractor access:
 
 *Last Updated: February 2026*
 *Review Schedule: Quarterly*
+
+## Losing the encryption key
+
+The one failure on this list that no backup fixes.
+
+Resident names, emails and phone numbers are protected by envelope encryption: a
+data key encrypts the field, and your cloud's key service wraps that data key.
+The database holds the encrypted value and the wrapped data key side by side.
+The key service holds the only thing that can unwrap it.
+
+If the key is destroyed, every wrapped data key becomes a sealed box. The
+encrypted values remain in the database, intact and meaningless. **Restoring a
+backup does not help** — the backup contains the same sealed boxes.
+
+What survives: the report text, category, location, photos, status history and
+audit log. All of it. You keep the complete public record of what was reported
+and what the town did. What you lose is the ability to say who reported it or to
+contact them.
+
+### The failure is silent, and the clock is short
+
+Nothing raises when a key stops answering. `_wrap_dek` falls back to the
+application key and carries on, so new reports save normally while older rows
+quietly stop being readable. Two consequences:
+
+- It looks like a database fault, not a key fault, because new records are fine.
+- If the cause was a scheduled deletion, the cancellation window (7–30 days on
+  AWS, the retention period on Azure, the destroy-scheduled-duration on Google)
+  can expire before anyone connects the symptom to the cause.
+
+The proactive health scan checks for exactly this every fifteen minutes and
+emails admins at critical severity. It performs a live wrap rather than reading
+the cached data key, because a long-running worker would otherwise keep
+reporting the state of the world from before the key broke — for the whole
+window. See `_kms_check` in `app/services/proactive_health.py`.
+
+### Prevention, in order of value
+
+1. **Deny the deletion, do not merely avoid it.** On AWS, add an explicit deny
+   for `kms:ScheduleKeyDeletion` and `kms:DisableKey` in the key policy — an
+   explicit deny cannot be overridden by any allow, including the account root.
+   On Azure, enable soft delete and purge protection at vault creation. On
+   Google, keys cannot be deleted at all; set the key's destroy scheduled
+   duration to its maximum (120 days) and keep
+   `cloudkms.cryptoKeyVersions.destroy` off everyday roles.
+2. **Set `REQUIRE_KMS`.** The application then refuses to write PII rather than
+   silently falling back to the application key. It converts a silent
+   divergence into a loud outage, which is the right trade for this data.
+3. **Calendar the credential expiry.** Azure client secrets expire. When one
+   lapses, decryption stops and nothing about the failure points at a date.
+4. **Do not confuse rotation with deletion.** Rotating is safe — old versions
+   are retained and keep decrypting old rows — and worth doing. Destroying is
+   final. They sit next to each other in every console.
+
+### If it has already happened
+
+Check whether the deletion is still pending. On AWS a scheduled deletion can be
+cancelled with `CancelKeyDeletion` any time inside the waiting period; on Azure
+a soft-deleted key can be recovered within the retention period; on Google a
+destroy-scheduled key version can be restored before its scheduled time. In all
+three the key stops working at the *start* of that period, so the system being
+broken is not evidence that it is too late.
+
+If the window has closed, the encrypted PII is unrecoverable. Everything else in
+the database is unaffected, and the service continues to function for new
+reports.

--- a/docs/ORCHESTRATOR_PLAN.md
+++ b/docs/ORCHESTRATOR_PLAN.md
@@ -154,10 +154,83 @@ contacts. **Metadata only — no resident data ever.** This table doubles as the
 StateRAMP/FedRAMP authorization-boundary inventory.
 
 ## B2. Provisioner
+
 Per town, in order: create DB → generate `SECRET_KEY` → create/assign KMS key
 → allocate storage bucket → set DNS + request TLS → deploy app image @ version
 → call the app's **A4 provisioning API** to set township + admin → email the
 one-time onboarding link. Idempotent and re-runnable.
+
+**That list is a deployment template.** Every line of it is something ARM,
+CloudFormation or Terraform already expresses, in a language the target cloud
+executes and a state IT reviewer can read. Writing it twice -- once as a
+template for towns who self-host, once as orchestrator code for towns the state
+hosts -- would be two implementations of one thing, and the one used less would
+be the one that breaks.
+
+So the template is the provisioner, and B2 becomes: render the parameters,
+invoke the cloud's deployment API, poll to completion, then call A4. Most of
+what is listed above moves out of Python and into the template.
+
+Three consequences worth stating, because they are the argument rather than a
+side effect:
+
+- **One artifact, two front doors.** A town clicks a button on the website and
+  the template runs under their own console session; the state calls the same
+  template through a service principal, eighty times. Same resources, same
+  hardening, same version.
+- **The self-host path stops rotting.** The usual failure of a hosted product is
+  that the self-install path decays because nobody internal uses it. Here the
+  state's provisioning exercises the identical artifact on every town it
+  onboards, so a break shows up immediately and in the place that hurts most.
+- **The hardening stops being optional.** Deny-deletion on the KMS key, purge
+  protection, the project lien, `REQUIRE_KMS=true`, the attached identity
+  instead of a stored credential -- these are the steps a human skips because
+  they are the least obviously necessary. A template cannot skip them. One-click
+  is not a convenience with a security cost; it is the more secure path,
+  because it is the one where the protective settings are not a choice.
+
+The template must not assume an interactive context: it runs as a signed-in
+human in one case and a service principal in the other, and must behave the
+same either way.
+
+### What one-click does not remove
+
+Templates eliminate the work that is *mechanical*. They do not eliminate the
+work that is a *queue*, and being clear about the difference avoids promising a
+town an afternoon when the answer is three weeks:
+
+- **Carrier and provider approvals.** 10DLC brand and campaign registration
+  before a US number can send at all. SES production access. Neither is a
+  resource anyone can create.
+- **Anything requiring DNS.** Domain verification for email, SPF and DKIM, the
+  town's own hostname and certificate. Controlled by whoever runs the town's
+  DNS, which is frequently not the person deploying.
+- **Staff sign-in.** An Entra app registration lives in the town's *directory*,
+  not in the subscription being deployed into -- and a deployment template with
+  permission to write to a directory is a far larger grant than a town should
+  hand over for this. Sign-in stays a human step, deliberately.
+- **Third-party accounts.** Twilio, a Google Maps browser key, an ArcGIS
+  organisation. No cloud template creates an account with another company.
+- **The billing account itself.** Someone owns the subscription and attaches a
+  payment method, and that ownership is the residual risk described in
+  DISASTER_RECOVERY.md -- an account closed for non-payment takes the KMS key
+  with it whatever the template set.
+
+Roughly: one-click removes the infrastructure setup and the security hardening,
+which is the bulk and the part most often done wrong. It leaves the approvals
+and the accounts, which are the part that takes calendar time. Plan the pitch
+around that split rather than around "zero setup".
+
+### Prerequisite already met, and one thing to fix
+
+`build-publish.yml` already publishes `ghcr.io/pinpoint-311/pinpoint-311-{backend,frontend}`
+stamped with version and DB revision, which is the hard part -- a template is
+mostly a manifest referencing those images.
+
+`docker-compose.prod.yml` pins `:latest`. That is wrong for one-click: two towns
+deploying on different days would get different software with nothing recording
+which. Templates must reference an immutable version tag, and the button points
+at the current release.
 
 ## B3. Release management
 Org publishes a versioned image → panel schedules a **canary rollout** across
@@ -220,6 +293,15 @@ provisioning/rollout/support action.
 4. **Shared-key chargeback** — "town brings own key" (recommended, no
    invoicing) vs shared-key metering + billing.
 5. **Data residency / region** per town.
+6. **Marketplace listing, and who is the seller of record.** Deploy buttons need
+   nobody's permission and can ship independently. A marketplace listing is a
+   separate question, and the reason to want one is procurement rather than
+   discoverability: a marketplace purchase can draw against a cloud agreement a
+   county or state already holds, which removes a procurement cycle for the
+   buyer. It requires a legal seller entity -- for a fiscally sponsored project
+   that means the sponsor -- and weeks of review per cloud. Free listings do not
+   require banking details, only seller registration, so the blocker is the
+   entity decision rather than the money.
 
 ---
 

--- a/docs/PROVIDER_SETUP_VERIFICATION.md
+++ b/docs/PROVIDER_SETUP_VERIFICATION.md
@@ -1,0 +1,89 @@
+# Provider setup instructions — what has been verified, and how
+
+The per-provider steps in `frontend/src/components/setupStepsContent.tsx` describe
+other companies' admin consoles. Those get reorganised on their own schedule, so
+this file records what each entry was checked against and by what method. The
+point is that staleness is *visible* rather than assumed.
+
+Three levels, and the difference matters:
+
+- **Walked** — somebody created the account, clicked the menus, obtained the
+  credential and watched the feature work end to end.
+- **Documented** — the steps were reconciled against the vendor's current
+  official documentation. This catches renamed menus and wrong role names. It
+  does not catch a console whose layout differs from its own docs, which is
+  common and is why "walked" is a separate level.
+- **Generic** — there is no vendor console to describe. The steps are questions
+  to ask whoever operates the system, or a protocol description.
+
+Field *keys* are not on this scale: every `fields:` declaration is checked
+against the real credential catalogs by
+`backend/tests/test_setup_steps_content.py`, and every secret the dispatch code
+reads is checked to have a box by `backend/tests/test_dispatch_keys_are_enterable.py`.
+Those are machine-verified on every commit regardless of the level below.
+
+Last reconciliation: 2026-07-30.
+
+| Path | Level | Checked against |
+|---|---|---|
+| `identity:auth0` | **Walked** | Auth0 dashboard, end to end |
+| `identity:entra` | Documented | learn.microsoft.com — Register an app; Certificates & secrets |
+| `identity:okta` | Documented | developer.okta.com / help.okta.com — Create OIDC app integrations; Security → API |
+| `identity:oidc` | Generic | OpenID Connect Discovery |
+| `maps:google` | **Walked** | Google Cloud console, end to end |
+| `maps:esri` | Documented | location.arcgis.com developer dashboard; API key credentials |
+| `maps:azure` | Documented | learn.microsoft.com — Manage authentication in Azure Maps |
+| `maps:apple` | Documented | developer.apple.com — Creating a Maps identifier and a private key |
+| `ai:vertex` | Documented | Vertex AI User role (`roles/aiplatform.user`) |
+| `ai:azure` | Documented | learn.microsoft.com — Foundry deployments; Keys and Endpoint |
+| `ai:bedrock` | Documented | Bedrock console — Model access; Marketplace subscription permission |
+| `translation:google` | Documented | Cloud Translation API User (`roles/cloudtranslate.user`) |
+| `translation:azure` | Documented | Translator resource — Keys and Endpoint, Location/Region |
+| `translation:aws` | Documented | `TranslateReadOnly` managed policy (includes `translate:TranslateText`) |
+| `email:smtp` | Generic | SMTP; the M365/Workspace restriction is a policy fact, not a console path |
+| `email:ses` | Documented | SES console — Identities, Create identity; Request production access |
+| `email:acs` | Documented | learn.microsoft.com — Prepare an email resource; Connect domain; MailFrom |
+| `sms:twilio` | **Walked** | Twilio console, end to end |
+| `sms:sns` | Documented | SNS console — Text messaging (SMS); SMS sandbox; origination identities |
+| `sms:acs` | Documented | Azure portal — Telephony and SMS → Phone numbers |
+| `sms:http` | Generic | Pinpoint's own POST contract |
+| `kms:google` | Documented | Cloud KMS — Create a key; CryptoKey Encrypter/Decrypter role |
+| `kms:azure` | Documented | Key Vault — Generate/Import; access policy `wrapKey`/`unwrapKey` |
+| `kms:aws` | Documented | KMS console — Create key, Symmetric, Encrypt and decrypt |
+| `redaction:google` | Documented | Cloud Vision API |
+| `redaction:aws` | Documented | Rekognition `DetectFaces` / `DetectText` |
+| `redaction:azure` | Documented | Face and Computer Vision are separate resources; Face is Limited Access |
+| `redaction:local` | Generic | Runs here; nothing to configure |
+
+## What reconciliation caught
+
+It is worth recording that this was not a formality.
+
+**Azure photo redaction was broken, not just imprecise.** Writing the steps
+surfaced that `image_redaction.py` reads four keys — `AZURE_FACE_ENDPOINT`,
+`AZURE_FACE_KEY`, `AZURE_VISION_ENDPOINT`, `AZURE_VISION_KEY` — that no card
+offered. Google and AWS reuse credentials entered elsewhere, so the gap was
+invisible: a town could select Azure, tick both blur toggles, save successfully,
+and have every resident photo stored unblurred, with no error and nowhere on the
+page to fix it. The catalog now offers all four, and
+`test_dispatch_keys_are_enterable.py` fails if a provider path ever again reads a
+secret that nothing can set.
+
+**Azure's vision service has two names.** Microsoft lists it as both *Computer
+Vision* and *Azure AI Vision*; the steps now say so, rather than sending someone
+to look for one of the two.
+
+## Recommended before a public launch
+
+Two paths are worth walking by hand rather than trusting to documentation:
+
+1. **Microsoft Entra ID** — the path most municipalities will take, because
+   their staff already have Microsoft 365 accounts. Highest traffic, so highest
+   cost if a menu has moved.
+2. **Amazon SES** — its sandbox failure mode is indistinguishable from success.
+   SES accepts the message, returns a success response, and delivers nothing to
+   an unverified address. Documentation describes this correctly; only a real
+   send proves the account is out of the sandbox.
+
+Walking either one is roughly fifteen minutes and needs an account of that
+vendor's. Update the level in the table when done.

--- a/docs/PROVIDER_SETUP_VERIFICATION.md
+++ b/docs/PROVIDER_SETUP_VERIFICATION.md
@@ -22,7 +22,7 @@ against the real credential catalogs by
 reads is checked to have a box by `backend/tests/test_dispatch_keys_are_enterable.py`.
 Those are machine-verified on every commit regardless of the level below.
 
-Last reconciliation: 2026-07-30.
+Last reconciliation: 2026-07-30 (second pass, every path).
 
 | Path | Level | Checked against |
 |---|---|---|
@@ -57,7 +57,55 @@ Last reconciliation: 2026-07-30.
 
 ## What reconciliation caught
 
-It is worth recording that this was not a formality.
+It is worth recording that this was not a formality. A second pass over every
+path found six factual errors on top of the broken feature below.
+
+**Azure OpenAI is no longer gated.** The steps said access "can take a day or
+two to be approved if it has not been requested before" and told towns to start
+that first if they were on a deadline. Microsoft removed the general
+registration requirement; every subscription is eligible for the standard
+models, and a form is now needed only for restricted features Pinpoint does not
+use. The advice would have sent a town looking for an approval process that does
+not exist, and delayed a launch for nothing.
+
+**Okta's issuer — a correction to an earlier correction.** These steps had
+claimed the issuer is "not your org URL" and "typically ends /oauth2/default".
+That is wrong, and it was written while removing a passage from the setup guide
+that said the opposite. Okta documents *both* as legitimate: the org
+authorization server issues on the plain domain and is Okta's recommendation for
+ordinary single sign-on, which is what Pinpoint does; a custom server such as
+`default` issues on `/oauth2/{id}` and exists for custom claims and policies.
+What matters is that the issuer matches the server the app is assigned to. The
+steps now say so, and give a ten-second check —
+`<issuer>/.well-known/openid-configuration` should return JSON in a browser.
+
+**ACS text messaging is registration-first.** The steps had a town acquire a
+number and then mentioned registration as a caveat. In the US, 10DLC brand and
+campaign registration must be approved *before* a number can be acquired or
+SMS-enabled at all. It is also not possible on a trial subscription or with free
+credits. Both facts now come before the step they would otherwise block.
+
+**Microsoft is removing password-based SMTP.** From the end of December 2026,
+Exchange Online disables basic authentication for SMTP AUTH on existing tenants
+by default, and tenants created after that cannot use it. A town on Microsoft
+365 choosing SMTP today buys a few months. The step says so and points at the
+durable alternatives.
+
+**ArcGIS keys start `AAPK`.** The steps accepted `AAPT` as well; that is Esri's
+prefix for short-lived access tokens, which is a different credential and will
+not work. Keys also expire at 00:00:00 GMT on the date set, which is now stated.
+
+**AWS KMS deletion is 7 to 30 days, defaulting to 30**, and the key becomes
+unusable the moment deletion is *scheduled* rather than when the window closes —
+so resident data stops decrypting immediately. It can be cancelled inside the
+window. The steps said only "at least seven days".
+
+Confirmed correct, having originally been written from memory: `TranslateReadOnly`
+does include `translate:TranslateText` despite the name; `roles/cloudtranslate.user`
+and `roles/aiplatform.user` are the right role names; Rekognition finds plates
+via `DetectText`; Cloud KMS Encrypter/Decrypter must be granted on the key;
+`AmazonSESFullAccess` exists and `ses:SendEmail` + `ses:SendRawEmail` are the
+minimum; Azure Translator's region is the short form from Keys and Endpoint.
 
 **Azure photo redaction was broken, not just imprecise.** Writing the steps
 surfaced that `image_redaction.py` reads four keys — `AZURE_FACE_ENDPOINT`,

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -21,14 +21,28 @@ interface IntegrationCheck {
     [key: string]: any;
 }
 
+/** Key management and secret storage are both pluggable, so neither panel can
+ *  carry a vendor name in its heading. Both used to say "Google". */
+const KMS_LABELS: Record<string, string> = {
+    google: 'Google Cloud KMS',
+    azure: 'Azure Key Vault',
+    aws: 'AWS KMS',
+};
+
+const STORE_LABELS: Record<string, string> = {
+    google: 'Google Secret Manager',
+    azure: 'Azure Key Vault',
+    aws: 'AWS Secrets Manager',
+};
+
 interface IntegrationHealth {
     overall_status: string;
     checks: {
         database: IntegrationCheck;
         auth0: IntegrationCheck;
         gcp_auth?: IntegrationCheck;
-        google_kms: IntegrationCheck;
-        google_secret_manager: IntegrationCheck;
+        kms: IntegrationCheck;
+        secret_store: IntegrationCheck;
         vertex_ai: IntegrationCheck;
         translation_api: IntegrationCheck;
     };
@@ -441,28 +455,33 @@ export default function OperationsPanel() {
                             </div>
                         )}
 
-                        {/* Google KMS */}
+                        {/* Key management — named for whichever manager is in
+                            use, not for Google. */}
                         <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
                             <div className="flex items-center gap-3 mb-2">
                                 <Shield className="w-5 h-5 text-blue-400" />
-                                <span className="text-white font-medium">Google KMS</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.google_kms.status)}`}>
-                                    {integrations.checks.google_kms.status}
+                                <span className="text-white font-medium">
+                                    {KMS_LABELS[integrations.checks.kms.kms_backend ?? ''] ?? 'Key Management'}
+                                </span>
+                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.kms.status)}`}>
+                                    {integrations.checks.kms.status}
                                 </span>
                             </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.google_kms.message}</p>
+                            <p className="text-gray-300 text-xs">{integrations.checks.kms.message}</p>
                         </div>
 
-                        {/* Secret Manager */}
+                        {/* Secret store */}
                         <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
                             <div className="flex items-center gap-3 mb-2">
                                 <Key className="w-5 h-5 text-green-400" />
-                                <span className="text-white font-medium">Secret Manager</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.google_secret_manager.status)}`}>
-                                    {integrations.checks.google_secret_manager.status}
+                                <span className="text-white font-medium">
+                                    {STORE_LABELS[integrations.checks.secret_store.store ?? ''] ?? 'Secret Store'}
+                                </span>
+                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.secret_store.status)}`}>
+                                    {integrations.checks.secret_store.status}
                                 </span>
                             </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.google_secret_manager.message}</p>
+                            <p className="text-gray-300 text-xs">{integrations.checks.secret_store.message}</p>
                         </div>
 
                         {/* Vertex AI */}

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -889,6 +889,15 @@ export default function ServiceProviders({ show, extras, instructions }: {
 
     const ALWAYS = new Set<Capability>(['identity', 'maps']);
     const visible = CAPS.filter(c => !show || ALWAYS.has(c.key) || show.has(c.key));
+
+    /* Order matters, and not only for readability.
+     *
+     * A credential saved before the secret store is reachable lands in the
+     * encrypted database instead, and until now nothing said so. The store is
+     * made reachable by the cloud credentials entered under Other settings, so
+     * anything asking for a key has to come after the town has had the chance
+     * to enter those -- which is what the ordering note below tells them, since
+     * the bootstrap card itself lives outside this list. */
     const loaded = visible.filter(c => statuses[c.key]);
     const onDefaultCount = (loaded || []).filter(c => statuses[c.key]?.onDefault).length;
     const configuredCount = (loaded || []).filter(c => statuses[c.key]?.configured).length;
@@ -968,6 +977,12 @@ export default function ServiceProviders({ show, extras, instructions }: {
                             <p className="text-white/50 text-xs mt-0.5">
                                 One at a time, in order. Save it and the next one opens.
                             </p>
+                            {configuredCount === 0 && (
+                                <p className="text-amber-200/80 text-xs mt-1.5 leading-relaxed">
+                                    Enter your cloud credentials first, under <strong className="text-amber-100">Other settings</strong> below.
+                                    Keys saved before that go into the encrypted database rather than your secret store.
+                                </p>
+                            )}
                         </div>
                         <button
                             type="button"

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -14,7 +14,7 @@ import {
 
 import { CollapsibleSection } from './ui';
 import SecretField from './SecretField';
-import { api, ProviderCatalog, ProviderInfo, ProviderModelSpec, CloudProfileState } from '../services/api';
+import { api, ProviderCatalog, ProviderInfo, ProviderModelSpec, CloudProfileState, CloudIdentity } from '../services/api';
 import type { ConnectorHealth } from '../types';
 
 // Relative "updated Xh ago" from an epoch-seconds timestamp.
@@ -127,10 +127,21 @@ export interface CapStatus {
     configured?: boolean;
 }
 
-function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided }: {
+/** Cloud names for a heading, kept out of the render so the three places that
+ *  need them cannot drift apart. */
+const CLOUD_LABEL: Record<string, string> = {
+    google: 'Google Cloud',
+    azure: 'Azure',
+    aws: 'AWS',
+};
+
+function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided, identity }: {
     cap: Capability; title: string; blurb: string; icon: typeof Sparkles; delay: number;
     recheckToken: number; reloadToken: number; onStatus: (cap: Capability, s: CapStatus) => void;
     health?: ConnectorHealth;
+    /* Fetched once by the parent and passed down: the probe is a metadata call
+     * and the answer is the same for every card on the page. */
+    identity?: CloudIdentity | null;
     /* Guided setup: the parent walks one capability at a time, so it decides
      * which card is open rather than each card deciding for itself. `step` is
      * the position in that walk, shown so a clerk can see where they are; it is
@@ -606,6 +617,37 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                     const field = (key: string) => {
                         const f = active.credential_fields.find(x => x.key === key);
                         if (!f) return null;  // catalog changed under the steps
+
+                        /* This server already has an identity on the cloud, so
+                         * this particular box needs no value -- and empty is the
+                         * better answer, not merely a permitted one: the
+                         * platform issues a token minutes at a time and rotates
+                         * it, so no long-lived secret exists to be mis-copied,
+                         * vaulted, or left to expire.
+                         *
+                         * It has to say so. Two of the three clouds already
+                         * behaved this way and nothing mentioned it, so every
+                         * town pasted a key into a box that did not need one. */
+                        if (identity?.skippable_keys?.includes(f.key)) {
+                            return (
+                                <div key={f.key} className="mb-3 rounded-xl border border-emerald-400/25 bg-emerald-500/[0.07] px-3 py-2.5">
+                                    <div className="flex items-start gap-2">
+                                        <ShieldCheck className="w-3.5 h-3.5 text-emerald-300 mt-0.5 shrink-0" />
+                                        <div>
+                                            <p className="text-xs text-emerald-100/90">
+                                                <span className="font-semibold">{f.label}</span> — nothing to enter.
+                                            </p>
+                                            <p className="text-[11px] text-white/45 mt-0.5">
+                                                This server already has an identity on {CLOUD_LABEL[identity.provider ?? ''] ?? 'your cloud'}
+                                                {identity.identity ? <> (<code className="bg-black/30 px-1 rounded">{identity.identity}</code>)</> : null}.
+                                                It signs in with that, so there is no key to create, copy, or renew.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        }
+
                         return (
                             <SecretField
                                 key={f.key}
@@ -908,6 +950,19 @@ export default function ServiceProviders({ show, extras }: {
     extras?: ReactNode;
 } = {}) {
     const [recheckToken, setRecheckToken] = useState(0);
+    /* Whether this server has an identity the cloud attached to it. Fetched
+     * once for the whole section -- the answer is the same for every card, and
+     * the probe is a metadata call that either answers instantly or times out.
+     * Failure is silent and reads as "no identity", which just means the cards
+     * ask for credentials the way they always did. */
+    const [identity, setIdentity] = useState<CloudIdentity | null>(null);
+    useEffect(() => {
+        let cancelled = false;
+        api.getCloudIdentity()
+            .then(i => { if (!cancelled) setIdentity(i); })
+            .catch(() => undefined);
+        return () => { cancelled = true; };
+    }, []);
     /* One request for the whole section rather than one per card: the endpoint
      * returns every connector, and four parallel calls on page load for data
      * that arrives together is wasteful.
@@ -1062,7 +1117,7 @@ export default function ServiceProviders({ show, extras }: {
                 {visible.map((c, i) => (
                     <CapabilityCard key={c.key} cap={c.key} title={c.title} blurb={c.blurb} icon={c.icon} delay={i * 0.08}
                         recheckToken={recheckToken} reloadToken={reloadToken} onStatus={onStatus}
-                        health={health[c.key]} guided={guided}
+                        health={health[c.key]} guided={guided} identity={identity}
                         step={{ index: i, total: visible.length, active: i === cursor }} />
                 ))}
             </div>

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -1,4 +1,8 @@
 import type { ReactNode } from 'react';
+import { claimedFields, stepsFor } from './setupSteps';
+// Registers every provider's steps as a side effect of importing it.
+import './setupStepsContent';
+import type { StepContext } from './setupSteps';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -123,7 +127,7 @@ export interface CapStatus {
     configured?: boolean;
 }
 
-function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided, instructions }: {
+function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided }: {
     cap: Capability; title: string; blurb: string; icon: typeof Sparkles; delay: number;
     recheckToken: number; reloadToken: number; onStatus: (cap: Capability, s: CapStatus) => void;
     health?: ConnectorHealth;
@@ -133,12 +137,6 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
      * undefined once setup is done and the page is just cards again. */
     step?: { index: number; total: number; active: boolean };
     guided?: boolean;
-    /* How to obtain the credentials for the provider currently selected,
-     * rendered immediately above the boxes they go into. The instructions used
-     * to sit in one long document at the top of the page, three thousand pixels
-     * from the fields, so following step four meant scrolling away from the
-     * instruction to find the box and back again to read the next one. */
-    instructions?: (provider: string) => ReactNode;
 }) {
     const [catalog, setCatalog] = useState<ProviderCatalog | null>(null);
     const [selected, setSelected] = useState<string>('');
@@ -148,6 +146,20 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     const [result, setResult] = useState<{ ok: boolean; detail: string } | null>(null);
     const [error, setError] = useState<string | null>(null);
     // Live model discovery (AI only)
+    // Copy targets inside steps: a callback URL retyped by hand is the single
+    // most common reason sign-in fails after the password is accepted.
+    const [copied, setCopied] = useState<string | null>(null);
+    const stepCtx: StepContext = {
+        origin: window.location.origin,
+        copy: (text, id) => {
+            navigator.clipboard?.writeText(text).then(
+                () => { setCopied(id); setTimeout(() => setCopied(null), 1600); },
+                () => { /* clipboard blocked; the value is visible and selectable */ },
+            );
+        },
+        copied,
+    };
+
     const [refreshingModels, setRefreshingModels] = useState(false);
     const [liveModels, setLiveModels] = useState<ProviderModelSpec[] | null>(null);
     const [modelsMeta, setModelsMeta] = useState<{ source?: string; fetched_at?: number | null } | null>(null);
@@ -589,38 +601,75 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                 })()}
 
                 {/* Credential/config fields */}
-                {active && (active?.credential_fields || []).length > 0 && (
-                    <div>
-                    <Step n={cap === 'ai' ? 3 : 2}>Credentials</Step>
-                    {instructions?.(selected) && (
-                        <div className="mb-3 rounded-2xl bg-white/[0.05] border border-white/10 px-4 py-3">
-                            <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold mb-1.5">
-                                How to get these
-                            </p>
-                            <div className="text-sm text-white/70 leading-relaxed space-y-1.5">
-                                {instructions(selected)}
-                            </div>
+                {active && (active?.credential_fields || []).length > 0 && (() => {
+                    const alreadySet = !!(catalog.configured?.[selected] && selected === catalog.current_provider);
+                    const field = (key: string) => {
+                        const f = active.credential_fields.find(x => x.key === key);
+                        if (!f) return null;  // catalog changed under the steps
+                        return (
+                            <SecretField
+                                key={f.key}
+                                label={f.label}
+                                secret={f.secret}
+                                value={values[f.key] || ''}
+                                onChange={(v) => setValues(p => ({ ...p, [f.key]: v }))}
+                                placeholder={`Enter ${f.label.toLowerCase()}`}
+                                help={active.field_help?.[f.key]}
+                                savedHint={alreadySet}
+                            />
+                        );
+                    };
+
+                    /* Steps own the boxes they produce, so each instruction is
+                     * followed immediately by the inputs it just told you how to
+                     * obtain. A provider with no steps written yet falls back to
+                     * the plain list, which is what every provider had before. */
+                    const steps = stepsFor(cap, selected, stepCtx);
+                    const claimed = claimedFields(steps);
+                    const leftover = active.credential_fields.filter(f => !claimed.has(f.key));
+
+                    return (
+                        <div>
+                            <Step n={cap === 'ai' ? 3 : 2}>{steps.length ? 'Set it up' : 'Credentials'}</Step>
+
+                            {steps.map((st, i) => (
+                                <div key={i} className="mb-4">
+                                    <div className="flex gap-3">
+                                        <span className="mt-0.5 w-6 h-6 shrink-0 rounded-full bg-white/10 border border-white/15 text-[11px] font-semibold text-white/70 flex items-center justify-center">
+                                            {i + 1}
+                                        </span>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="text-sm text-white/75 leading-relaxed">{st.body}</div>
+                                            {st.check && (
+                                                <p className="mt-1.5 text-xs text-emerald-300/75 flex items-start gap-1.5">
+                                                    <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                                                    <span><span className="font-medium">You should see:</span> {st.check}</span>
+                                                </p>
+                                            )}
+                                            {st.trouble && (
+                                                <p className="mt-1.5 text-xs text-amber-200/75 flex items-start gap-1.5">
+                                                    <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                                                    <span>{st.trouble}</span>
+                                                </p>
+                                            )}
+                                            {!!st.fields?.length && (
+                                                <div className="mt-2.5 grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                                                    {st.fields.map(field)}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+
+                            {leftover.length > 0 && (
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                                    {leftover.map(f => field(f.key))}
+                                </div>
+                            )}
                         </div>
-                    )}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
-                        {active.credential_fields.map(f => {
-                            const alreadySet = !!(catalog.configured?.[selected] && selected === catalog.current_provider);
-                            return (
-                                <SecretField
-                                    key={f.key}
-                                    label={f.label}
-                                    secret={f.secret}
-                                    value={values[f.key] || ''}
-                                    onChange={(v) => setValues(p => ({ ...p, [f.key]: v }))}
-                                    placeholder={`Enter ${f.label.toLowerCase()}`}
-                                    help={active.field_help?.[f.key]}
-                                    savedHint={alreadySet}
-                                />
-                            );
-                        })}
-                    </div>
-                    </div>
-                )}
+                    );
+                })()}
 
                 <div className="flex flex-wrap items-center gap-2.5 pt-1 border-t border-white/5 mt-1">
                     <button
@@ -840,7 +889,7 @@ function CloudEnvironment({ onApplied }: { onApplied: () => void }) {
     );
 }
 
-export default function ServiceProviders({ show, extras, instructions }: {
+export default function ServiceProviders({ show, extras }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -857,8 +906,6 @@ export default function ServiceProviders({ show, extras, instructions }: {
      * across both. Rendered here instead, after the capability cards, so the
      * page has one list. */
     extras?: ReactNode;
-    /** Per-capability, per-provider "how to get these credentials". */
-    instructions?: (cap: Capability, provider: string) => ReactNode;
 } = {}) {
     const [recheckToken, setRecheckToken] = useState(0);
     /* One request for the whole section rather than one per card: the endpoint
@@ -1016,7 +1063,6 @@ export default function ServiceProviders({ show, extras, instructions }: {
                     <CapabilityCard key={c.key} cap={c.key} title={c.title} blurb={c.blurb} icon={c.icon} delay={i * 0.08}
                         recheckToken={recheckToken} reloadToken={reloadToken} onStatus={onStatus}
                         health={health[c.key]} guided={guided}
-                        instructions={instructions ? (provider) => instructions(c.key, provider) : undefined}
                         step={{ index: i, total: visible.length, active: i === cursor }} />
                 ))}
             </div>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
     Key, Shield, Cloud, MessageSquare, Mail, CheckCircle,
-    AlertCircle, ChevronDown, ChevronUp, Copy, Check,
+    AlertCircle, ChevronDown, ChevronUp,
     ExternalLink, AlertTriangle, Database, BookOpen,
     ListChecks, HardDrive, MapPin,
     Sparkles, Languages, Lock, Image as ImageIcon, Landmark,
@@ -46,7 +46,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const [backupKey, setBackupKey] = useState<string | null>(null);
     const [backupKeyAcknowledged, setBackupKeyAcknowledged] = useState(false);
 
-    const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
     /* The guide starts open on a fresh install and closed once the required
      * integrations are in. It is a first-run document: hidden behind a click it
      * is missed by the person who needs it most, and left open forever it pushes
@@ -125,12 +124,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         } finally {
             setSavingKey(null);
         }
-    };
-
-    const copyToClipboard = (text: string, label: string) => {
-        navigator.clipboard.writeText(text);
-        setCopyFeedback(label);
-        setTimeout(() => setCopyFeedback(null), 2000);
     };
 
 
@@ -235,6 +228,37 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                 )}
             </div>
         </div>
+    );
+
+    /* Hands off to the card that owns a credential.
+     *
+     * This guide used to carry its own copy of every vendor's console walk --
+     * Auth0, Entra, Okta, Esri, Apple, all of them -- written before the cards
+     * could hold steps of their own. Now that they can, and the boxes sit
+     * directly beneath the step that produces them, keeping a second copy up
+     * here was worse than having none: the two drifted. The guide told people
+     * Okta's issuer was their org URL while the card told them it was not, and
+     * it still asked towns to invent a backup passphrase months after that
+     * field was replaced by a generated one.
+     *
+     * So the guide keeps what only it has -- the decisions, the cloud
+     * foundation that belongs to no single card, and the steps with no
+     * credential attached -- and defers the console walk to one place. */
+    const SeeCard = ({ children }: { children: React.ReactNode }) => (
+        <div className="ml-9 rounded-lg bg-white/[0.04] border border-white/10 px-3 py-2 flex items-start gap-2">
+            <ListChecks className="w-3.5 h-3.5 text-white/40 mt-0.5 shrink-0" aria-hidden="true" />
+            <p className="text-xs text-white/55 leading-relaxed">{children}</p>
+        </div>
+    );
+
+    /** The step-by-step for whichever provider you pick lives on the card, with
+     *  the boxes it fills. One sentence, worded the same way each time. */
+    const OnTheCard = ({ card }: { card: string }) => (
+        <SeeCard>
+            Scroll to the <strong className="text-white/80">{card}</strong> card below and choose your
+            provider. The steps for that provider appear there, each one directly above the boxes it
+            fills in — so you are never scrolling between an instruction and the field it describes.
+        </SeeCard>
     );
 
     /* "If it goes wrong" for a step, called out rather than buried in prose.
@@ -506,61 +530,21 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
 
                                 {/* ── 1. Staff sign-in (always required) ── */}
                                 <Guide tone="orange" icon={Key} title="Staff sign-in" done={signInConfigured}
-                                    what={<>Residents never sign in — this is only for the clerks and staff who work the reports. Rather than Pinpoint storing staff passwords itself, an outside sign-in service handles that, which is what lets you require two-factor and switch off an ex-employee in one place. The steps below follow whichever service you picked above.</>}
+                                    what={<>Residents never sign in — this is only for the clerks and staff who work the reports. Rather than Pinpoint storing staff passwords itself, an outside sign-in service handles that, which is what lets you require two-factor and switch off an ex-employee in one place.</>}
                                     time={setupIdp === 'auth0' ? "About 20 minutes, and you only ever do it once" : "About 10 minutes if you already administer it"}
                                     cost={setupIdp === 'auth0' ? "Auth0 is free up to 25,000 monthly logins — far more than a town's staff will use" : "Usually already covered by the licence your town has for it"}>
-                                    {setupIdp === 'auth0' && <>
-                                    <InstructionStep num={1}
-                                        check={<>the Auth0 dashboard, with your town's name in the top-left corner.</>}
-                                    >Make the account. Go to <a href="https://auth0.com" target="_blank" rel="noopener noreferrer" className="text-orange-300 underline underline-offset-2">auth0.com</a> and sign up with a <strong className="text-white/90">shared town email address</strong>, not your personal one — whoever replaces you will need to get in. When it asks for a <Term means="which part of the world your staff logins are stored in">region</Term>, pick the one closest to you. <strong className="text-white/90">This cannot be changed later</strong>, so if your town or state has a rule about keeping data in the US, choose a US region now.</InstructionStep>
-                                    <InstructionStep num={2}
-                                        check={<>a settings page with boxes labelled Domain, Client ID and Client Secret. Leave this tab open — you come back to it in step 5.</>}
-                                    >Tell Auth0 about Pinpoint. In the left menu click <strong className="text-white/90">Applications</strong>, then <strong className="text-white/90">Applications</strong> again, then the <strong className="text-white/90">Create Application</strong> button. Name it <em className="text-white/60">"{`{township} 311`}"</em>. From the list of types choose <strong className="text-white/90">Regular Web Application</strong> — not Single Page, not Machine to Machine — and click Create. If it then asks you to pick a technology (React, Node, and so on), <strong className="text-white/90">ignore that and close it</strong>; it only shows sample code you do not need.</InstructionStep>
-                                    <InstructionStep num={3}>Tell Auth0 where to send people back to. Still on the <strong className="text-white/90">Settings</strong> tab, scroll down to <strong className="text-white/90">Application URIs</strong>. Copy each value below into the matching box using the copy button — <strong className="text-white/90">do not retype them</strong>, a single missing character stops sign-in working:
-                                        <div className="mt-2 space-y-1.5">
-                                            <div className="flex items-center gap-2 flex-wrap"><span className="text-white/45 text-xs w-40 shrink-0">Allowed Callback URLs</span><code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}/api/auth/callback</code>
-                                                <button onClick={() => copyToClipboard(`${window.location.origin}/api/auth/callback`, 'callback')} aria-label="Copy to clipboard" className="inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'callback' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button></div>
-                                            <div className="flex items-center gap-2 flex-wrap"><span className="text-white/45 text-xs w-40 shrink-0">Allowed Logout URLs</span><code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}</code>
-                                                <button onClick={() => copyToClipboard(window.location.origin, 'logout')} aria-label="Copy to clipboard" className="inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'logout' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button></div>
-                                            <div className="flex items-center gap-2 flex-wrap"><span className="text-white/45 text-xs w-40 shrink-0">Allowed Web Origins</span><code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}</code>
-                                                <button onClick={() => copyToClipboard(window.location.origin, 'weborigin')} aria-label="Copy to clipboard" className="inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'weborigin' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button></div>
-                                        </div>
-                                        <span className="block mt-1.5 text-white/45 text-xs">Then scroll to the very bottom and click <strong className="text-white/70">Save Changes</strong> — it is easy to miss, and nothing you typed is kept until you do.</span>
+                                    <InstructionStep num={1}>
+                                        <strong className="text-white/90">Check whether you already have this.</strong> If your staff sign in to Microsoft 365, you already run <strong className="text-white/90">Microsoft Entra ID</strong> and should pick that above — no new account, no new password for anyone, and your IT provider can do it in ten minutes. The same is true if the town uses Okta. Auth0 is the answer when there is nothing already in place.
                                     </InstructionStep>
-                                    <Trouble>If sign-in later bounces you straight back to the login page, or you see <em>"Callback URL mismatch"</em>, it is almost always this step: the address in Auth0 has to match your site exactly, including <code className="bg-black/30 px-1 rounded">https://</code> and with no trailing slash.</Trouble>
+                                    <InstructionStep num={2}>Register Pinpoint with {setupIdp === 'auth0' ? 'Auth0' : setupIdp === 'entra' ? 'Entra' : setupIdp === 'okta' ? 'Okta' : 'your provider'} and collect its credentials.</InstructionStep>
+                                    <OnTheCard card="Staff Sign-In" />
+                                    <InstructionStep num={3}
+                                        check={<>"Always" selected under the policy setting, and at least one factor switched on.</>}
+                                    >Require a second step at login. This is the single most valuable thing on this page: it means a stolen or guessed staff password is not enough on its own to reach resident records. Every provider here can do it — in Auth0 it is <strong className="text-white/90">Security → Multi-factor Auth</strong>, in Entra it is a Conditional Access policy, in Okta it is a sign-on policy. Turn on an authenticator app or passkeys, and set the policy to apply always. Warn staff first: the next time they sign in they will be asked to set it up.</InstructionStep>
+                                    <Trouble>This is not something Pinpoint can switch on for you — it lives entirely in the sign-in service. It is also the one setting a state auditor is most likely to ask about, so it is worth doing on the day rather than later.</Trouble>
                                     <InstructionStep num={4}
-                                        check={<>"Always" selected under Define Policies, and at least one factor switched on.</>}
-                                    >Require a second step at login. This is the single most valuable thing on this page: it means a stolen or guessed staff password is not enough on its own to get into resident records. Go to <strong className="text-white/90">Security → Multi-factor Auth</strong>, turn on <strong className="text-white/90">One-Time Password</strong> (a code from an app like Google Authenticator) or <strong className="text-white/90">Passkeys</strong> if your staff have newer phones. Then under <strong className="text-white/90">Define Policies</strong> choose <strong className="text-white/90">Always</strong>. Warn staff first — the next time they sign in they will be asked to set this up.</InstructionStep>
-                                    <InstructionStep num={5}
-                                        check={<>a green tick and "connection OK" on the card. If you get amber text instead, it tells you which value it could not use.</>}
-                                    >Copy the three values into Pinpoint. Back on that Auth0 <strong className="text-white/90">Settings</strong> tab there are three boxes: <strong className="text-white/90">Domain</strong>, <strong className="text-white/90">Client ID</strong> and <strong className="text-white/90">Client Secret</strong> (you will need to click "reveal" to see the secret). Copy each one into the box with the same name on the <strong className="text-white/90">Staff Sign-In</strong> card, in <strong className="text-white/90">Service Providers</strong> at the bottom of this page. Then press <strong className="text-white/90">Save &amp; Test</strong>, which stores them and immediately checks they work.</InstructionStep>
-                                    <Trouble>Copy and paste rather than retyping, and do not worry about accidentally grabbing a space at either end — Pinpoint trims those for you. The Client Secret is shown only as dots until you reveal it; a half-copied secret is the most common reason this step fails.</Trouble>
-                                    <InstructionStep num={6}
                                         check={<>their name in Pinpoint's User Management list after they have signed in once.</>}
-                                    >Add your first staff member. In Auth0 go to <strong className="text-white/90">User Management → Users → Create User</strong> and add them with their work email. <strong className="text-white/90">They have to sign in to Pinpoint once before you can give them a role</strong> — signing in is what creates their record here. After that, open <strong className="text-white/90">User Management</strong> in Pinpoint, set them to Admin or Staff, and choose their department.</InstructionStep>
-                                    <InstructionStep num={7}>
-                                        <strong className="text-white/90">The shortcut, if it applies to you.</strong> Does your town already sign in to Microsoft 365 / Office 365, or to Okta? Then you do not need Auth0 at all — skip steps 1 to 4, and on the <strong className="text-white/90">Staff Sign-In</strong> card choose <strong className="text-white/90">Microsoft Entra ID</strong> (that is what Microsoft 365 sign-in is called) or <strong className="text-white/90">Okta</strong>. Your IT provider can give you the three values it asks for. This is usually less work, and staff get to use the password they already have. The web addresses in step 3 are the same whichever you choose.
-                                    </InstructionStep>
-                                    </>}
-                                    {setupIdp === 'entra' && <>
-                                        <InstructionStep num={1} check={<>the app listed under App registrations, with a Directory (tenant) ID and Application (client) ID on its Overview page.</>}>In the <strong className="text-white/90">Microsoft Entra admin centre</strong>, go to <strong className="text-white/90">App registrations → New registration</strong>. Name it <em className="text-white/60">"{`{township} 311`}"</em>, and for supported account types choose the option limited to your own organisation.</InstructionStep>
-                                        <InstructionStep num={2}>Set the redirect URI. Platform <strong className="text-white/90">Web</strong>, and paste exactly: <code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}/api/auth/callback</code>
-                                            <button onClick={() => copyToClipboard(`${window.location.origin}/api/auth/callback`, 'entracb')} aria-label="Copy to clipboard" className="ml-1 inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'entracb' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button></InstructionStep>
-                                        <InstructionStep num={3} check={<>the secret <strong className="text-white/80">Value</strong> — not the Secret ID. It is shown once and cannot be retrieved later.</>}>Under <strong className="text-white/90">Certificates &amp; secrets → New client secret</strong>, create one and copy its Value immediately.</InstructionStep>
-                                        <InstructionStep num={4}>Paste into <strong className="text-white/90">Service Providers → Staff Sign-In → Microsoft Entra ID</strong>: the <strong className="text-white/90">Directory (tenant) ID</strong>, <strong className="text-white/90">Application (client) ID</strong> and the secret Value. <span className="text-white/45">Government tenants also set the Authority host to <code className="bg-black/30 px-1 rounded">login.microsoftonline.us</code>.</span> Then press Save &amp; Test.</InstructionStep>
-                                    </>}
-                                    {setupIdp === 'okta' && <>
-                                        <InstructionStep num={1} check={<>a Client ID and Client secret on the app's General tab.</>}>In the Okta admin console, <strong className="text-white/90">Applications → Create App Integration</strong>. Choose <strong className="text-white/90">OIDC — OpenID Connect</strong> and <strong className="text-white/90">Web Application</strong>.</InstructionStep>
-                                        <InstructionStep num={2}>Set the sign-in redirect URI to <code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}/api/auth/callback</code>
-                                            <button onClick={() => copyToClipboard(`${window.location.origin}/api/auth/callback`, 'oktacb')} aria-label="Copy to clipboard" className="ml-1 inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'oktacb' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button> and the sign-out URI to <code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}</code>. Assign the app to the staff group who should get in.</InstructionStep>
-                                        <InstructionStep num={3}>Paste into <strong className="text-white/90">Service Providers → Staff Sign-In → Okta</strong>: the <strong className="text-white/90">Issuer URL</strong> (your Okta domain, e.g. <code className="bg-black/30 px-1 rounded">https://your-org.okta.com</code>), the Client ID and the Client Secret. Then Save &amp; Test.</InstructionStep>
-                                    </>}
-                                    {setupIdp === 'oidc' && <>
-                                        <InstructionStep num={1}>Any provider speaking OpenID Connect works. In its admin console register a <strong className="text-white/90">confidential web application</strong> (one that can hold a secret), with the redirect URI <code className="bg-black/30 px-1.5 py-0.5 rounded text-orange-300 text-xs break-all">{window.location.origin}/api/auth/callback</code>
-                                            <button onClick={() => copyToClipboard(`${window.location.origin}/api/auth/callback`, 'oidccb')} aria-label="Copy to clipboard" className="ml-1 inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'oidccb' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button></InstructionStep>
-                                        <InstructionStep num={2}>Paste the <strong className="text-white/90">Issuer URL</strong>, Client ID and Client Secret into <strong className="text-white/90">Service Providers → Staff Sign-In → Generic OIDC</strong>, then Save &amp; Test.</InstructionStep>
-                                        <Trouble>Enter the issuer itself, not the discovery document. If the docs show a URL ending in <code className="bg-black/30 px-1 rounded">/.well-known/openid-configuration</code>, drop that part — Pinpoint appends it. Pasting the full discovery URL is the single most common mistake here, and the field will warn you about it.</Trouble>
-                                    </>}
+                                    >Add your first staff member, in the sign-in service rather than here. <strong className="text-white/90">They have to sign in to Pinpoint once before you can give them a role</strong> — signing in is what creates their record. After that, open <strong className="text-white/90">User Management</strong> in Pinpoint, set them to Admin or Staff, and choose their department.</InstructionStep>
                                 </Guide>
 
                                 {/* ── 2. Cloud foundation (only if a cloud-backed feature is wanted) ── */}
@@ -598,66 +582,55 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
 
                                 {/* ── AI ── */}
                                 <Guide show={wants('ai')} tone="sky" icon={Sparkles} title="AI triage"
-                                    what={<>Reads each new report and suggests a priority and a department, so a clerk is confirming a guess rather than sorting from scratch. It never closes or assigns anything on its own — staff always decide.</>}
-                                    time="About 10 minutes once your cloud account exists"
-                                    cost="Pennies per report. A town filing 500 reports a month typically spends a few dollars.">
-                                    {setupCloud === 'google' && <>
-                                        <InstructionStep num={1}>With Vertex AI enabled above, open <strong className="text-white/90">Service Providers → AI Provider</strong>, pick <strong className="text-white/90">Google Vertex AI</strong>, and paste your Project ID + service-account JSON.</InstructionStep>
-                                        <InstructionStep num={2}>Choose a model. Press <strong className="text-white/90">Refresh from provider</strong> to pull the current Gemini models live — no need to track model names by hand.</InstructionStep>
-                                    </>}
-                                    {setupCloud === 'azure' && <>
-                                        <InstructionStep num={1}>Create an <strong className="text-white/90">Azure OpenAI</strong> resource, then <strong className="text-white/90">Deploy</strong> a vision-capable model (e.g. <code className="bg-black/30 px-1 rounded text-sky-300 text-xs">gpt-4o</code>). Note the deployment name.</InstructionStep>
-                                        <InstructionStep num={2}>In <strong className="text-white/90">Service Providers → AI Provider</strong> pick <strong className="text-white/90">Azure</strong> and paste the <strong className="text-white/90">Endpoint</strong>, <strong className="text-white/90">API key</strong>, and <strong className="text-white/90">Deployment name</strong>. "Refresh from provider" lists your live deployments.</InstructionStep>
-                                    </>}
-                                    {setupCloud === 'aws' && <>
-                                        <InstructionStep num={1}>In <strong className="text-white/90">Bedrock → Model access</strong>, enable the models you want (e.g. a Claude model). Vision-capable models also cover image moderation.</InstructionStep>
-                                        <InstructionStep num={2}>In <strong className="text-white/90">Service Providers → AI Provider</strong> pick <strong className="text-white/90">AWS Bedrock</strong> and enter your region; credentials come from your AWS setup above.</InstructionStep>
-                                    </>}
-                                    <InstructionStep num={3}><em className="text-white/50">Optional:</em> AI is skippable — if it's off or unreachable, requests still submit and the triage panel shows the computed context (history, nearby, weather); only the AI summary is skipped.</InstructionStep>
+                                    what={<>Reads each new report and suggests a category, a priority and the department it belongs to. A clerk still decides — the suggestion is a starting point, never an action.</>}
+                                    time="About 15 minutes once your cloud account exists"
+                                    cost="Cents per hundred reports on any of the three providers.">
+                                    <InstructionStep num={1}>Enable the model service in the cloud account you set up above, and give Pinpoint permission to call it — nothing more than that. A leaked key scoped to "ask the model a question" can run up a bill; the same key with a broad role can delete the project.</InstructionStep>
+                                    <OnTheCard card="AI Provider" />
+                                    <Trouble>Model availability differs by region on every provider, and on AWS the models have to be requested before they can be used. If the picker is empty, that is usually why rather than a bad key.</Trouble>
                                 </Guide>
 
                                 {/* ── Translation ── */}
                                 <Guide show={wants('translation')} tone="cyan" icon={Languages} title="Translation"
-                                    what={<>Lets a resident file in their own language and read updates in it, while staff see everything in English. Useful in most New Jersey towns; if you are not sure you need it, you can turn it on later.</>}
-                                    time="About 5 minutes once your cloud account exists"
-                                    cost="Charged per character translated — usually a few dollars a month.">
-                                    {setupCloud === 'google' && <InstructionStep num={1}>Cloud Translation is enabled in the foundation step. In <strong className="text-white/90">Service Providers → Translation</strong> pick <strong className="text-white/90">Google</strong> — it uses the same service account.</InstructionStep>}
-                                    {setupCloud === 'azure' && <InstructionStep num={1}>Create a <strong className="text-white/90">Translator</strong> resource, copy its <strong className="text-white/90">Key</strong> + <strong className="text-white/90">Region</strong>, and enter them under <strong className="text-white/90">Service Providers → Translation → Azure</strong>.</InstructionStep>}
-                                    {setupCloud === 'aws' && <InstructionStep num={1}>Amazon Translate needs no extra resource. In <strong className="text-white/90">Service Providers → Translation</strong> pick <strong className="text-white/90">AWS</strong>; it uses your region + credentials.</InstructionStep>}
+                                    what={<>Lets a resident file a report in their own language and read the replies in it, and lets staff work entirely in English. For many towns this is a Title VI obligation rather than a nicety.</>}
+                                    time="About 10 minutes"
+                                    cost="Free for a small town's volume on all three providers.">
+                                    <InstructionStep num={1}>Enable the translation service in the cloud account you set up above. On Google it is an API to switch on; on Azure a Translator resource; on AWS nothing at all, it is on by default.</InstructionStep>
+                                    <OnTheCard card="Translation" />
                                 </Guide>
 
                                 {/* ── Secrets + PII encryption ── */}
                                 <Guide show={wants('secrets')} tone="violet" icon={Lock} title="Secure storage for keys and resident data (recommended)"
-                                    what={<>All the keys you are pasting in during setup have to live somewhere. By default they sit in Pinpoint's own database; with this turned on they live in your cloud's dedicated vault instead, and residents' names, phone numbers and emails are encrypted with a key only your town controls. This is the option to point at when someone asks how resident data is protected.</>}
+                                    what={<>Two related things. Your integration credentials move out of the database into your cloud's secret store, and the key that encrypts resident names, emails and phone numbers is held by your cloud's key service rather than derived from a setting in a file. Both are what an auditor means by "key management".</>}
                                     time="About 20 minutes"
-                                    cost="Well under a dollar a month at a town's scale.">
-                                    {setupCloud === 'google' && <>
-                                        <InstructionStep num={1}>In <strong className="text-white/90">Security → Key Management</strong> create a key ring <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">pinpoint311-keyring</code> and a symmetric key <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">pii-encryption-key</code> (or your own names).</InstructionStep>
-                                        <InstructionStep num={2}>Grant the service account <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">Cloud KMS CryptoKey Encrypter/Decrypter</code> and <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">Secret Manager Admin</code>, then fill the Google Cloud card below.</InstructionStep>
-                                    </>}
-                                    {setupCloud === 'azure' && <InstructionStep num={1}>Create an <strong className="text-white/90">Azure Key Vault</strong>. Pinpoint stores integration secrets and wraps the PII encryption key there — set <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">SECRETS_PROVIDER=azure</code> and the vault URL/credentials.</InstructionStep>}
-                                    {setupCloud === 'aws' && <InstructionStep num={1}>Create a <strong className="text-white/90">KMS key</strong> and enable <strong className="text-white/90">Secrets Manager</strong>. Set <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">SECRETS_PROVIDER=aws</code>; the same AWS credentials cover both.</InstructionStep>}
-                                    <InstructionStep num={2}>Once a vault is configured, integration credentials are stored <strong className="text-white/90">there</strong> (the app keeps only a reference), not in the app database. The connector card shows a "stored in your Secret Manager" badge.</InstructionStep>
+                                    cost="Under a dollar a month.">
+                                    <InstructionStep num={1}>Create the key and the vault in the cloud account you set up above, and grant Pinpoint permission to <strong className="text-white/90">wrap and unwrap</strong> with that key — not just to read it.</InstructionStep>
+                                    <Trouble>Wrap and unwrap are the two permissions people miss, and missing them fails quietly: the key exists, the settings save, and resident data is encrypted with the application key instead. The health dashboard is the only place that says so — it will tell you the key manager you selected is not the one being used.</Trouble>
+                                    <OnTheCard card="Resident Data Encryption" />
+                                    <InstructionStep num={2}>Once the vault is reachable, credentials already in the database move across on their own, within the hour. There is no button to press and nothing to remember.</InstructionStep>
+                                    <Trouble>Never delete or disable this key once resident data has been written under it. Every cloud enforces a waiting period and then destroys it permanently, and nobody — including the cloud provider — can recover what it protected.</Trouble>
                                 </Guide>
 
                                 {/* ── Email ── */}
                                 <Guide show={wants('email')} tone="violet" icon={Mail} title="Email notifications" done={smtpConfigured}
-                                    what={<>Sends the resident a confirmation when they file, and an update when staff change the status. Without it a resident has no way to know anything happened, which is the most common complaint about 311 systems.</>}
-                                    time="About 15 minutes"
-                                    cost="Free at a town's volume with most providers.">
-                                    <InstructionStep num={1}><strong className="text-white/90">Any cloud — SMTP:</strong> use SendGrid, Gmail App Passwords, or your org relay. Host <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">smtp.sendgrid.net</code> / <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">587</code>, then fill the <strong className="text-white/90">Email</strong> card in Service Providers, picking <strong className="text-white/90">SMTP</strong>.</InstructionStep>
-                                    {setupCloud === 'azure' && <InstructionStep num={2}><strong className="text-white/90">Or native Azure:</strong> create an <strong className="text-white/90">Azure Communication Services</strong> resource, connect an email domain, and use its connection string (provider "acs").</InstructionStep>}
-                                    {setupCloud === 'aws' && <InstructionStep num={2}><strong className="text-white/90">Or native AWS:</strong> verify a sender/domain in <strong className="text-white/90">Amazon SES</strong> and use SES (provider "ses") with your region + credentials.</InstructionStep>}
+                                    what={<>The confirmation a resident gets when they file, and the update when it is resolved. Without this, residents have no idea anything happened, and the phone calls come to you instead.</>}
+                                    time="About 15 minutes, longer if DNS records are involved"
+                                    cost="Free to a few dollars a month.">
+                                    <InstructionStep num={1}>Decide who sends. A dedicated town address like <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">311@yourtown.gov</code> rather than <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">noreply@</code> — residents reply to these, and a reply that goes nowhere is a complaint you never hear.</InstructionStep>
+                                    <OnTheCard card="Email" />
+                                    <Trouble>Microsoft 365 and Google Workspace both block plain SMTP by default. If your IT provider says it is not allowed, they are right — Amazon SES or Azure Communication Services will be less work than getting an exception.</Trouble>
                                 </Guide>
 
                                 {/* ── SMS ── */}
                                 <Guide show={wants('sms')} tone="emerald" icon={MessageSquare} title="Text message notifications" done={smsConfigured}
-                                    what={<>The same updates as email, by text. Optional, and residents choose whether to give a mobile number.</>}
-                                    time="About 20 minutes, plus a wait"
-                                    cost="Roughly a cent per message. Note that US carriers now require you to register your town before you can send texts, which takes a few business days — start this early if you want it.">
-                                    <InstructionStep num={1}><strong className="text-white/90">Any cloud — Twilio:</strong> create an account at <a href="https://www.twilio.com" target="_blank" rel="noopener noreferrer" className="text-emerald-300 underline underline-offset-2">twilio.com</a>, buy a number, and enter the SID/token/number in the SMS card.</InstructionStep>
-                                    {setupCloud === 'azure' && <InstructionStep num={2}><strong className="text-white/90">Or native Azure:</strong> use <strong className="text-white/90">Azure Communication Services</strong> SMS (provider "acs") with a provisioned number.</InstructionStep>}
-                                    {setupCloud === 'aws' && <InstructionStep num={2}><strong className="text-white/90">Or native AWS:</strong> use <strong className="text-white/90">Amazon SNS</strong> (provider "sns"); it uses your region + credentials.</InstructionStep>}
+                                    what={<>The same updates by text, for residents who give a mobile number. Optional — email alone is a complete service.</>}
+                                    time="About 15 minutes, plus carrier registration"
+                                    cost="Around a cent per message.">
+                                    <InstructionStep num={1}>
+                                        <strong className="text-white/90">Start the carrier registration first, whichever provider you use.</strong> Texting US numbers from a business or government sender needs 10DLC registration, which identifies your town to the carriers. It is not a technical step and it is not quick — allow a couple of weeks. Unregistered messages are filtered heavily and often silently.
+                                    </InstructionStep>
+                                    <OnTheCard card="Text Messages" />
+                                    <Trouble>Every provider starts you in a trial or sandbox that can only text numbers you have verified. Everything looks like it works — the send succeeds — and residents receive nothing. Leave it before launch.</Trouble>
                                 </Guide>
 
                                 {/* ── Content moderation ── */}
@@ -674,45 +647,16 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
 
                                 {/* ── Maps (always) ── */}
                                 <Guide tone="blue" icon={MapPin} title="Maps" done={mapsConfigured}
-                                    what={<>Every town needs one. Without it a resident cannot search for their address or drop a pin, so reports arrive with no location. Any of the four providers works — the steps below follow the one you picked above.</>}
-                                    time={setupMaps === 'google' ? "About 15 minutes" : "About 10 minutes"}
-                                    cost={setupMaps === 'google'
-                                        ? "Google gives $200 of free map use every month, far more than a town of any size will reach. You still have to put a card on file — Google will not turn the maps on without one."
-                                        : setupMaps === 'esri' ? "Often already covered by a county or state ArcGIS agreement — check before buying."
-                                        : setupMaps === 'apple' ? "Needs a paid Apple Developer account (about $99/year)."
-                                        : "Pay-as-you-go, with a free tier that covers a town's volume."}>
-                                    {setupMaps === 'google' && <>
-                                    <InstructionStep num={1}
-                                        check={<>a blue "API Enabled" banner on each of the three, and a billing account listed under Billing.</>}
-                                    >Turn on the three map services. Go to <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">Google Cloud</a> and sign in with a <strong className="text-white/90">shared town account</strong>. If you already made a project in an earlier step, use that one. Go to <strong className="text-white/90">APIs &amp; Services → Library</strong>, search for each of these and click Enable on all three: <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Maps JavaScript API</code>, <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Geocoding API</code>, <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Places API</code>. Then go to <strong className="text-white/90">Billing</strong> and attach a payment method.</InstructionStep>
-                                    <Trouble>The payment method is not optional and it is the step people skip. Google will happily give you a key without it, the key will look correct, and the map will show a grey box saying <em>"this page can't load Google Maps correctly"</em> with no other explanation. If you see that grey box, check Billing first.</Trouble>
+                                    what={<>The map a resident drops a pin on, and the address lookup that turns what they type into a location your crews can find. Required — a 311 report without a location is not actionable.</>}
+                                    time="About 20 minutes"
+                                    cost="Google and Azure have free tiers a town will not exceed; Esri may already be covered by a county licence; Apple needs a paid developer membership.">
+                                    <InstructionStep num={1}>
+                                        <strong className="text-white/90">Ask your GIS department before you buy anything.</strong> If the town or county has an ArcGIS agreement — many New Jersey towns do — choose Esri above. You get the map free under that licence, and more importantly you can point address lookup at the county's own locator, which knows your street names, your address ranges and your recent subdivisions. A national geocoder does not.
+                                    </InstructionStep>
+                                    <OnTheCard card="Maps Provider" />
                                     <InstructionStep num={2}
-                                        check={<>a long string starting with <code className="bg-black/30 px-1 rounded">AIza</code>. Copy it somewhere safe for a moment — you need it in step 4.</>}
-                                    >Create the key. Go to <strong className="text-white/90">APIs &amp; Services → Credentials</strong>, click <strong className="text-white/90">Create Credentials</strong> at the top, and choose <strong className="text-white/90">API key</strong>.</InstructionStep>
-                                    <InstructionStep num={3}
-                                        check={<>your site listed under Website restrictions, and only the three services ticked under API restrictions.</>}
-                                    >Lock the key to your own website. Do not skip this — an unrestricted key can be copied off your site and run up a bill on your town's card. Click the key you just made. Under <strong className="text-white/90">Application restrictions</strong> choose <strong className="text-white/90">Websites</strong>, click Add, and paste exactly this: <code className="bg-black/30 px-1.5 py-0.5 rounded text-blue-300 text-xs break-all">{window.location.origin}/*</code>
-                                        <button onClick={() => copyToClipboard(`${window.location.origin}/*`, 'mapsref')} aria-label="Copy to clipboard" className="ml-1 inline-flex text-white/40 hover:text-white/70 transition-colors">{copyFeedback === 'mapsref' ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}</button> — the <code className="bg-black/30 px-1 rounded">/*</code> on the end matters. Then under <strong className="text-white/90">API restrictions</strong> choose <strong className="text-white/90">Restrict key</strong> and tick the same three services from step 1. Save.</InstructionStep>
-                                    <InstructionStep num={4}
                                         check={<>the address box offering suggestions as you type, and a pin appearing when you click the map.</>}
-                                    >Paste the key into Pinpoint and check it. Put it in the <strong className="text-white/90">Maps Provider</strong> card in <strong className="text-white/90">Service Providers</strong> at the bottom of this page, then press <strong className="text-white/90">Save &amp; Test</strong>. Now open the resident portal in another tab and try filing a test report. <span className="text-white/45">(The <strong className="text-white/70">Map ID</strong> box is optional — it only changes how the map looks. Leave it empty.)</span></InstructionStep>
-                                    <Trouble>Changes to a Google key can take up to five minutes to take effect. If the map is still grey straight after saving, wait a few minutes and reload before changing anything else.</Trouble>
-                                    </>}
-                                    {setupMaps === 'esri' && <>
-                                        <InstructionStep num={1} check={<>an API key listed in your ArcGIS developer dashboard.</>}>Sign in to <strong className="text-white/90">ArcGIS Location Platform</strong> with your organisation's account, and create an <strong className="text-white/90">API key</strong>. Scope it to the basemap and geocoding services you are entitled to use.</InstructionStep>
-                                        <InstructionStep num={2}>Paste it into <strong className="text-white/90">Service Providers → Maps Provider → Esri / ArcGIS</strong> as the <strong className="text-white/90">ArcGIS API key</strong>, then Save &amp; Test. <span className="text-white/45">Basemap ID and Address locator URL are optional — set them only if your county publishes its own, which is the usual reason to choose Esri.</span></InstructionStep>
-                                        <Trouble>Check with whoever administers your county or state ArcGIS agreement before buying anything. Many New Jersey towns are already covered by a county licence, and geocoding against the county's own locator is more accurate for local addresses than a national one.</Trouble>
-                                    </>}
-                                    {setupMaps === 'azure' && <>
-                                        <InstructionStep num={1} check={<>two keys listed under Authentication; either one works.</>}>In the Azure portal create an <strong className="text-white/90">Azure Maps</strong> account, then open <strong className="text-white/90">Authentication</strong> and copy the <strong className="text-white/90">Primary Key</strong>.</InstructionStep>
-                                        <InstructionStep num={2}>Paste it into <strong className="text-white/90">Service Providers → Maps Provider → Azure Maps</strong> as the <strong className="text-white/90">Subscription key</strong>, then Save &amp; Test.</InstructionStep>
-                                    </>}
-                                    {setupMaps === 'apple' && <>
-                                        <InstructionStep num={1} check={<>a downloaded <code className="bg-black/30 px-1 rounded">.p8</code> file. It downloads once and cannot be downloaded again.</>}>This needs a paid <strong className="text-white/90">Apple Developer</strong> account. In the developer portal create a <strong className="text-white/90">MapKit JS</strong> key and download it.</InstructionStep>
-                                        <InstructionStep num={2}>Collect three values: your <strong className="text-white/90">Team ID</strong> (membership details), the <strong className="text-white/90">Key ID</strong> shown next to the key, and the contents of the <code className="bg-black/30 px-1 rounded">.p8</code> file.</InstructionStep>
-                                        <InstructionStep num={3}>Enter all three under <strong className="text-white/90">Service Providers → Maps Provider → Apple Maps</strong>, then Save &amp; Test.</InstructionStep>
-                                        <Trouble>Paste the whole <code className="bg-black/30 px-1 rounded">.p8</code> file including the <code className="bg-black/30 px-1 rounded">-----BEGIN PRIVATE KEY-----</code> and <code className="bg-black/30 px-1 rounded">-----END PRIVATE KEY-----</code> lines. Pasting only the middle block is the usual mistake, and the field will tell you if you do.</Trouble>
-                                    </>}
+                                    >Test it as a resident would. Open the resident portal in another tab and file a test report — the map failing is the one thing on this page a resident notices immediately.</InstructionStep>
                                 </Guide>
 
                                 {/* ── GovTech connector ── */}
@@ -728,12 +672,11 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                 {/* ── Database backups ── */}
                                 {/* ── Photo redaction ── */}
                                 <Guide show={wants('moderation')} tone="rose" icon={ImageIcon} title="Blurring faces and licence plates" done={redactionConfigured}
-                                    what={<>Residents photograph the pothole and the neighbour walking past it. This finds faces and plates before the photo is stored, so the municipal site never publishes them. It runs on the way in — the unblurred original is never saved.</>}
-                                    time="About 2 minutes"
-                                    cost={setupCloud === 'google' ? "Roughly a tenth of a cent per photo on Cloud Vision." : "A fraction of a cent per photo, or nothing at all on your own server."}>
-                                    <InstructionStep num={1}>Open <strong className="text-white/90">Service Providers → Photo Redaction</strong> and pick a detector. The cloud ones reuse the credentials you already entered — there is no new key. <strong className="text-white/90">On this server</strong> needs no account at all and no photo leaves the building, at some cost in accuracy.</InstructionStep>
-                                    <InstructionStep num={2} check={<>a face blurred in the photo on the request you just filed.</>}>Faces and plates are both on by default. Save, then file a test report with a photo of a person or a car and open it in the staff view.</InstructionStep>
-                                    <Trouble>Plate detection guesses, and what it occasionally guesses wrong is a house number. If your crews work from those, switch <strong className="text-white/90">Blur licence plates</strong> off on the same card — faces stay on.</Trouble>
+                                    what={<>Residents photograph potholes with cars parked beside them and neighbours walking past. Those people did not ask to be in a public record, and a 311 photo is one. This blurs faces and plates before the photo is stored.</>}
+                                    time="About 10 minutes"
+                                    cost="A dollar or two per thousand photos, or free if you run it on this server.">
+                                    <InstructionStep num={1}>Choose where detection happens. All three clouds do it well; the option that runs on this server finds fewer faces — particularly small or partly turned ones — but no photo ever leaves the building, which for some towns settles it.</InstructionStep>
+                                    <OnTheCard card="Photo Redaction" />
                                 </Guide>
 
                                 {/* ── Error reporting ── */}
@@ -750,9 +693,11 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     what={<>Takes a nightly encrypted copy of everything and stores it off the server. Do this one. 311 reports are public records the town is legally required to keep, and a server can fail.</>}
                                     time="About 20 minutes"
                                     cost="A few dollars a month for storage.">
-                                    <InstructionStep num={1}>Provision an <strong className="text-white/90">S3-compatible</strong> bucket (AWS S3, Oracle Object Storage, MinIO, …) with put/get/list/delete permissions and an access key.</InstructionStep>
-                                    <InstructionStep num={2}>Choose a strong <strong className="text-white/90">AES-256 passphrase</strong> and store it safely — backups can't be restored without it.</InstructionStep>
-                                    <InstructionStep num={3}>Enter the bucket, keys, encryption passphrase, and optional endpoint/region in the <strong className="text-white/90">Database Backups</strong> card below.</InstructionStep>
+                                    <InstructionStep num={1}>Provision an <strong className="text-white/90">S3-compatible</strong> bucket (AWS S3, Oracle Object Storage, MinIO, …) with put/get/list/delete permissions, and take an access key for it.</InstructionStep>
+                                    <InstructionStep num={2}
+                                        check={<>the passphrase shown once, with a box to tick confirming you have put a copy somewhere else.</>}
+                                    >Enter the bucket and keys in the <strong className="text-white/90">Database Backups</strong> card below, and press <strong className="text-white/90">Create backup passphrase</strong>. You are not asked to invent one — inventing a passphrase reliably produces either something guessable or something nobody can find again.</InstructionStep>
+                                    <Trouble>The one part nobody can automate is keeping a copy somewhere other than this server. A key held only inside the system it protects is worth nothing on the day that system is gone — which is the day a backup matters. A password manager, or a sealed envelope in the clerk's safe.</Trouble>
                                     <div className="mt-3 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2">
                                         <p className="text-amber-200/80 text-xs"><strong>⚠ Privacy note:</strong> Backups contain a full snapshot including resident PII. Retention deletes old backups, but PII anonymization only applies to the live database — not to existing backup files.</p>
                                     </div>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -987,22 +987,27 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                                 </div>
                                             )}
 
-                                            {/* Where the stored data lives.
-                                                *
-                                                * This used to be two buttons -- "Vault Local Secrets to
-                                                * GCP Identity" and "Re-encrypt All PII Data (after key
-                                                * rotation)" -- which asked a clerk to recognise the need
-                                                * for work they had no way to know about. Both now run on
-                                                * a schedule, so all that is left is one sentence, shown
-                                                * only while there is something in flight. */}
-                                            <div className="border-t border-white/10 pt-3 mt-3">
-                                                <StorageStatusLine />
-                                            </div>
                                         </div>
                                     )}
                                 </div>
                             </motion.div>
                             )}
+
+                            {/* Where the stored data actually lives.
+                              *
+                              * This used to be two buttons -- "Vault Local Secrets to GCP
+                              * Identity" and "Re-encrypt All PII Data (after key rotation)" --
+                              * which asked a clerk to recognise the need for work they had no
+                              * way to know about. Both now run on a schedule, so all that is
+                              * left is one sentence.
+                              *
+                              * Deliberately outside the Google Cloud card. Secret storage and
+                              * key management are pluggable, and anything nested in that card
+                              * is invisible to a town on Azure or AWS -- which is exactly the
+                              * town most likely to want to know where its credentials are. */}
+                            <div className="px-1">
+                                <StorageStatusLine />
+                            </div>
 
 
                             {/* Sentry Error Tracking - Premium Card */}

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -16,6 +16,7 @@ import { api } from '../services/api';
 import type { Capability } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
+import StorageStatusLine from './StorageStatusLine';
 
 
 interface ModulesState {
@@ -38,6 +39,11 @@ interface SetupIntegrationsPageProps {
 export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh, modules, onUpdateModules }: SetupIntegrationsPageProps) {
     const [secretValues, setSecretValues] = useState<Record<string, string>>({});
     const [savingKey, setSavingKey] = useState<string | null>(null);
+    // The backup passphrase is generated rather than invented, shown once, and
+    // gated on someone confirming they have put a copy somewhere else. See the
+    // /setup/backup-key endpoint for why that last part cannot be automated.
+    const [backupKey, setBackupKey] = useState<string | null>(null);
+    const [backupKeyAcknowledged, setBackupKeyAcknowledged] = useState(false);
 
     const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
     /* The guide starts open on a fresh install and closed once the required
@@ -981,57 +987,16 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                                 </div>
                                             )}
 
-                                            {/* Migrate Secrets to GCP */}
+                                            {/* Where the stored data lives.
+                                                *
+                                                * This used to be two buttons -- "Vault Local Secrets to
+                                                * GCP Identity" and "Re-encrypt All PII Data (after key
+                                                * rotation)" -- which asked a clerk to recognise the need
+                                                * for work they had no way to know about. Both now run on
+                                                * a schedule, so all that is left is one sentence, shown
+                                                * only while there is something in flight. */}
                                             <div className="border-t border-white/10 pt-3 mt-3">
-                                                <Button
-                                                    size="sm"
-                                                    variant="ghost"
-                                                    className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
-                                                    onClick={async () => {
-                                                        try {
-                                                            setSaveMessage('Migrating secrets to GCP...');
-                                                            const result = await api.migrateToSecretManager();
-                                                            setSaveMessage(
-                                                                `✅ Migrated: ${result.migrated} keys. Scrubbed from DB: ${result.scrubbed}.` +
-                                                                (result.failed > 0 ? ` Failed: ${result.failed}` : '')
-                                                            );
-                                                        } catch (err: any) {
-                                                            setSaveMessage(`❌ ${err.message || 'Migration failed'}`);
-                                                        }
-                                                    }}
-                                                >
-                                                    Vault Local Secrets to GCP Identity
-                                                </Button>
-                                                <p className="text-white/30 text-[10px] mt-1 text-center">
-                                                    Moves database-encrypted API keys into Secret Manager
-                                                </p>
-                                            </div>
-
-                                            {/* Re-encrypt PII after KMS key rotation */}
-                                            <div className="border-t border-white/10 pt-3 mt-1">
-                                                <Button
-                                                    size="sm"
-                                                    variant="ghost"
-                                                    className="w-full text-xs text-white/50 hover:text-white hover:bg-white/10"
-                                                    onClick={async () => {
-                                                        try {
-                                                            setSaveMessage('Re-encrypting PII data...');
-                                                            const result = await api.reencryptPii();
-                                                            setSaveMessage(
-                                                                `✅ Done: ${result.reencrypted}/${result.total} rows re-encrypted` +
-                                                                (result.migrated_from_fernet > 0 ? `, ${result.migrated_from_fernet} migrated from Fernet` : '') +
-                                                                (result.errors > 0 ? `, ${result.errors} errors` : '')
-                                                            );
-                                                        } catch (err: any) {
-                                                            setSaveMessage(`❌ ${err.message || 'Re-encryption failed'}`);
-                                                        }
-                                                    }}
-                                                >
-                                                    🔐 Re-encrypt All PII Data (after key rotation)
-                                                </Button>
-                                                <p className="text-white/30 text-[10px] mt-1 text-center">
-                                                    Migrates historical PII to the current primary KMS key version
-                                                </p>
+                                                <StorageStatusLine />
                                             </div>
                                         </div>
                                     )}
@@ -1217,13 +1182,62 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
 
                                             <div>
                                                 <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
-                                                <Input
-                                                    type="password"
-                                                    placeholder="Strong passphrase for AES-256 encryption"
-                                                    value={secretValues['BACKUP_ENCRYPTION_KEY'] || ''}
-                                                    onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_ENCRYPTION_KEY': e.target.value }))}
-                                                    className="text-sm"
-                                                />
+                                                {!backupKey ? (
+                                                    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                                                        <p className="text-white/50 text-xs mb-2.5">
+                                                            {isConfigured('BACKUP_ENCRYPTION_KEY')
+                                                                ? "A passphrase is already set and backups are being encrypted with it. Creating a new one means older backups can only be restored with the old passphrase — so only do this if the current one has been exposed."
+                                                                : "Backups are encrypted before they leave this server. We'll create the passphrase for you — you don't need to think one up."}
+                                                        </p>
+                                                        <Button
+                                                            size="sm"
+                                                            variant="ghost"
+                                                            className="w-full border border-white/15 hover:bg-white/10"
+                                                            onClick={async () => {
+                                                                try {
+                                                                    const { key } = await api.generateBackupKey();
+                                                                    setBackupKey(key);
+                                                                } catch (err: any) {
+                                                                    setSaveMessage(`❌ ${err.message || 'Could not create a passphrase'}`);
+                                                                }
+                                                            }}
+                                                        >
+                                                            {isConfigured('BACKUP_ENCRYPTION_KEY')
+                                                                ? 'Replace backup passphrase'
+                                                                : 'Create backup passphrase'}
+                                                        </Button>
+                                                    </div>
+                                                ) : (
+                                                    <div className="rounded-xl border border-amber-400/30 bg-amber-500/[0.07] p-3 space-y-2.5">
+                                                        <p className="text-amber-100/90 text-xs leading-relaxed">
+                                                            This is shown once. Put a copy somewhere that is <strong>not this
+                                                            server</strong> — a password manager, or a sealed envelope in the
+                                                            clerk's safe. Without it, a backup cannot be restored, and that is the
+                                                            one thing we cannot do for you.
+                                                        </p>
+                                                        <div className="flex items-center gap-2">
+                                                            <code className="flex-1 bg-black/40 rounded-lg px-3 py-2 text-[11px] text-amber-200 break-all select-all">
+                                                                {backupKey}
+                                                            </code>
+                                                            <Button
+                                                                size="sm"
+                                                                variant="ghost"
+                                                                onClick={() => navigator.clipboard?.writeText(backupKey)}
+                                                            >
+                                                                Copy
+                                                            </Button>
+                                                        </div>
+                                                        <label className="flex items-start gap-2 text-xs text-white/70 cursor-pointer">
+                                                            <input
+                                                                type="checkbox"
+                                                                checked={backupKeyAcknowledged}
+                                                                onChange={(e) => setBackupKeyAcknowledged(e.target.checked)}
+                                                                className="mt-0.5 accent-amber-400"
+                                                            />
+                                                            I have saved a copy of this passphrase somewhere off this server.
+                                                        </label>
+                                                    </div>
+                                                )}
                                             </div>
 
                                             <div className="grid grid-cols-2 gap-2">
@@ -1256,11 +1270,14 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                                     if (secretValues['BACKUP_S3_BUCKET']) await handleSave('BACKUP_S3_BUCKET');
                                                     if (secretValues['BACKUP_S3_ACCESS_KEY']) await handleSave('BACKUP_S3_ACCESS_KEY');
                                                     if (secretValues['BACKUP_S3_SECRET_KEY']) await handleSave('BACKUP_S3_SECRET_KEY');
-                                                    if (secretValues['BACKUP_ENCRYPTION_KEY']) await handleSave('BACKUP_ENCRYPTION_KEY');
+                                                    // The passphrase is stored by the endpoint that
+                                                    // generates it, so there is nothing to save here.
                                                     if (secretValues['BACKUP_S3_ENDPOINT']) await handleSave('BACKUP_S3_ENDPOINT');
                                                     if (secretValues['BACKUP_S3_REGION']) await handleSave('BACKUP_S3_REGION');
                                                 }}
-                                                disabled={!secretValues['BACKUP_S3_BUCKET'] || !secretValues['BACKUP_ENCRYPTION_KEY'] || savingKey !== null}
+                                                disabled={!secretValues['BACKUP_S3_BUCKET']
+                                                    || !(backupKeyAcknowledged || (!backupKey && isConfigured('BACKUP_ENCRYPTION_KEY')))
+                                                    || savingKey !== null}
                                             >
                                                 {savingKey ? 'Saving...' : 'Save Backup Settings'}
                                             </Button>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -91,54 +91,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             .map(([, capability]) => capability),
     );
 
-    /* What to do to obtain the credentials for a given provider, shown inside
-     * the card immediately above the boxes.
-     *
-     * Short on purpose. The long guide above still exists for someone starting
-     * from nothing; this is the reminder you want when you are already looking
-     * at the field and have forgotten which console page the value is on. Keyed
-     * by capability and provider so switching provider switches the reminder,
-     * the same way the fields themselves switch.
-     *
-     * Returning null is normal -- a provider that needs no explanation beyond
-     * its field labels should not be given filler. */
-    const cardInstructions = (cap: Capability, provider: string): React.ReactNode => {
-        const K: Record<string, React.ReactNode> = {
-            'ai:vertex': <>Enable <strong className="text-white/85">Vertex AI API</strong> in Google Cloud, then use the project ID and service-account JSON from the Google Cloud step above.</>,
-            'ai:azure': <>Create an <strong className="text-white/85">Azure OpenAI</strong> resource and deploy a vision-capable model. The deployment name is what goes in the third box, not the model name.</>,
-            'ai:bedrock': <>In <strong className="text-white/85">Bedrock → Model access</strong>, enable the models you want first — a region alone is not enough if nothing is enabled in it.</>,
-            'translation:google': <>Nothing new to fetch. Enable <strong className="text-white/85">Cloud Translation API</strong> and reuse the same project as AI.</>,
-            'translation:azure': <>Create a <strong className="text-white/85">Translator</strong> resource; its Key and Region are on the resource's Keys and Endpoint page.</>,
-            'translation:aws': <>No resource to create. Amazon Translate works with the region and credentials you already use.</>,
-            'identity:auth0': <>Applications → your app → Settings. Add <code className="bg-black/30 px-1 rounded text-[11px]">{window.location.origin}/api/auth/callback</code> as an Allowed Callback URL first, or sign-in fails after the password.</>,
-            'identity:entra': <>App registrations → your app. Overview holds both IDs; the secret <em>Value</em> (not the Secret ID) is under Certificates &amp; secrets and is shown only once.</>,
-            'identity:okta': <>The Issuer is your Okta domain, e.g. <code className="bg-black/30 px-1 rounded text-[11px]">https://your-org.okta.com</code>. Assign the app to a staff group or nobody can sign in.</>,
-            'identity:oidc': <>Enter the issuer itself. If your provider's docs show a URL ending <code className="bg-black/30 px-1 rounded text-[11px]">/.well-known/openid-configuration</code>, leave that part off.</>,
-            'maps:google': <>Enable Maps JavaScript, Geocoding and Places, attach billing, then restrict the key to <code className="bg-black/30 px-1 rounded text-[11px]">{window.location.origin}/*</code>. Without billing the key looks fine and the map stays grey.</>,
-            'maps:esri': <>An API key from ArcGIS Location Platform. Check whether your county's licence already covers you before buying one.</>,
-            'maps:azure': <>Azure Maps account → Authentication → Primary Key.</>,
-            'maps:apple': <>Needs a paid Apple Developer account. Paste the whole <code className="bg-black/30 px-1 rounded text-[11px]">.p8</code> file including its BEGIN and END lines.</>,
-            'email:smtp': <>Your existing mail server. For Microsoft 365 or Google Workspace this needs an <strong className="text-white/85">app password</strong>, not the account password.</>,
-            'email:ses': <>SES refuses to send from an address or domain you have not verified in its console first.</>,
-            'email:acs': <>The endpoint and key are on the Communication Services resource, under Keys.</>,
-            'sms:none': <>Nothing to enter. Residents still get email updates.</>,
-            'sms:twilio': <>Account SID and Auth Token are on the Twilio console home page. The number must be one you own there, in <code className="bg-black/30 px-1 rounded text-[11px]">+1XXXXXXXXXX</code> form.</>,
-            'sms:sns': <>Uses your existing AWS credentials. New AWS accounts are sandboxed for SMS — request production access or only verified numbers receive anything.</>,
-            'sms:acs': <>The same Communication Services resource as email, plus a number provisioned in it.</>,
-            'sms:http': <>For a gateway not listed here. Not certified against any particular vendor, so send a test before relying on it.</>,
-            'kms:google': <>Enable <strong className="text-white/85">Cloud KMS API</strong>. The three boxes only name the key inside your project; leave them blank for the defaults.</>,
-            'kms:azure': <>Key Vault URL and key name, plus an app registration that can wrap and unwrap with it.</>,
-            'kms:aws': <>A KMS key ID or ARN in the same region as the rest of your AWS setup.</>,
-            'kms:local': <>Nothing to enter. Resident data is still encrypted, using the application's own key rather than a cloud key service.</>,
-            'redaction:local': <>Nothing to enter — detection runs here and no photo leaves the building. Less accurate than the cloud detectors.</>,
-        };
-        const cloud = K[`${cap}:${provider}`];
-        if (cloud) return cloud;
-        if (cap === 'redaction') {
-            return <>No new credentials — this reuses the {provider === 'google' ? 'Google Cloud' : provider === 'aws' ? 'AWS' : 'Azure'} keys you entered above. Both toggles are on by default; plate detection guesses, and what it occasionally blurs is a house number.</>;
-        }
-        return null;
-    };
 
     // Managed (state-hosted) mode: infrastructure cards are locked because the
     // state's orchestrator owns those keys (Google Cloud, Backups, domain).
@@ -802,7 +754,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             <div id="sec-providers">
                 <ServiceProviders
                     show={wantedCapabilities}
-                    instructions={cardInstructions}
                     extras={
                         <>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -7,7 +7,7 @@ import {
     ExternalLink, AlertTriangle, Database, BookOpen,
     ListChecks, HardDrive, MapPin,
     Sparkles, Languages, Lock, Image as ImageIcon, Landmark,
-    Clock, DollarSign,
+    Clock, DollarSign, Bell,
 } from 'lucide-react';
 
 import { Card, Button, Input, Badge, CollapsibleSection } from './ui';
@@ -17,6 +17,7 @@ import type { Capability } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 import StorageStatusLine from './StorageStatusLine';
+import { openStayInformed } from './StayInformed';
 
 
 interface ModulesState {
@@ -379,6 +380,26 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                             {step.required && !step.done && <span className="text-[10px] opacity-70">required</span>}
                         </span>
                     ))}
+                </div>
+
+                {/* Below the chips and outside the count on purpose. This is the
+                  * one thing on this page that is not an integration and cannot
+                  * be "done" -- counting it would make the percentage a measure
+                  * of whether somebody gave us their email, which it is not. It
+                  * lives here so the form stays reachable after the prompt has
+                  * been dismissed, which is permanent. */}
+                <div className="mt-4 pt-3 border-t border-white/10 flex items-center gap-2 flex-wrap">
+                    <Bell className="w-3.5 h-3.5 text-white/35" />
+                    <span className="text-xs text-white/45">
+                        We have no way to reach you about security fixes — Pinpoint calls home about nothing.
+                    </span>
+                    <button
+                        type="button"
+                        onClick={openStayInformed}
+                        className="text-xs text-indigo-300 hover:text-indigo-200 underline underline-offset-2"
+                    >
+                        Share a contact (optional)
+                    </button>
                 </div>
             </motion.div>
 

--- a/frontend/src/components/StayInformed.tsx
+++ b/frontend/src/components/StayInformed.tsx
@@ -1,0 +1,540 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Bell, ExternalLink, Check, X } from 'lucide-react';
+
+import { Button, Input, Select } from './ui';
+
+/**
+ * The one voluntary outbound call this application makes.
+ *
+ * Pinpoint is self-hosted and phones home about nothing. That is a real
+ * property and worth keeping, and it has a cost: when a security fix ships,
+ * there is no way to tell the towns running the affected version. This form is
+ * the disclosed exception -- a person types their details and presses a button,
+ * and nothing leaves the browser until they do.
+ *
+ * Three rules follow from that, and they are the reason this file is shaped the
+ * way it is:
+ *
+ *   * The payload carries only what somebody typed, plus the two consent
+ *     booleans. No version string, no deployment fingerprint, no counts -- not
+ *     because those would be unwelcome, but because "only what you typed" is a
+ *     sentence a clerk can verify by reading the form, and "only what you typed
+ *     plus some diagnostics" is not.
+ *
+ *   * It posts from the browser, not the server. A server-side submission would
+ *     mean the application itself holds a connection to pinpoint311.org, which
+ *     is exactly the property being preserved. From the browser, a town that
+ *     firewalls outbound traffic sees this fail and nothing else changes.
+ *
+ *   * It never blocks. Closing the modal by any route is permanent for that
+ *     browser -- it does not reappear on the next load -- and a failed
+ *     submission degrades to a link rather than an error, because a town whose
+ *     network refuses the request has not done anything wrong and should not be
+ *     shown a red box about it.
+ *
+ * COMPLIANCE.md documents all of this, which is the point: the exception is
+ * disclosed rather than discovered.
+ */
+
+/** Public, unauthenticated, CORS-open. No API key: distributing one with an
+ *  open-source install would put it in every clone of the repository, which is
+ *  not a secret, and requiring one would defeat the zero-config install. */
+export const REGISTRATION_ENDPOINT = 'https://pinpoint311.org/api/deployments/register';
+
+/** The same form on the website, for anyone who would rather not submit from
+ *  inside their own console -- and the fallback when the request fails. */
+export const REGISTRATION_FORM_URL = 'https://pinpoint311.org/register';
+
+export const PRIVACY_POLICY_URL = 'https://pinpoint311.org/privacy';
+
+/* Two flags, not one, and the distinction is the whole design.
+ *
+ * The modal is a one-time interruption: closed by any route, it never opens by
+ * itself again. The banner is the standing way back in, and it is dismissed
+ * separately. Collapsing them into one flag would mean "Not now" quietly
+ * removes the only visible path back to the form -- which turns an optional
+ * prompt into a one-shot offer, and buries the thing a town would want on the
+ * day an advisory goes out.
+ *
+ * Per browser rather than per user. It is a nudge, not a task; the second admin
+ * to sign in has no reason to be asked again about something the first dealt
+ * with, and there is no server-side state here to key it to anyway. */
+const MODAL_KEY = 'pinpoint311.stay-informed.dismissed';
+const BANNER_KEY = 'pinpoint311.stay-informed.banner-dismissed';
+
+const OPEN_EVENT = 'pinpoint311:stay-informed:open';
+const CHANGE_EVENT = 'pinpoint311:stay-informed:change';
+
+function readFlag(key: string): boolean {
+    try {
+        return localStorage.getItem(key) !== null;
+    } catch {
+        // Private browsing, or storage disabled by policy. Treating that as
+        // "dismissed" is the safe direction: it means nothing appears rather
+        // than appearing on every single page load with no way to stop it.
+        return true;
+    }
+}
+
+function writeFlag(key: string, value: string) {
+    try {
+        localStorage.setItem(key, value);
+    } catch { /* nothing to do; see above */ }
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+export function isStayInformedDismissed(): boolean {
+    return readFlag(MODAL_KEY);
+}
+
+type Outcome = 'submitted' | 'already-in-touch' | 'not-now';
+
+function recordDismissal(how: Outcome) {
+    writeFlag(MODAL_KEY, how);
+    // Submitting answers the question, and somebody already in touch has
+    // answered it too. Only "Not now" leaves it open -- so only "Not now"
+    // leaves the banner up.
+    if (how !== 'not-now') writeFlag(BANNER_KEY, how);
+}
+
+/** Reopen the form from the banner or the setup checklist. */
+export function openStayInformed() {
+    window.dispatchEvent(new CustomEvent(OPEN_EVENT));
+}
+
+// ---------------------------------------------------------------------------
+
+interface FormState {
+    organization: string;
+    contact_name: string;
+    contact_email: string;
+    contact_role: string;
+    deployment_url: string;
+    region: string;
+    usage: string;
+    consent_updates: boolean;
+    consent_public_listing: boolean;
+    /** Honeypot. Hidden from people, irresistible to form-filling bots, and
+     *  submitted as-is so the receiving endpoint can drop anything non-empty
+     *  without a CAPTCHA in front of a municipal clerk. */
+    website: string;
+}
+
+const EMPTY: FormState = {
+    organization: '',
+    contact_name: '',
+    contact_email: '',
+    contact_role: '',
+    deployment_url: '',
+    region: '',
+    usage: '',
+    consent_updates: true,
+    consent_public_listing: false,
+    website: '',
+};
+
+const USAGE_OPTIONS = [
+    { value: '', label: 'Select…' },
+    { value: 'single', label: 'Self-hosted for one municipality' },
+    { value: 'multiple', label: 'Hosting for multiple municipalities' },
+    { value: 'evaluating', label: 'Evaluating' },
+];
+
+function Field({ label, hint, optional, children }: {
+    label: string; hint?: string; optional?: boolean; children: React.ReactNode;
+}) {
+    return (
+        <label className="block">
+            <span className="flex items-baseline gap-2 mb-1.5">
+                <span className="text-sm text-white/70">{label}</span>
+                {optional && <span className="text-[11px] text-white/35">optional</span>}
+            </span>
+            {children}
+            {hint && <span className="block text-[11px] text-white/40 mt-1">{hint}</span>}
+        </label>
+    );
+}
+
+function Consent({ checked, onChange, children }: {
+    checked: boolean; onChange: (v: boolean) => void; children: React.ReactNode;
+}) {
+    return (
+        <label className="flex items-start gap-3 cursor-pointer group">
+            <span className={`mt-0.5 w-5 h-5 rounded-lg shrink-0 flex items-center justify-center border transition-all duration-200 ${checked
+                ? 'bg-gradient-to-br from-primary-400 to-indigo-500 border-transparent shadow-lg shadow-primary-500/25'
+                : 'bg-white/[0.06] border-white/20 group-hover:border-white/35'
+                }`}>
+                {checked && <Check className="w-3.5 h-3.5 text-white" strokeWidth={3} />}
+            </span>
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => onChange(e.target.checked)}
+                className="sr-only"
+            />
+            <span className="text-sm text-white/65 leading-snug">{children}</span>
+        </label>
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+function StayInformedForm({ onDone }: { onDone: (how: Outcome) => void }) {
+    const [form, setForm] = useState<FormState>(EMPTY);
+    const [state, setState] = useState<'editing' | 'sending' | 'sent' | 'fallback'>('editing');
+
+    const set = <K extends keyof FormState>(key: K) => (value: FormState[K]) =>
+        setForm(prev => ({ ...prev, [key]: value }));
+
+    const complete = form.organization.trim() && form.contact_name.trim() && form.contact_email.trim();
+
+    async function submit(event: React.FormEvent) {
+        event.preventDefault();
+        if (!complete || state === 'sending') return;
+        setState('sending');
+        try {
+            const response = await fetch(REGISTRATION_ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                // No credentials and no custom headers: both would turn this
+                // into a preflighted, cookie-bearing request from every town's
+                // domain, and there is nothing here worth either.
+                body: JSON.stringify(form),
+            });
+            if (!response.ok) throw new Error(String(response.status));
+            setState('sent');
+            recordDismissal('submitted');
+        } catch {
+            // Deliberately not an error. The most likely cause is a town that
+            // firewalls outbound traffic, which is a reasonable thing for a
+            // municipal network to do and not a mistake to report back at them.
+            setState('fallback');
+        }
+    }
+
+    if (state === 'sent') {
+        return (
+            <div className="text-center py-6">
+                <div className="w-14 h-14 mx-auto rounded-2xl bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center shadow-lg shadow-emerald-500/25">
+                    <Check className="w-7 h-7 text-white" strokeWidth={2.5} />
+                </div>
+                <p className="text-white/80 mt-4">Thank you — we have your details.</p>
+                <p className="text-white/45 text-sm mt-1.5">
+                    You'll hear from us when there is a security advisory or a release worth knowing about,
+                    and not otherwise.
+                </p>
+                <Button className="mt-6" onClick={() => onDone('submitted')}>Close</Button>
+            </div>
+        );
+    }
+
+    if (state === 'fallback') {
+        return (
+            <div className="text-center py-6">
+                <p className="text-white/80">We couldn't reach pinpoint311.org from this browser.</p>
+                <p className="text-white/45 text-sm mt-1.5 max-w-sm mx-auto">
+                    That is often just a municipal network blocking outbound traffic, which is a perfectly
+                    sensible thing for it to do. The same form is on our website if you'd like to use it
+                    from somewhere else.
+                </p>
+                <a
+                    href={REGISTRATION_FORM_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 mt-5 px-5 py-2.5 rounded-xl bg-white/10 hover:bg-white/15 border border-white/15 text-white/85 text-sm transition-colors"
+                >
+                    Open the form on pinpoint311.org
+                    <ExternalLink className="w-3.5 h-3.5" />
+                </a>
+                <div>
+                    <button
+                        type="button"
+                        onClick={() => onDone('not-now')}
+                        className="text-white/40 hover:text-white/70 text-sm mt-5 transition-colors"
+                    >
+                        Close
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <form onSubmit={submit} className="space-y-5">
+            <div className="space-y-3">
+                <p className="text-white/65 text-sm leading-relaxed">
+                    Pinpoint 311 is open source and self-hosted, so we have no way to reach you when a
+                    security fix or important update is released. If you share your contact information,
+                    we will send security advisories and release notes, and we are glad to help where we
+                    can.
+                </p>
+                <p className="text-white/40 text-xs leading-relaxed">
+                    This is entirely optional. Nothing is sent automatically — only what you enter below
+                    is submitted.
+                </p>
+            </div>
+
+            <div className="grid gap-4">
+                <Field label="Organization or municipality">
+                    <Input
+                        value={form.organization}
+                        onChange={(e) => set('organization')(e.target.value)}
+                        placeholder="Township of Example"
+                        required
+                    />
+                </Field>
+
+                <div className="grid sm:grid-cols-2 gap-4">
+                    <Field label="Your name">
+                        <Input
+                            value={form.contact_name}
+                            onChange={(e) => set('contact_name')(e.target.value)}
+                            required
+                        />
+                    </Field>
+                    <Field label="Email">
+                        <Input
+                            type="email"
+                            value={form.contact_email}
+                            onChange={(e) => set('contact_email')(e.target.value)}
+                            required
+                        />
+                    </Field>
+                </div>
+
+                <div className="grid sm:grid-cols-2 gap-4">
+                    <Field label="Role or title" optional>
+                        <Input
+                            value={form.contact_role}
+                            onChange={(e) => set('contact_role')(e.target.value)}
+                            placeholder="Municipal Clerk"
+                        />
+                    </Field>
+                    <Field label="State or country" optional>
+                        <Input
+                            value={form.region}
+                            onChange={(e) => set('region')(e.target.value)}
+                            placeholder="New Jersey"
+                        />
+                    </Field>
+                </div>
+
+                <Field
+                    label="Deployment URL"
+                    optional
+                    hint="so we can notify you if we detect an issue with your instance"
+                >
+                    <Input
+                        value={form.deployment_url}
+                        onChange={(e) => set('deployment_url')(e.target.value)}
+                        placeholder="https://311.example.gov"
+                    />
+                </Field>
+
+                <Field label="How you're using it" optional>
+                    <Select
+                        options={USAGE_OPTIONS}
+                        value={form.usage}
+                        onChange={(e) => set('usage')(e.target.value)}
+                    />
+                </Field>
+            </div>
+
+            {/* Honeypot. Off-screen rather than display:none, which some bots
+              * check for, and marked so assistive technology skips it. */}
+            <div aria-hidden="true" className="absolute -left-[9999px] w-px h-px overflow-hidden">
+                <label>
+                    Website
+                    <input
+                        tabIndex={-1}
+                        autoComplete="off"
+                        value={form.website}
+                        onChange={(e) => set('website')(e.target.value)}
+                    />
+                </label>
+            </div>
+
+            <div className="space-y-3 pt-1">
+                <Consent checked={form.consent_updates} onChange={set('consent_updates')}>
+                    Send me security advisories and release notes.
+                </Consent>
+                <Consent checked={form.consent_public_listing} onChange={set('consent_public_listing')}>
+                    You may list us publicly as a Pinpoint 311 deployment.
+                </Consent>
+            </div>
+
+            <div className="flex flex-col gap-3 pt-1">
+                <Button type="submit" disabled={!complete || state === 'sending'} className="w-full">
+                    {state === 'sending' ? 'Sending…' : 'Submit'}
+                </Button>
+                <button
+                    type="button"
+                    onClick={() => onDone('already-in-touch')}
+                    className="w-full px-4 py-2.5 rounded-xl bg-white/[0.06] hover:bg-white/10 border border-white/12 text-white/70 text-sm transition-colors"
+                >
+                    I'm already in touch with Pinpoint 311
+                </button>
+                <button
+                    type="button"
+                    onClick={() => onDone('not-now')}
+                    className="text-white/40 hover:text-white/70 text-sm transition-colors"
+                >
+                    Not now
+                </button>
+            </div>
+
+            <p className="text-center text-[11px] text-white/30 pt-1">
+                <a href={PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer"
+                    className="hover:text-white/55 underline underline-offset-2">Privacy policy</a>
+                <span className="mx-2">·</span>
+                <a href={REGISTRATION_FORM_URL} target="_blank" rel="noopener noreferrer"
+                    className="hover:text-white/55 underline underline-offset-2">Same form on pinpoint311.org</a>
+            </p>
+        </form>
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount once, near the root of the admin console.
+ *
+ * `ready` is what says setup is finished rather than in progress -- the caller
+ * decides, because only it knows whether somebody is mid-configuration. This
+ * component only guarantees that a dismissal is permanent.
+ */
+export function StayInformedHost({ ready }: { ready: boolean }) {
+    const [open, setOpen] = useState(false);
+    const [dismissed, setDismissed] = useState(() => readFlag(MODAL_KEY));
+    const [bannerDismissed, setBannerDismissed] = useState(() => readFlag(BANNER_KEY));
+    const autoPrompted = useRef(false);
+
+    useEffect(() => {
+        const reopen = () => setOpen(true);
+        const changed = () => {
+            setDismissed(readFlag(MODAL_KEY));
+            setBannerDismissed(readFlag(BANNER_KEY));
+        };
+        window.addEventListener(OPEN_EVENT, reopen);
+        window.addEventListener(CHANGE_EVENT, changed);
+        return () => {
+            window.removeEventListener(OPEN_EVENT, reopen);
+            window.removeEventListener(CHANGE_EVENT, changed);
+        };
+    }, []);
+
+    useEffect(() => {
+        // Once per page load at most, and never after any dismissal.
+        if (ready && !dismissed && !autoPrompted.current) {
+            autoPrompted.current = true;
+            setOpen(true);
+        }
+    }, [ready, dismissed]);
+
+    const finish = (how: Outcome) => {
+        recordDismissal(how);
+        setDismissed(true);
+        if (how !== 'not-now') setBannerDismissed(true);
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <AnimatePresence>
+                {open && (
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-slate-950/50 backdrop-blur-sm overflow-y-auto"
+                        // Clicking away is a dismissal like any other -- it is
+                        // an optional form, not something to trap somebody in.
+                        onClick={() => finish('not-now')}
+                    >
+                        <motion.div
+                            initial={{ opacity: 0, y: 24, scale: 0.97 }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{ opacity: 0, y: 12, scale: 0.98 }}
+                            transition={{ type: 'spring', stiffness: 300, damping: 26 }}
+                            onClick={(e) => e.stopPropagation()}
+                            role="dialog"
+                            aria-modal="true"
+                            aria-label="Stay informed about security updates and new features"
+                            className="setup-panel w-full max-w-xl my-auto p-7 sm:p-8"
+                        >
+                            <button
+                                type="button"
+                                onClick={() => finish('not-now')}
+                                aria-label="Close"
+                                className="absolute top-4 right-4 w-8 h-8 rounded-full flex items-center justify-center text-white/35 hover:text-white/80 hover:bg-white/10 transition-colors"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+
+                            {/* pr-8 so the heading never runs under the close
+                              * button, which it does at this width without it. */}
+                            <div className="flex items-center gap-4 mb-5 pr-8">
+                                <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary-400 to-indigo-500 flex items-center justify-center shadow-lg shadow-primary-500/25 shrink-0">
+                                    <Bell className="w-6 h-6 text-white" />
+                                </div>
+                                <h2 className="font-bold text-lg text-white leading-tight">
+                                    Stay informed about security updates and new features
+                                </h2>
+                            </div>
+
+                            <StayInformedForm onDone={finish} />
+                        </motion.div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {/* Independent of the modal's flag: this is what "reachable
+              * without blocking" means. It appears once the modal has been put
+              * aside and stays until it is dismissed in its own right. */}
+            {!bannerDismissed && dismissed && !open && ready && (
+                <StayInformedBanner onDismiss={() => { writeFlag(BANNER_KEY, 'dismissed'); setBannerDismissed(true); }} />
+            )}
+        </>
+    );
+}
+
+/**
+ * The standing way back to the form. Small, in the corner, and out of the way
+ * of everything -- but present, because the alternative is that "Not now" is
+ * indistinguishable from "never", and the moment a town wants this is the
+ * morning an advisory goes out rather than the afternoon they installed.
+ */
+function StayInformedBanner({ onDismiss }: { onDismiss: () => void }) {
+    return (
+        <div className="fixed bottom-4 right-4 z-40 max-w-sm">
+            <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="setup-panel px-4 py-3 flex items-start gap-3 shadow-2xl"
+            >
+                <Bell className="w-4 h-4 text-primary-300 mt-0.5 shrink-0" />
+                <p className="text-xs text-white/60 leading-snug flex-1">
+                    We have no way to reach you about security fixes.{' '}
+                    <button
+                        type="button"
+                        onClick={openStayInformed}
+                        className="text-primary-300 hover:text-primary-200 underline underline-offset-2"
+                    >
+                        Share a contact
+                    </button>
+                </p>
+                <button
+                    type="button"
+                    onClick={onDismiss}
+                    aria-label="Dismiss"
+                    className="text-white/30 hover:text-white/70 transition-colors shrink-0"
+                >
+                    <X className="w-3.5 h-3.5" />
+                </button>
+            </motion.div>
+        </div>
+    );
+}
+
+export default StayInformedHost;

--- a/frontend/src/components/StorageStatusLine.tsx
+++ b/frontend/src/components/StorageStatusLine.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { ShieldCheck, RefreshCw } from 'lucide-react';
+
+import { api } from '../services/api';
+import type { StorageStatus } from '../services/api';
+
+/**
+ * One sentence about where the town's secrets and resident data actually sit.
+ *
+ * It replaces two buttons: "Vault Local Secrets to GCP Identity" and
+ * "Re-encrypt All PII Data (after key rotation)". Both did real work, and
+ * neither could be pressed at the right time by anybody who had not been told
+ * what they meant -- the second was conditioned on a key rotation, an event a
+ * clerk has no reason to know has occurred.
+ *
+ * Both now run on a schedule. So the only thing left worth saying is whether
+ * anything is mid-flight, and the normal answer is a green tick. Numbers are
+ * given in things a person recognises -- keys, resident records -- rather than
+ * in the vocabulary of the operation that produces them.
+ */
+export function StorageStatusLine() {
+    const [status, setStatus] = useState<StorageStatus | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        api.getStorageStatus()
+            .then(s => { if (!cancelled) setStatus(s); })
+            // Advisory only. A status line that cannot load is not worth an
+            // error message on a page about something else.
+            .catch(() => undefined);
+        return () => { cancelled = true; };
+    }, []);
+
+    if (!status) return null;
+
+    const storeName = {
+        azure: 'Azure Key Vault',
+        aws: 'AWS Secrets Manager',
+    }[status.secrets.store ?? ''] ?? 'Google Secret Manager';
+
+    const pending: string[] = [];
+    if (status.secrets.count && status.secrets.reachable) {
+        pending.push(
+            `${status.secrets.count} ${status.secrets.count === 1 ? 'key is' : 'keys are'} ` +
+            `still in the database and will move to ${storeName}`
+        );
+    }
+    if (status.pii.stale) {
+        pending.push(
+            `${status.pii.stale.toLocaleString()} resident ${status.pii.stale === 1 ? 'record' : 'records'} ` +
+            `will be re-encrypted onto your current key`
+        );
+    }
+
+    if (!pending.length) {
+        return (
+            <p className="flex items-center justify-center gap-2 text-[11px] text-emerald-300/70">
+                <ShieldCheck className="w-3.5 h-3.5 shrink-0" />
+                Secrets are in {storeName} and resident data is on your current encryption key.
+            </p>
+        );
+    }
+
+    return (
+        <div className="flex items-start gap-2 text-[11px] text-white/50">
+            <RefreshCw className="w-3.5 h-3.5 mt-0.5 shrink-0 text-primary-300" />
+            <p>
+                {pending.join(', and ')}. This happens automatically overnight — everything stays
+                encrypted and readable in the meantime, and there is nothing for you to do.
+            </p>
+        </div>
+    );
+}
+
+export default StorageStatusLine;

--- a/frontend/src/components/SystemHealthDashboard.tsx
+++ b/frontend/src/components/SystemHealthDashboard.tsx
@@ -14,12 +14,32 @@ interface HealthCheckResponse {
         database: HealthCheckResult;
         auth0: HealthCheckResult;
         gcp_auth: HealthCheckResult;
-        google_kms: HealthCheckResult;
-        google_secret_manager: HealthCheckResult;
+        kms: HealthCheckResult;
+        secret_store: HealthCheckResult;
         vertex_ai: HealthCheckResult;
         translation_api: HealthCheckResult;
     };
     timestamp: string;
+}
+
+/** Which key manager wrapped the data key, in words. `local` is the honest
+ *  answer for a self-hosted install with no cloud account, and is also what a
+ *  town sees when the KMS it selected is unreachable — so it says so rather
+ *  than naming a vendor that is not being used. */
+function backendLabel(backend?: string): string {
+    return {
+        google: 'Google Cloud KMS',
+        azure: 'Azure Key Vault',
+        aws: 'AWS KMS',
+    }[backend ?? ''] ?? 'Key Management';
+}
+
+function storeLabel(store?: string): string {
+    return {
+        google: 'Google Secret Manager',
+        azure: 'Azure Key Vault',
+        aws: 'AWS Secrets Manager',
+    }[store ?? ''] ?? 'Secret Store';
 }
 
 export default function SystemHealthDashboard() {
@@ -218,32 +238,39 @@ export default function SystemHealthDashboard() {
                         </Card>
                     )}
 
-                    {/* Google Cloud KMS */}
+                    {/* Key management. Headed by whichever key manager is
+                        actually in use — this card said "Google Cloud KMS"
+                        unconditionally, including to towns running Azure Key
+                        Vault or AWS KMS. */}
                     <Card>
                         <div className="flex items-start gap-3">
-                            {getStatusIcon(health.checks.google_kms.status)}
+                            {getStatusIcon(health.checks.kms.status)}
                             <div className="flex-1">
-                                <h3 className="font-semibold text-white">Google Cloud KMS</h3>
+                                <h3 className="font-semibold text-white">
+                                    {backendLabel(health.checks.kms.kms_backend)}
+                                </h3>
                                 <p className="text-xs text-gray-500 mb-1">PII Encryption</p>
-                                <p className={`text-sm ${getStatusColor(health.checks.google_kms.status)}`}>
-                                    {health.checks.google_kms.message}
+                                <p className={`text-sm ${getStatusColor(health.checks.kms.status)}`}>
+                                    {health.checks.kms.message}
                                 </p>
-                                {renderCheckDetails(health.checks.google_kms)}
+                                {renderCheckDetails(health.checks.kms)}
                             </div>
                         </div>
                     </Card>
 
-                    {/* Secret Manager */}
+                    {/* Secret store */}
                     <Card>
                         <div className="flex items-start gap-3">
-                            {getStatusIcon(health.checks.google_secret_manager.status)}
+                            {getStatusIcon(health.checks.secret_store.status)}
                             <div className="flex-1">
-                                <h3 className="font-semibold text-white">Secret Manager</h3>
-                                <p className="text-xs text-gray-500 mb-1">Google Cloud</p>
-                                <p className={`text-sm ${getStatusColor(health.checks.google_secret_manager.status)}`}>
-                                    {health.checks.google_secret_manager.message}
+                                <h3 className="font-semibold text-white">
+                                    {storeLabel(health.checks.secret_store.store)}
+                                </h3>
+                                <p className="text-xs text-gray-500 mb-1">Credential storage</p>
+                                <p className={`text-sm ${getStatusColor(health.checks.secret_store.status)}`}>
+                                    {health.checks.secret_store.message}
                                 </p>
-                                {renderCheckDetails(health.checks.google_secret_manager)}
+                                {renderCheckDetails(health.checks.secret_store)}
                             </div>
                         </div>
                     </Card>

--- a/frontend/src/components/TrackRequests.tsx
+++ b/frontend/src/components/TrackRequests.tsx
@@ -96,15 +96,33 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
         loadRequests();
     }, []);
 
-    // Auto-load request from URL
+    /* Auto-load the report a tracking link points at.
+     *
+     * Falls back to fetching it directly when it is not in the loaded list. A
+     * link is shared by the person who filed the report and by staff, and it
+     * has to work for an unlisted report -- which by definition is not in the
+     * public list -- and for one filed on a different device, where
+     * localStorage knows nothing about it. Previously either case left the page
+     * showing the list with no indication that the link had failed. */
     useEffect(() => {
-        if (initialRequestId && requests.length > 0) {
-            const request = requests.find(r => r.service_request_id === initialRequestId);
-            if (request) {
-                setSelectedRequest(request);
-            }
+        if (!initialRequestId) return;
+        const known = requests.find(r => r.service_request_id === initialRequestId);
+        if (known) {
+            setSelectedRequest(known);
+            return;
         }
-    }, [initialRequestId, requests]);
+        if (isLoading) return;  // the list may still bring it in
+        let cancelled = false;
+        api.getPublicRequestDetail(initialRequestId)
+            .then(r => {
+                if (cancelled || !r) return;
+                setRequests(prev => prev.some(p => p.service_request_id === r.service_request_id)
+                    ? prev : [r, ...prev]);
+                setSelectedRequest(r);
+            })
+            .catch(() => { /* genuinely not found, or deleted */ });
+        return () => { cancelled = true; };
+    }, [initialRequestId, requests, isLoading]);
 
     useEffect(() => {
         if (selectedRequest) {
@@ -132,7 +150,36 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
         try {
             // Always load all requests - filtering happens client-side
             const data = await api.getPublicRequests();
-            setRequests(data);
+
+            /* The public list excludes reports the resident marked unlisted,
+             * which is the whole point of the setting -- but it is also the
+             * list this component searches for "my reports" and for the report
+             * a tracking link points at. So a resident who filed an unlisted
+             * report could not see it in their own list, and their own link did
+             * nothing: the id was not in the array, `find` returned undefined,
+             * and the component sat there.
+             *
+             * Unlisted means "not in the town's public listing", not "hidden
+             * from the person who filed it". The by-id endpoint deliberately
+             * does not filter on is_public for exactly this reason, so anything
+             * of ours that is missing from the list is fetched directly and
+             * merged in. */
+            const mine: string[] = (() => {
+                try {
+                    const stored = JSON.parse(localStorage.getItem('my_requests') || '[]');
+                    return Array.isArray(stored) ? stored : [];
+                } catch { return []; }
+            })();
+
+            const present = new Set(data.map(r => r.service_request_id));
+            const missing = mine.filter(id => !present.has(id));
+            const fetched = missing.length
+                ? (await Promise.all(missing.map(id =>
+                    api.getPublicRequestDetail(id).catch(() => null))))
+                    .filter((r): r is PublicServiceRequest => r !== null)
+                : [];
+
+            setRequests(fetched.length ? [...fetched, ...data] : data);
         } catch (err) {
             console.error('Failed to load requests:', err);
         } finally {

--- a/frontend/src/components/setupSteps.tsx
+++ b/frontend/src/components/setupSteps.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react';
+
+import type { Capability } from '../services/api';
+
+/**
+ * The setup instructions, as steps that own the boxes they produce.
+ *
+ * Instructions used to live in one long document at the top of the page while
+ * the credential fields sat three thousand pixels below it, so following step
+ * four meant scrolling away from the instruction to find the box and back up to
+ * read the next one. The fix is not "put the instructions nearer the fields" --
+ * it is that a step and the box it fills are one thing.
+ *
+ * The shape that makes that work is `fields`: the secret keys a step produces.
+ * The card walks the steps in order, and after each one renders exactly the
+ * inputs that step just told you how to obtain. `check` is the sentence that
+ * says you are in the right place -- "you should see a page with boxes labelled
+ * Domain, Client ID and Client Secret" -- which is only worth anything sitting
+ * directly above those three boxes.
+ *
+ * Deliberately separate from ServiceProviders.tsx. The mechanism does not go
+ * stale; vendor console paths do, and they will be filled in and corrected here
+ * over time without touching a component.
+ *
+ * Two rules the card enforces, both of which exist so content can be incomplete
+ * without breaking anything:
+ *
+ *   * a field no step claims still renders, at the end. Adding a credential to
+ *     a catalog can never make it silently unreachable.
+ *   * a provider with no steps at all falls back to the plain field list, which
+ *     is what every provider had before this existed.
+ */
+
+export interface SetupStep {
+    /** What to do. Rich, because it needs links, code spans and copy buttons. */
+    body: ReactNode;
+    /** How you know it worked, shown immediately above this step's fields. */
+    check?: ReactNode;
+    /** Secret keys this step produces, rendered as inputs directly beneath it. */
+    fields?: string[];
+    /** A caveat worth reading before the next step, not after it goes wrong. */
+    trouble?: ReactNode;
+}
+
+/** Everything a step-writer needs that depends on the deployment. */
+export interface StepContext {
+    /** This installation's origin, for callback URLs and key restrictions. */
+    origin: string;
+    /** Copy-to-clipboard, so a URL is never retyped by hand. */
+    copy: (text: string, id: string) => void;
+    /** Which id is currently showing its "copied" tick. */
+    copied: string | null;
+}
+
+export type StepBuilder = (ctx: StepContext) => SetupStep[];
+
+/**
+ * Keyed `capability:provider`. Absent is a normal, supported state -- it means
+ * the field labels already say everything, and the card shows them plainly.
+ */
+export const SETUP_STEPS: Partial<Record<string, StepBuilder>> = {};
+
+/** Register a provider's steps. Kept as a function so the content file reads as
+ *  a list of declarations rather than one enormous object literal. */
+export function defineSteps(cap: Capability, provider: string, build: StepBuilder): void {
+    SETUP_STEPS[`${cap}:${provider}`] = build;
+}
+
+export function stepsFor(cap: Capability, provider: string, ctx: StepContext): SetupStep[] {
+    return SETUP_STEPS[`${cap}:${provider}`]?.(ctx) ?? [];
+}
+
+/** Field keys any step claims, so the card knows which are left over. */
+export function claimedFields(steps: SetupStep[]): Set<string> {
+    const claimed = new Set<string>();
+    for (const step of steps) for (const key of step.fields ?? []) claimed.add(key);
+    return claimed;
+}

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -896,7 +896,29 @@ defineSteps('kms', 'google', () => [
             </>
         ),
         fields: ['KMS_LOCATION', 'KMS_KEY_RING', 'KMS_KEY_ID'],
-        trouble: <>Never delete or disable this key, or the key ring holding it. Resident contact details are encrypted under it, and Google cannot recover a destroyed key for anyone.</>,
+    },
+    {
+        body: (
+            <>
+                <B>Then make it hard to destroy.</B> Google will not let you delete a key or a key ring
+                at all — only <em>destroy a key version</em>, which is enough to lose the data. Two
+                things to do now, while you are already here:
+                <span className="mt-2 grid gap-1.5">
+                    <span className="text-white/50 text-xs">
+                        Set the key's <B>destroy scheduled duration</B> to the longest you can — the
+                        default is 24 hours, and it can go to 120 days. That is the length of the window
+                        in which somebody can undo the mistake.
+                    </span>
+                    <span className="text-white/50 text-xs">
+                        Make sure day-to-day accounts do not hold{' '}
+                        <C>cloudkms.cryptoKeyVersions.destroy</C>. Encrypter/Decrypter does not include
+                        it — so if you followed the previous step exactly, Pinpoint already cannot
+                        destroy its own key. Check that a human administrator's role does not either.
+                    </span>
+                </span>
+            </>
+        ),
+        trouble: <>Rotating this key is safe and good practice — old versions stay and keep decrypting old rows. <B>Destroying</B> a version is the fatal one, and the two sit next to each other in the console. Once a version is destroyed, Google cannot recover it for you, for law enforcement, or for anyone.</>,
     },
 ]);
 
@@ -940,7 +962,21 @@ defineSteps('kms', 'azure', () => [
             </>
         ),
         fields: ['AZURE_KEYVAULT_URL', 'AZURE_KEYVAULT_KEY', 'AZURE_TENANT_ID', 'AZURE_KEYVAULT_CLIENT_ID', 'AZURE_KEYVAULT_CLIENT_SECRET'],
-        trouble: <>The client secret has an expiry date. Write it down: when it lapses, resident data stops decrypting, and nothing about that failure points at a calendar.</>,
+        trouble: <>The client secret has an expiry date. Put it in the town's calendar with a month's notice: when it lapses, resident data stops decrypting, and nothing about that failure points at a calendar. Azure will not warn you.</>,
+    },
+    {
+        body: (
+            <>
+                <B>Last, lock the vault down.</B> Confirm <B>soft delete</B> and <B>purge protection</B>{' '}
+                are both showing as enabled on the vault's Properties page — with them on, a deleted key
+                is recoverable for the retention period and cannot be permanently purged early, even by
+                an administrator, even deliberately. Then check that the everyday accounts your staff use
+                do not hold <B>Delete</B> or <B>Purge</B> on keys; a service principal certainly should
+                not.
+            </>
+        ),
+        check: <>Soft delete: Enabled, and Purge protection: Enabled, on Properties.</>,
+        trouble: <>This is the step to insist on. Purge protection cannot be switched on later in some configurations, and it is the only setting that makes an accidental deletion survivable rather than final.</>,
     },
 ]);
 
@@ -965,7 +1001,20 @@ defineSteps('kms', 'aws', () => [
             </>
         ),
         fields: ['AWS_REGION', 'AWS_KMS_KEY_ID'],
-        trouble: <>Never schedule this key for deletion. AWS enforces a waiting period between 7 and 30 days — 30 by default — during which the key cannot be used at all, so resident data stops decrypting the moment deletion is scheduled rather than when it completes. It can be cancelled inside that window. After it, the data encrypted under the key is unrecoverable, by you and by AWS.</>,
+    },
+    {
+        body: (
+            <>
+                <B>Then make deletion impossible rather than merely inadvisable.</B> AWS has no
+                "protect from deletion" switch, so you do it in the key policy: add a statement that{' '}
+                <B>denies</B> <C>kms:ScheduleKeyDeletion</C> and <C>kms:DisableKey</C> to everyone. An
+                explicit deny in AWS cannot be overridden by any allow, including the account root — so
+                the deletion simply cannot be started, by anyone, by accident or otherwise. If you ever
+                genuinely need to retire the key, an administrator edits the policy first, which is one
+                deliberate step where there was none.
+            </>
+        ),
+        trouble: <>Do this rather than relying on care. The console offers deletion from the same page as everything else, the default waiting period is 30 days, and the key stops working the moment deletion is <em>scheduled</em> — so resident data breaks at the start of the window, not the end. It can be cancelled inside those 30 days; after that, the data is unrecoverable by you and by AWS.</>,
     },
 ]);
 

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -990,15 +990,45 @@ defineSteps('redaction', 'aws', () => [
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
 ]);
 
+// Azure is the only redaction backend with credentials of its own. Google and
+// AWS reuse what was entered elsewhere; Azure needs two separate resources,
+// because Microsoft splits face detection and text reading across them.
+
 defineSteps('redaction', 'azure', () => [
     {
         body: (
             <>
-                In the <L href="https://portal.azure.com">Azure portal</L> create a{' '}
-                <B>Computer Vision</B> resource (listed under Azure AI services), and use its key and
-                endpoint. If you already have a multi-service Azure AI resource, that works too.
+                <B>Read this before choosing Azure.</B> Faces and plates come from two different Azure
+                services, so you create two resources, and the face one is gated: Microsoft keeps the{' '}
+                <B>Face API</B> behind a Limited Access review under its Responsible AI Standard.
+                Detection — returning rectangles, which is all Pinpoint does — is the least restricted
+                use, but the subscription still has to be approved before it will answer. If you only
+                want plates, you can skip the face resource entirely.
             </>
         ),
+        trouble: <>If your town cannot get through that review, pick a different detector. Google and Amazon have no equivalent gate, and the on-server option has none at all.</>,
+    },
+    {
+        body: (
+            <>
+                For faces: in the <L href="https://portal.azure.com">Azure portal</L> create a <B>Face</B>{' '}
+                resource (under Azure AI services), then open{' '}
+                <B>Resource Management → Keys and Endpoint</B> and copy <B>KEY 1</B> and the endpoint.
+            </>
+        ),
+        fields: ['AZURE_FACE_ENDPOINT', 'AZURE_FACE_KEY'],
+    },
+    {
+        body: (
+            <>
+                For plates: create a <B>Computer Vision</B> resource — Microsoft also lists this as{' '}
+                <B>Azure AI Vision</B>, and the two names refer to the same thing. Copy its key and
+                endpoint from the same place. Plates are found by reading the text in the photo, which
+                is why this is a separate service from the one that finds faces.
+            </>
+        ),
+        fields: ['AZURE_VISION_ENDPOINT', 'AZURE_VISION_KEY'],
+        trouble: <>A multi-service Azure AI resource covers the vision half, but not Face — that one is always its own resource.</>,
     },
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
 ]);

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -858,6 +858,34 @@ defineSteps('sms', 'http', () => [
     },
 ]);
 
+/**
+ * The risk none of the key-level controls cover.
+ *
+ * Denying deletion, purge protection and liens all stop somebody deleting the
+ * *key*. None of them survives the loss of the *account* that holds it, and for
+ * a municipality that is the likelier way this ends: a card that expires
+ * between budget cycles, a subscription opened on a departing employee's
+ * personal account, a purchasing gap nobody notices until the disable notice.
+ *
+ * Verified timelines, all of which start quietly: an Azure subscription is
+ * deleted 90 days after cancellation and its resources go with it; an AWS
+ * account's resources are deleted 90 days after closure; a deleted Google
+ * project takes its key ring, and Google commits to erasing the key material
+ * within 45 days. The key survives none of those, and no setting inside the key
+ * changes it.
+ */
+const ACCOUNT_SURVIVES = (
+    <>
+        <B>Finally, the boring one that matters most.</B> Every protection above guards the key. None
+        of them guards the <em>account</em> — and an account closed for non-payment takes the key with
+        it after about 90 days, whatever is set on the key itself. So: the cloud account must be in the
+        town's name on a town payment method, not an individual's; more than one person must be an
+        administrator; and billing alerts must go to a shared address that is still monitored after
+        somebody leaves. For most towns that is the realistic way this data gets lost — not a
+        mis-click, a lapsed card between budget cycles.
+    </>
+);
+
 // ===========================================================================
 // Key management for resident data
 //
@@ -920,6 +948,20 @@ defineSteps('kms', 'google', () => [
         ),
         trouble: <>Rotating this key is safe and good practice — old versions stay and keep decrypting old rows. <B>Destroying</B> a version is the fatal one, and the two sit next to each other in the console. Once a version is destroyed, Google cannot recover it for you, for law enforcement, or for anyone.</>,
     },
+    {
+        body: (
+            <>
+                <B>Protect the project, not just the key.</B> None of the above survives the project
+                being deleted — that takes the key ring with it. Place a <B>lien</B> on the project,
+                which blocks deletion outright until somebody removes the lien:
+                <span className="mt-2 block"><C>gcloud alpha resource-manager liens create --project=YOUR_PROJECT --restrictions=resourcemanager.projects.delete --reason="Holds the Pinpoint 311 PII encryption key"</C></span>
+            </>
+        ),
+        trouble: <>Ask whoever manages your Google Cloud billing to run it if you do not have the command line. It is one command, it is free, and it is the difference between a mis-click being an inconvenience and being permanent.</>,
+    },
+    {
+        body: <>{ACCOUNT_SURVIVES}</>,
+    },
 ]);
 
 defineSteps('kms', 'azure', () => [
@@ -978,6 +1020,20 @@ defineSteps('kms', 'azure', () => [
         check: <>Soft delete: Enabled, and Purge protection: Enabled, on Properties.</>,
         trouble: <>This is the step to insist on. Purge protection cannot be switched on later in some configurations, and it is the only setting that makes an accidental deletion survivable rather than final.</>,
     },
+    {
+        body: (
+            <>
+                <B>Then lock the vault itself.</B> On the vault, open <B>Settings → Locks</B> and add a
+                lock of type <B>Delete</B>. An Azure lock overrides user permissions — with it in place
+                nobody can delete the vault, and an attempt to delete the whole resource group fails
+                rather than half-completing.
+            </>
+        ),
+        check: <>a lock listed on the vault, type Delete.</>,
+    },
+    {
+        body: <>{ACCOUNT_SURVIVES}</>,
+    },
 ]);
 
 defineSteps('kms', 'aws', () => [
@@ -1015,6 +1071,9 @@ defineSteps('kms', 'aws', () => [
             </>
         ),
         trouble: <>Do this rather than relying on care. The console offers deletion from the same page as everything else, the default waiting period is 30 days, and the key stops working the moment deletion is <em>scheduled</em> — so resident data breaks at the start of the window, not the end. It can be cancelled inside those 30 days; after that, the data is unrecoverable by you and by AWS.</>,
+    },
+    {
+        body: <>{ACCOUNT_SURVIVES}</>,
     },
 ]);
 

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -1085,6 +1085,33 @@ defineSteps('kms', 'aws', () => [
 // town is actually deciding, which is what to blur.
 // ===========================================================================
 
+/**
+ * The two warnings every redaction path needs.
+ *
+ * Redaction is the one capability whose failure is invisible from inside the
+ * product. A misconfigured email provider bounces and somebody notices; a
+ * detector that finds nothing looks exactly like a photo with nobody in it. The
+ * blurring either happened or it did not, and the only way to know is to look
+ * at a photo.
+ */
+const UNCONFIGURED_DETECTOR = (
+    <>
+        If the credentials are missing or wrong, this fails <em>quietly</em>. The detector returns no
+        faces, Pinpoint blurs nothing, the photo is stored, and the card still shows redaction as on —
+        because "found nobody" and "could not ask" look identical from here. Check the Photo Redaction
+        line on the health dashboard after saving, and do the test below.
+    </>
+);
+
+const VERIFY_WITH_A_PHOTO = (
+    <>
+        <B>Test it once, with a real photo.</B> Open the resident portal, file a test report with a
+        picture that has a recognisable face in it, then look at the stored image in the staff
+        dashboard. Thirty seconds, and it is the only thing that actually proves this is working.
+        Delete the test report afterwards.
+    </>
+);
+
 const REDACTION_CHOICE = (
     <>
         Faces and licence plates are both on by default. Residents photograph potholes with cars parked
@@ -1103,8 +1130,9 @@ defineSteps('redaction', 'google', () => [
             </>
         ),
         check: <>"API Enabled" on the Cloud Vision API page.</>,
+        trouble: <>{UNCONFIGURED_DETECTOR}</>,
     },
-    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);
 
 defineSteps('redaction', 'aws', () => [
@@ -1113,11 +1141,14 @@ defineSteps('redaction', 'aws', () => [
             <>
                 Amazon Rekognition needs nothing enabled in its console. Add{' '}
                 <C>rekognition:DetectFaces</C> and <C>rekognition:DetectText</C> to the IAM user this
-                deployment uses — plate detection works by reading text in the image.
+                deployment uses — plate detection works by reading text in the image, so leaving
+                DetectText off silently disables plates while faces keep working.
             </>
         ),
+        check: <>both actions listed on the IAM user's policy.</>,
+        trouble: <>{UNCONFIGURED_DETECTOR}</>,
     },
-    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);
 
 // Azure is the only redaction backend with credentials of its own. Google and
@@ -1167,12 +1198,24 @@ defineSteps('redaction', 'local', () => [
     {
         body: (
             <>
-                Detection runs on this server. Nothing to configure and no photo ever leaves the
-                building, which is the reason to choose it. It finds fewer faces than the cloud
-                detectors, particularly small or partly turned ones — so it is the safer choice for
-                privacy and the weaker one for coverage.
+                <B>This is what you get if you choose nothing.</B> Detection runs on this server using
+                OpenCV, with no account, no key and no cost — and no resident photo ever leaves the
+                building, which is the real reason to keep it.
             </>
         ),
+        trouble: <>It is the default because the alternative was worse. A deployment with no cloud credentials used to blur nothing at all while the page displayed Google Cloud Vision as the provider. Imperfect blurring beats none; that is the whole argument, and it is worth knowing which one you are relying on.</>,
     },
-    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+    {
+        body: (
+            <>
+                <B>What it misses.</B> It finds faces that are roughly front-on and reasonably large.
+                Small faces, faces in profile, faces in shadow or behind glass are often missed, and
+                plate detection is weaker still. The cloud detectors are meaningfully better at all of
+                those. If your town publishes photos to a public map and a missed face is a serious
+                problem, one of them is worth the setup.
+            </>
+        ),
+        trouble: <>The safest arrangement for a town with no cloud account is to keep this on <em>and</em> have a person look at photos before they are published, rather than treating either one as sufficient on its own.</>,
+    },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -18,6 +18,11 @@ import type { StepContext } from './setupSteps';
  * value must be copied exactly -- callback URLs, key restrictions -- give them
  * the copy button rather than a string to retype, because one missing character
  * fails silently and looks like a wrong password.
+ *
+ * The `fields` on each step are checked against the real credential catalogs by
+ * backend/tests/test_setup_steps_content.py. A key invented from memory here
+ * would otherwise render a box that saves to nothing, which is the failure this
+ * whole page exists to avoid.
  */
 
 /** A copy-to-clipboard chip for a value that must be exact. */
@@ -41,22 +46,37 @@ const B = ({ children }: { children: React.ReactNode }) => (
     <strong className="text-white/90">{children}</strong>
 );
 
-// ---------------------------------------------------------------------------
-// Staff sign-in — Auth0
+/** A vendor console link. Always new-tab: a clerk mid-setup who navigates away
+ *  loses everything typed into the boxes below. */
+const L = ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer"
+        className="text-primary-300 underline underline-offset-2">{children}</a>
+);
+
+const C = ({ children }: { children: React.ReactNode }) => (
+    <code className="bg-black/30 px-1 rounded text-[11px] text-primary-200">{children}</code>
+);
+
+// ===========================================================================
+// Staff sign-in
 //
-// Transcribed from the long-form guide, which was written against the Auth0
-// dashboard and is the one path here that has been walked end to end. The
-// ordering is what matters: the callback URLs go in before the credentials come
-// out, because a tenant configured in the other order accepts the password and
-// then fails on the redirect, which reads as a wrong secret.
+// All three OIDC providers redirect to the same place. The callback URL goes in
+// before the credentials come out in every one of them, because a tenant
+// missing the redirect accepts the password and then fails on the way back,
+// which reads to everybody as a wrong secret.
+// ===========================================================================
+
+const CALLBACK = (origin: string) => `${origin}/api/auth/callback`;
+
+// ---------------------------------------------------------------------------
+// Auth0
 // ---------------------------------------------------------------------------
 
 defineSteps('identity', 'auth0', (ctx) => [
     {
         body: (
             <>
-                Create the account at <a href="https://auth0.com" target="_blank" rel="noopener noreferrer"
-                    className="text-primary-300 underline underline-offset-2">auth0.com</a>, using a{' '}
+                Create the account at <L href="https://auth0.com">auth0.com</L>, using a{' '}
                 <B>shared town email address</B> rather than a personal one — whoever replaces you will
                 need to get in. When it asks for a region, pick one in the US if your town or state has a
                 rule about where data is held; it cannot be changed afterwards.
@@ -82,7 +102,7 @@ defineSteps('identity', 'auth0', (ctx) => [
                 <span className="mt-2 grid gap-1.5">
                     <span className="flex items-center gap-2 flex-wrap">
                         <span className="text-white/45 text-xs w-40 shrink-0">Allowed Callback URLs</span>
-                        <CopyValue ctx={ctx} id="a0cb" value={`${ctx.origin}/api/auth/callback`} />
+                        <CopyValue ctx={ctx} id="a0cb" value={CALLBACK(ctx.origin)} />
                     </span>
                     <span className="flex items-center gap-2 flex-wrap">
                         <span className="text-white/45 text-xs w-40 shrink-0">Allowed Logout URLs</span>
@@ -105,24 +125,181 @@ defineSteps('identity', 'auth0', (ctx) => [
 ]);
 
 // ---------------------------------------------------------------------------
-// Maps — Google
+// Microsoft Entra ID
 //
-// Also transcribed from the long-form guide. Billing is step one rather than a
-// footnote: without it Google issues a key that looks correct and the map shows
-// a grey box, which is the single most common failure on this page.
+// The path most towns will actually take, because the staff already have
+// Microsoft 365 accounts and Entra is the directory behind them. The one thing
+// worth reading twice is the secret: Entra shows it once and then replaces it
+// with dots forever, and the box beside it labelled "Secret ID" is not it.
+// ---------------------------------------------------------------------------
+
+defineSteps('identity', 'entra', (ctx) => [
+    {
+        body: (
+            <>
+                Sign in to the <L href="https://portal.azure.com">Azure portal</L> with an account that
+                can administer your directory, open <B>Microsoft Entra ID</B>, and in the left pane choose{' '}
+                <B>Manage → App registrations</B>, then <B>New registration</B>.
+            </>
+        ),
+        check: <>a form headed "Register an application".</>,
+    },
+    {
+        body: (
+            <>
+                Name it something a successor will recognise — <C>Pinpoint 311</C> is fine. Under{' '}
+                <B>Redirect URI</B>, set the type to <B>Web</B> and paste{' '}
+                <CopyValue ctx={ctx} id="enrd" value={CALLBACK(ctx.origin)} />. Leave the account-types
+                option on the default (this directory only) unless your town genuinely shares staff with
+                another tenant. Press <B>Register</B>.
+            </>
+        ),
+        trouble: <>The redirect type matters. "Single-page application" is offered right below Web and looks equivalent; it is not, and staff sign-in will fail on the way back with an error about the flow.</>,
+    },
+    {
+        body: (
+            <>
+                The overview page that appears shows <B>Application (client) ID</B> and <B>Directory
+                (tenant) ID</B>. Copy both here. Leave the authority box empty unless you are on a
+                sovereign cloud — it defaults to the normal commercial endpoint.
+            </>
+        ),
+        check: <>two GUIDs on the overview page, both looking like <C>8f3c…-…-…</C>.</>,
+        fields: ['ENTRA_TENANT_ID', 'ENTRA_CLIENT_ID', 'ENTRA_AUTHORITY'],
+    },
+    {
+        body: (
+            <>
+                In the left pane choose <B>Manage → Certificates &amp; secrets</B>, then{' '}
+                <B>Client secrets → New client secret</B>. Give it a description and an expiry, press{' '}
+                <B>Add</B>, and copy the <B>Value</B> column into the box below.
+            </>
+        ),
+        fields: ['ENTRA_CLIENT_SECRET'],
+        trouble: <>Copy it now. Entra shows the Value once; leave the page and it is dots forever and you have to issue a new one. The <B>Secret ID</B> next to it is not the secret. Note the expiry date somewhere — staff sign-in stops working on that day, and it is a long way from here to that diagnosis.</>,
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Okta
+//
+// The trap here is that the issuer is not on the application page. It lives
+// under a different menu entirely, and the value people reach for -- the org
+// URL in the address bar -- is close enough to look right and wrong enough to
+// fail.
+// ---------------------------------------------------------------------------
+
+defineSteps('identity', 'okta', (ctx) => [
+    {
+        body: (
+            <>
+                In the Okta <B>Admin Console</B> (the "Admin" button in the top-right of the normal
+                dashboard), open <B>Applications → Applications</B> and press <B>Create App
+                Integration</B>. Choose <B>OIDC – OpenID Connect</B> as the sign-in method and{' '}
+                <B>Web Application</B> as the application type, then <B>Next</B>.
+            </>
+        ),
+        trouble: <>Web Application, not Single-Page Application. A SPA integration issues no client secret, and the box below will have nothing to put in it.</>,
+    },
+    {
+        body: (
+            <>
+                Name it, then fill the two URL fields:
+                <span className="mt-2 grid gap-1.5">
+                    <span className="flex items-center gap-2 flex-wrap">
+                        <span className="text-white/45 text-xs w-44 shrink-0">Sign-in redirect URIs</span>
+                        <CopyValue ctx={ctx} id="okrd" value={CALLBACK(ctx.origin)} />
+                    </span>
+                    <span className="flex items-center gap-2 flex-wrap">
+                        <span className="text-white/45 text-xs w-44 shrink-0">Sign-out redirect URIs</span>
+                        <CopyValue ctx={ctx} id="oklo" value={ctx.origin} />
+                    </span>
+                </span>
+                Under <B>Assignments</B>, pick the groups whose members should be able to sign in to
+                Pinpoint, then <B>Save</B>.
+            </>
+        ),
+        check: <>the app's <B>General</B> tab, with a <B>Client Credentials</B> section on it.</>,
+    },
+    {
+        body: (
+            <>
+                Copy <B>Client ID</B> from that section, and press <B>Show</B> beside <B>Client
+                secret</B> to reveal and copy the other.
+            </>
+        ),
+        fields: ['OKTA_CLIENT_ID', 'OKTA_CLIENT_SECRET'],
+    },
+    {
+        body: (
+            <>
+                The issuer is somewhere else. Open <B>Security → API</B> in the left menu and copy the{' '}
+                <B>Issuer URI</B> of the authorization server you are using — usually the one named{' '}
+                <C>default</C>.
+            </>
+        ),
+        fields: ['OKTA_ISSUER'],
+        trouble: <>Not your org URL. It typically ends <C>/oauth2/default</C>, and the plain org address looks close enough to be pasted by mistake — after which sign-in fails at discovery with a message that names neither.</>,
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Generic OIDC
+//
+// For a state-run identity provider, Keycloak, Shibboleth, or anything else
+// standards-compliant. Written as questions to ask whoever runs it rather than
+// as a menu path, because there is no menu to describe.
+// ---------------------------------------------------------------------------
+
+defineSteps('identity', 'oidc', (ctx) => [
+    {
+        body: (
+            <>
+                Ask whoever operates your identity provider to register a <B>confidential client</B>{' '}
+                (sometimes called a web or server-side application) using the <B>authorization code</B>{' '}
+                flow, with this redirect URI: <CopyValue ctx={ctx} id="oidcrd" value={CALLBACK(ctx.origin)} />.
+                Ask for the scopes <C>openid</C>, <C>profile</C> and <C>email</C> — Pinpoint matches staff
+                accounts by email address, so a provider that does not release it cannot be used.
+            </>
+        ),
+        trouble: <>If they offer a "public client", that is the wrong kind: it issues no secret. Say confidential, or server-side.</>,
+    },
+    {
+        body: (
+            <>
+                Ask for the <B>issuer URL</B> — the base address, not the full endpoint. You can check it
+                yourself: <C>{'<issuer>'}/.well-known/openid-configuration</C> should return a page of
+                JSON in a browser. If it 404s, the issuer is wrong.
+            </>
+        ),
+        fields: ['OIDC_ISSUER'],
+    },
+    {
+        body: <>Then the client's ID and secret.</>,
+        fields: ['OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET'],
+    },
+]);
+
+// ===========================================================================
+// Maps
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Google Maps
+//
+// Billing is step one rather than a footnote: without it Google issues a key
+// that looks correct and the map shows a grey box, which is the single most
+// common failure on this page.
 // ---------------------------------------------------------------------------
 
 defineSteps('maps', 'google', (ctx) => [
     {
         body: (
             <>
-                In <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer"
-                    className="text-primary-300 underline underline-offset-2">Google Cloud</a>, open{' '}
-                <B>APIs &amp; Services → Library</B> and enable all three of{' '}
-                <code className="bg-black/30 px-1 rounded text-[11px]">Maps JavaScript API</code>,{' '}
-                <code className="bg-black/30 px-1 rounded text-[11px]">Geocoding API</code> and{' '}
-                <code className="bg-black/30 px-1 rounded text-[11px]">Places API</code>. Then open{' '}
-                <B>Billing</B> and attach a payment method.
+                In <L href="https://console.cloud.google.com">Google Cloud</L>, open{' '}
+                <B>APIs &amp; Services → Library</B> and enable all three of <C>Maps JavaScript API</C>,{' '}
+                <C>Geocoding API</C> and <C>Places API</C>. Then open <B>Billing</B> and attach a payment
+                method.
             </>
         ),
         check: <>an "API Enabled" banner on each of the three, and a billing account listed under Billing.</>,
@@ -133,9 +310,8 @@ defineSteps('maps', 'google', (ctx) => [
             <>
                 Go to <B>APIs &amp; Services → Credentials → Create Credentials → API key</B>. Then open
                 the key and restrict it: under <B>Application restrictions</B> choose <B>Websites</B> and
-                add <CopyValue ctx={ctx} id="gmref" value={`${ctx.origin}/*`} /> — the{' '}
-                <code className="bg-black/30 px-1 rounded text-[11px]">/*</code> matters. Under{' '}
-                <B>API restrictions</B> choose <B>Restrict key</B> and tick the same three APIs.
+                add <CopyValue ctx={ctx} id="gmref" value={`${ctx.origin}/*`} /> — the <C>/*</C> matters.
+                Under <B>API restrictions</B> choose <B>Restrict key</B> and tick the same three APIs.
             </>
         ),
         check: <>your site under Website restrictions, and only those three APIs ticked.</>,
@@ -149,26 +325,694 @@ defineSteps('maps', 'google', (ctx) => [
 ]);
 
 // ---------------------------------------------------------------------------
-// Text messages — Twilio
+// Esri / ArcGIS
 //
-// Short because the console is short: everything needed is on the dashboard
-// home page, and the only real trap is the number format.
+// The one most likely to already be in place: a town with a GIS department has
+// an ArcGIS organisation, and often its own address locator, which is better
+// than any national geocoder at finding a local address.
 // ---------------------------------------------------------------------------
+
+defineSteps('maps', 'esri', () => [
+    {
+        body: (
+            <>
+                Before anything else, ask your GIS department whether the town already has an ArcGIS
+                organisation. If it does, the key should be created there rather than on a new personal
+                developer account — otherwise it belongs to whoever signed up.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                Sign in at <L href="https://location.arcgis.com">location.arcgis.com</L>, open the
+                developer dashboard, and create an <B>API key</B> credential. Scope it to the services
+                you need: <B>Basemap styles</B> and <B>Geocoding</B> at minimum. Set an expiry you will
+                remember — ArcGIS API keys are valid for up to a year and then simply stop.
+            </>
+        ),
+        check: <>a key string starting <C>AAPT</C> or <C>AAPK</C>.</>,
+        trouble: <>Note the expiry date somewhere the town will see it. When one of these lapses the map goes blank with no warning and nothing in the console says why.</>,
+    },
+    {
+        body: (
+            <>
+                Paste the key. Both other boxes are optional: the basemap is an Esri style id (for
+                example <C>arcgis/navigation</C>) if you want something other than the default, and the
+                locator is the URL of your own address locator service if the GIS department publishes
+                one.
+            </>
+        ),
+        fields: ['ARCGIS_API_KEY', 'ARCGIS_BASEMAP_ID', 'ARCGIS_LOCATOR_URL'],
+        trouble: <>A town locator is worth asking for. It knows your street names, your address ranges and your recent subdivisions, which a national geocoder often does not.</>,
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Azure Maps
+// ---------------------------------------------------------------------------
+
+defineSteps('maps', 'azure', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L>, press <B>Create a
+                resource</B>, search for <B>Azure Maps</B>, and create an account in the same
+                subscription and region as the rest of your Azure services.
+            </>
+        ),
+        check: <>the new Maps account's overview page.</>,
+    },
+    {
+        body: (
+            <>
+                Open <B>Settings → Authentication</B> on that account and copy the <B>Primary Key</B>{' '}
+                under Shared Key Authentication.
+            </>
+        ),
+        fields: ['AZURE_MAPS_KEY'],
+        trouble: <>Take the primary key and leave the secondary alone. The pair exists so a key can be rotated without downtime — using both at once removes the point of having two.</>,
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Apple Maps
+//
+// The most involved of the four and the only one where a downloaded file is the
+// credential. It also requires a paid Apple Developer membership, which is
+// worth saying at the top rather than discovering at step three.
+// ---------------------------------------------------------------------------
+
+defineSteps('maps', 'apple', () => [
+    {
+        body: (
+            <>
+                This needs a paid <L href="https://developer.apple.com/programs/">Apple Developer
+                Program</L> membership (about $99/year) held by the town, not by a person. If you do not
+                have one, one of the other map providers will be much less work.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                At <L href="https://developer.apple.com/account">developer.apple.com/account</L> open{' '}
+                <B>Certificates, Identifiers &amp; Profiles → Identifiers</B>, press <B>+</B>, and create
+                an identifier of type <B>Maps IDs</B>.
+            </>
+        ),
+        check: <>your new Maps ID in the identifiers list.</>,
+    },
+    {
+        body: (
+            <>
+                Then open <B>Keys</B> in the same sidebar, press <B>+</B>, tick <B>MapKit JS</B>, and
+                configure it to use the Maps ID you just made. Create the key and press <B>Download</B>.
+                You get a file named <C>AuthKey_XXXXXXXXXX.p8</C>.
+            </>
+        ),
+        trouble: <>Download it now and keep it. Apple removes the file from their servers after the one download; if you lose it the only remedy is revoking the key and starting again.</>,
+    },
+    {
+        body: (
+            <>
+                The <B>Key ID</B> is on that key's page. The <B>Team ID</B> is in{' '}
+                <B>Membership details</B> at the top of your account. For the private key, open the{' '}
+                <C>.p8</C> file in a plain text editor and paste the whole contents — including the{' '}
+                <C>-----BEGIN PRIVATE KEY-----</C> and <C>-----END PRIVATE KEY-----</C> lines.
+            </>
+        ),
+        fields: ['APPLE_MAPKIT_TEAM_ID', 'APPLE_MAPKIT_KEY_ID', 'APPLE_MAPKIT_PRIVATE_KEY'],
+        trouble: <>Open it with a text editor, not Word — a word processor will add formatting that makes the key unreadable. The header and footer lines are part of the key, not decoration.</>,
+    },
+]);
+
+// ===========================================================================
+// AI analysis
+// ===========================================================================
+
+defineSteps('ai', 'vertex', () => [
+    {
+        body: (
+            <>
+                In <L href="https://console.cloud.google.com">Google Cloud</L>, select or create the
+                project you want to bill this to, then open <B>APIs &amp; Services → Library</B> and
+                enable <C>Vertex AI API</C>. Attach a billing account if the project has none.
+            </>
+        ),
+        check: <>"API Enabled" on the Vertex AI API page.</>,
+    },
+    {
+        body: (
+            <>
+                Open <B>IAM &amp; Admin → Service Accounts</B> and create one — a name like{' '}
+                <C>pinpoint-311</C> is fine. Grant it the <B>Vertex AI User</B> role. Do not grant Owner
+                or Editor: this account only ever needs to ask the model a question.
+            </>
+        ),
+        trouble: <>The broad roles are one click away and it is tempting to take them to avoid a permissions problem later. A leaked key with Vertex AI User can run up a model bill; the same key with Editor can delete the project.</>,
+    },
+    {
+        body: (
+            <>
+                On that service account open <B>Keys → Add Key → Create new key → JSON</B>. A file
+                downloads. Open it in a plain text editor and paste the whole contents below, along with
+                your project ID (it is in the file, as <C>project_id</C>).
+            </>
+        ),
+        fields: ['VERTEX_AI_PROJECT', 'VERTEX_AI_SERVICE_ACCOUNT_KEY'],
+        trouble: <>Delete the downloaded file once it is saved here. It is a password to your cloud account sitting in the Downloads folder of whichever machine did the setup.</>,
+    },
+]);
+
+defineSteps('ai', 'azure', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L>, create an <B>Azure OpenAI</B>{' '}
+                resource in a region your town is allowed to use. Access to Azure OpenAI is granted per
+                subscription and can take a day or two to be approved if it has not been requested
+                before.
+            </>
+        ),
+        trouble: <>Check this first if you are on a deadline. Everything else here takes ten minutes; the approval does not.</>,
+    },
+    {
+        body: (
+            <>
+                Open the resource in <L href="https://ai.azure.com">Microsoft Foundry</L> and deploy a
+                model — <B>Deployments → Deploy model</B>. The <B>deployment name</B> you choose is what
+                goes in the box below, and it is not necessarily the model name: you can call a GPT-4o
+                deployment anything you like, and Pinpoint asks for the deployment.
+            </>
+        ),
+        check: <>your deployment listed with status Succeeded.</>,
+    },
+    {
+        body: (
+            <>
+                Back on the Azure resource, open <B>Resource Management → Keys and Endpoint</B> and copy{' '}
+                <B>KEY 1</B> and the <B>Endpoint</B>. Leave the API version box empty unless Microsoft
+                has told you to pin one — it defaults to a current version.
+            </>
+        ),
+        fields: ['AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_API_KEY', 'AZURE_OPENAI_DEPLOYMENT', 'AZURE_OPENAI_API_VERSION'],
+        trouble: <>The endpoint is the base address ending in a slash, not the full chat-completions URL from the sample code.</>,
+    },
+]);
+
+defineSteps('ai', 'bedrock', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://console.aws.amazon.com/bedrock">Bedrock console</L>, set the
+                region selector (top right) to the region you intend to use — model availability differs
+                by region and this choice is load-bearing for everything below.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                In the left pane under <B>Bedrock configurations</B> choose <B>Model access</B>, then{' '}
+                <B>Modify model access</B>. Select the models you want and submit the use-case form.
+                Access usually appears within a few minutes.
+            </>
+        ),
+        check: <>the model showing <B>Access granted</B> rather than Available to request.</>,
+        trouble: <>If submitting fails, the account may not have AWS Marketplace subscription permission — that lives under <B>Billing → Marketplace settings</B> and usually needs whoever owns the AWS account.</>,
+    },
+    {
+        body: (
+            <>
+                Create an IAM user for Pinpoint with permission to invoke models —{' '}
+                <C>bedrock:InvokeModel</C> and <C>bedrock:InvokeModelWithResponseStream</C> — and nothing
+                else. Take an access key from <B>Security credentials</B> and paste it here with the same
+                region you set above.
+            </>
+        ),
+        fields: ['AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+        trouble: <>The secret access key is shown once, on the screen where you create it. There is no way to see it again — only to issue a new one.</>,
+    },
+]);
+
+// ===========================================================================
+// Translation
+// ===========================================================================
+
+defineSteps('translation', 'google', () => [
+    {
+        body: (
+            <>
+                In <L href="https://console.cloud.google.com">Google Cloud</L>, open{' '}
+                <B>APIs &amp; Services → Library</B> and enable <C>Cloud Translation API</C> in the same
+                project you are using elsewhere.
+            </>
+        ),
+        check: <>"API Enabled" on the Cloud Translation API page.</>,
+    },
+    {
+        body: (
+            <>
+                Enter that project's ID. Translation reuses the Google credentials already configured for
+                this deployment, so there is no separate key to create.
+            </>
+        ),
+        fields: ['GOOGLE_CLOUD_PROJECT'],
+        trouble: <>The project <B>ID</B>, not the display name. They are often similar and occasionally identical; the ID is the one shown in the project picker in smaller grey type.</>,
+    },
+]);
+
+defineSteps('translation', 'azure', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L>, press <B>Create a
+                resource</B> and create a <B>Translator</B> resource. The free tier handles a
+                small town's volume; note the <B>region</B> you pick, because it is part of the
+                credentials.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                Open <B>Resource Management → Keys and Endpoint</B> and copy <B>KEY 1</B> and the{' '}
+                <B>Location/Region</B> value. Leave the endpoint box empty unless you were given a
+                custom one — the default global endpoint is correct for almost everyone.
+            </>
+        ),
+        fields: ['AZURE_TRANSLATOR_KEY', 'AZURE_TRANSLATOR_REGION', 'AZURE_TRANSLATOR_ENDPOINT'],
+        trouble: <>The region must be the short form shown on that page, like <C>eastus</C>, not "East US". A mismatched region fails authentication and reports it as a bad key.</>,
+    },
+]);
+
+defineSteps('translation', 'aws', () => [
+    {
+        body: (
+            <>
+                Amazon Translate needs no setup in its own console — it is on by default. Create an IAM
+                user for Pinpoint with the <C>TranslateReadOnly</C> managed policy, which despite the
+                name is what permits translating text.
+            </>
+        ),
+        trouble: <>If you already made an IAM user for Bedrock or SES, add this policy to that one rather than creating another set of keys to keep track of.</>,
+    },
+    {
+        body: <>Take an access key from that user's <B>Security credentials</B> tab and enter it with your region.</>,
+        fields: ['AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+    },
+]);
+
+// ===========================================================================
+// Email
+// ===========================================================================
+
+defineSteps('email', 'smtp', () => [
+    {
+        body: (
+            <>
+                Ask whoever runs the town's email for the SMTP server address and port, and for a
+                dedicated account to send from. A separate account matters: when residents reply to a
+                status update, the replies land wherever this sends from.
+            </>
+        ),
+        trouble: <>Microsoft 365 and Google Workspace both restrict plain SMTP by default. If your IT provider says it is blocked, they are right, and Amazon SES or Azure Communication Services will be less work than arguing for an exception.</>,
+    },
+    {
+        body: (
+            <>
+                Fill in the server details. Port <C>587</C> with STARTTLS is the usual answer; <C>465</C>{' '}
+                is the older implicit-TLS port and also works.
+            </>
+        ),
+        fields: ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASSWORD'],
+    },
+    {
+        body: (
+            <>
+                Then what residents see in their inbox. Use a monitored address —{' '}
+                <C>311@yourtown.gov</C> rather than <C>noreply@</C>, because people reply to these and a
+                reply that goes nowhere is a complaint you never hear.
+            </>
+        ),
+        fields: ['SMTP_FROM_EMAIL', 'SMTP_FROM_NAME'],
+    },
+]);
+
+defineSteps('email', 'ses', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://console.aws.amazon.com/ses">SES console</L>, set your region,
+                then open <B>Identities → Create identity</B> and verify your <B>domain</B> — not just a
+                single address. Verifying the domain lets you send from any address on it, and it is what
+                makes DKIM available.
+            </>
+        ),
+        check: <>the identity showing <B>Verified</B>. It requires DNS records, so whoever manages the town's DNS needs to be involved.</>,
+    },
+    {
+        body: (
+            <>
+                New SES accounts are in the <B>sandbox</B> and can only send to addresses you have also
+                verified — which means residents get nothing. Open <B>Account dashboard</B> and press{' '}
+                <B>Request production access</B>. Approval usually takes about a day.
+            </>
+        ),
+        trouble: <>This is the step that quietly breaks a launch. In the sandbox everything looks like it works: SES accepts the message and returns success, and the resident never receives it.</>,
+    },
+    {
+        body: (
+            <>
+                Create an IAM user for Pinpoint with the <C>AmazonSESFullAccess</C> policy (or just{' '}
+                <C>ses:SendEmail</C> and <C>ses:SendRawEmail</C> if you would rather be precise), then
+                fill these in. The from address must be on the domain you verified.
+            </>
+        ),
+        fields: ['AWS_REGION', 'SES_FROM_EMAIL', 'SMTP_FROM_NAME', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+        trouble: <>The region must be the one where you verified the domain. SES identities do not exist across regions, and a mismatch reports as an unverified sender.</>,
+    },
+]);
+
+defineSteps('email', 'acs', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L> create two resources:{' '}
+                <B>Communication Services</B>, and <B>Email Communication Services</B>. Both are needed,
+                and they must be in the <B>same geography</B> — you cannot connect them otherwise.
+            </>
+        ),
+        trouble: <>Two resources with near-identical names is genuinely confusing. The Email one owns the domain; the plain Communication Services one owns the endpoint and key.</>,
+    },
+    {
+        body: (
+            <>
+                On the Email resource, add a domain. <B>Add a free Azure subdomain</B> is one click and
+                works immediately, but sends from an <C>azurecomm.net</C> address, which residents will
+                not recognise as the town. <B>Set up a custom domain</B> takes DNS records (TXT, SPF and
+                DKIM) and is worth it for anything public-facing.
+            </>
+        ),
+        check: <>the domain listed with verification complete, and a MailFrom address shown on its page.</>,
+    },
+    {
+        body: (
+            <>
+                Open the Communication Services resource, go to <B>Email → Domains</B> and press{' '}
+                <B>Connect domain</B> to link the one you just made.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                Then on that same resource open <B>Settings → Keys</B> and copy the <B>Endpoint</B> and{' '}
+                <B>Primary key</B>. The from address is the MailFrom value on the domain page.
+            </>
+        ),
+        fields: ['ACS_ENDPOINT', 'ACS_ACCESS_KEY', 'ACS_FROM_EMAIL', 'SMTP_FROM_NAME'],
+    },
+]);
+
+// ===========================================================================
+// Text messages
+// ===========================================================================
 
 defineSteps('sms', 'twilio', () => [
     {
         body: (
             <>
-                Sign in at <a href="https://console.twilio.com" target="_blank" rel="noopener noreferrer"
-                    className="text-primary-300 underline underline-offset-2">console.twilio.com</a>. The{' '}
+                Sign in at <L href="https://console.twilio.com">console.twilio.com</L>. The{' '}
                 <B>Account SID</B> and <B>Auth Token</B> are on the dashboard home page.
             </>
         ),
         fields: ['TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN'],
     },
     {
-        body: <>Buy or select a number under <B>Phone Numbers → Manage → Active numbers</B>, and enter it in <code className="bg-black/30 px-1 rounded text-[11px]">+1XXXXXXXXXX</code> form.</>,
+        body: <>Buy or select a number under <B>Phone Numbers → Manage → Active numbers</B>, and enter it in <C>+1XXXXXXXXXX</C> form.</>,
         fields: ['TWILIO_PHONE_NUMBER'],
         trouble: <>It has to be a number you own in Twilio. A trial account can only text numbers you have verified.</>,
     },
+]);
+
+defineSteps('sms', 'sns', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://console.aws.amazon.com/sns">SNS console</L>, open <B>Text
+                messaging (SMS)</B> in the left pane and check the account status at the top. A new
+                account is in the <B>SMS sandbox</B> and can only text numbers you have verified there.
+            </>
+        ),
+        trouble: <>Leave the sandbox before launch, from that same page. Inside it, messages to residents are rejected — and the rejection is in a log, not on the page where somebody would see it.</>,
+    },
+    {
+        body: (
+            <>
+                Still on that page, set a <B>monthly spending limit</B> you are comfortable with, then
+                register an origination identity. For a US municipality that normally means a{' '}
+                <B>10DLC</B> number, which requires registering the town as a brand; the carriers filter
+                unregistered traffic heavily.
+            </>
+        ),
+        trouble: <>Start the 10DLC registration early. It is a carrier process, not an AWS one, and it can take a couple of weeks.</>,
+    },
+    {
+        body: (
+            <>
+                Create an IAM user for Pinpoint with permission for <C>sns:Publish</C>, and enter its
+                access key with your region. The sender ID box is optional and only has an effect in
+                countries that support alphabetic senders — it is ignored for US numbers.
+            </>
+        ),
+        fields: ['AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'SMS_SENDER_ID'],
+    },
+]);
+
+defineSteps('sms', 'acs', () => [
+    {
+        body: (
+            <>
+                Use the same <B>Communication Services</B> resource as email if you have one. Open it in
+                the <L href="https://portal.azure.com">Azure portal</L> and go to{' '}
+                <B>Telephony and SMS → Phone numbers → Get</B> to acquire a number with SMS enabled.
+            </>
+        ),
+        check: <>a number listed with SMS among its capabilities.</>,
+        trouble: <>Acquiring a US number needs a regulatory profile and, for most SMS use, 10DLC registration. Azure walks you through it, but it is not instant — start it before you need it.</>,
+    },
+    {
+        body: (
+            <>
+                Then <B>Settings → Keys</B> on that resource for the endpoint and key, and the number you
+                just acquired in <C>+1XXXXXXXXXX</C> form.
+            </>
+        ),
+        fields: ['ACS_ENDPOINT', 'ACS_ACCESS_KEY', 'SMS_FROM_NUMBER'],
+    },
+]);
+
+defineSteps('sms', 'http', () => [
+    {
+        body: (
+            <>
+                For a gateway that is not listed — a regional carrier, a state contract, or an existing
+                notification system. Pinpoint sends a POST with a JSON body containing the destination
+                number and the message text, and treats any 2xx response as delivered.
+            </>
+        ),
+    },
+    {
+        body: (
+            <>
+                Enter the endpoint URL your provider gave you, and the key they issued. The key is sent
+                as a bearer token.
+            </>
+        ),
+        fields: ['SMS_HTTP_API_URL', 'SMS_HTTP_API_KEY'],
+        trouble: <>If their API expects a different shape or a different header, this will fail on every send. Check with them before relying on it, and send yourself a test message from the button below.</>,
+    },
+]);
+
+// ===========================================================================
+// Key management for resident data
+//
+// These wrap the key that encrypts resident names, emails and phone numbers.
+// The recurring warning is the same in all three: this key is not something you
+// can lose and re-create. Losing it means the data it protected is gone.
+// ===========================================================================
+
+defineSteps('kms', 'google', () => [
+    {
+        body: (
+            <>
+                In <L href="https://console.cloud.google.com">Google Cloud</L>, enable{' '}
+                <C>Cloud KMS API</C>, then open <B>Security → Key Management</B> and create a{' '}
+                <B>key ring</B> followed by a <B>key</B> inside it. Choose purpose{' '}
+                <B>Symmetric encrypt/decrypt</B>. A rotation period of 90 days is a reasonable default.
+            </>
+        ),
+        check: <>your key listed inside your key ring.</>,
+    },
+    {
+        body: (
+            <>
+                Grant the service account this deployment uses the role <B>Cloud KMS CryptoKey
+                Encrypter/Decrypter</B> on that key. Grant it on the key itself, not on the whole
+                project.
+            </>
+        ),
+        trouble: <>Without this the key exists, the settings save, and resident data is quietly encrypted with the application key instead. The health dashboard will say so — it is the one place that reports it.</>,
+    },
+    {
+        body: (
+            <>
+                Enter the location, key ring name and key name exactly as they appear in the console.
+                The location is the short form, like <C>us-central1</C>.
+            </>
+        ),
+        fields: ['KMS_LOCATION', 'KMS_KEY_RING', 'KMS_KEY_ID'],
+        trouble: <>Never delete or disable this key, or the key ring holding it. Resident contact details are encrypted under it, and Google cannot recover a destroyed key for anyone.</>,
+    },
+]);
+
+defineSteps('kms', 'azure', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L> create a <B>Key Vault</B>.
+                Turn on <B>soft delete</B> and <B>purge protection</B> — both are offered during
+                creation, and they are what stops an accidental deletion becoming permanent.
+            </>
+        ),
+        trouble: <>Purge protection cannot be turned on later on some configurations, and it is exactly the setting a town regrets not having. Take it now.</>,
+    },
+    {
+        body: (
+            <>
+                Open <B>Objects → Keys → Generate/Import</B> and create an <B>RSA</B> key. 2048 is fine;
+                4096 is fine too. Note the key's name.
+            </>
+        ),
+        check: <>the key listed with status Enabled.</>,
+    },
+    {
+        body: (
+            <>
+                Register an application for Pinpoint (<B>Microsoft Entra ID → App registrations → New
+                registration</B>), create a client secret for it under{' '}
+                <B>Certificates &amp; secrets</B>, and grant that application <B>Get</B>, <B>Wrap Key</B>{' '}
+                and <B>Unwrap Key</B> on the vault — under <B>Access policies</B>, or as the{' '}
+                <B>Key Vault Crypto User</B> role if your vault uses Azure RBAC.
+            </>
+        ),
+        trouble: <>Wrap and Unwrap are the two that matter and they are easy to miss in a long checklist of permissions. Get alone is not enough.</>,
+    },
+    {
+        body: (
+            <>
+                Then fill these in. The vault URL is the full{' '}
+                <C>https://yourvault.vault.azure.net/</C> address from the vault's overview page.
+            </>
+        ),
+        fields: ['AZURE_KEYVAULT_URL', 'AZURE_KEYVAULT_KEY', 'AZURE_TENANT_ID', 'AZURE_KEYVAULT_CLIENT_ID', 'AZURE_KEYVAULT_CLIENT_SECRET'],
+        trouble: <>The client secret has an expiry date. Write it down: when it lapses, resident data stops decrypting, and nothing about that failure points at a calendar.</>,
+    },
+]);
+
+defineSteps('kms', 'aws', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://console.aws.amazon.com/kms">KMS console</L>, set your region,
+                choose <B>Customer managed keys</B>, then <B>Create key</B>. Take key type{' '}
+                <B>Symmetric</B> and key usage <B>Encrypt and decrypt</B> — both are the defaults. Give
+                it an alias like <C>pinpoint-311-pii</C>.
+            </>
+        ),
+        check: <>the key listed with status Enabled.</>,
+    },
+    {
+        body: (
+            <>
+                On the key's <B>Key policy</B>, add the IAM user or role this deployment uses as a{' '}
+                <B>key user</B>, which grants encrypt and decrypt. Then enter the key ID (or its ARN) and
+                the region.
+            </>
+        ),
+        fields: ['AWS_REGION', 'AWS_KMS_KEY_ID'],
+        trouble: <>Never schedule this key for deletion. AWS enforces a waiting period of at least seven days, and at the end of it the resident data encrypted under it is unrecoverable — by you, and by AWS.</>,
+    },
+]);
+
+// ===========================================================================
+// Photo redaction
+//
+// Three cloud detectors and one that runs here. The steps are short because the
+// work is a permission, not a console tour -- and the settings below are what a
+// town is actually deciding, which is what to blur.
+// ===========================================================================
+
+const REDACTION_CHOICE = (
+    <>
+        Faces and licence plates are both on by default. Residents photograph potholes with cars parked
+        beside them and neighbours walking past, and neither of those people asked to be in a public
+        record.
+    </>
+);
+
+defineSteps('redaction', 'google', () => [
+    {
+        body: (
+            <>
+                In <L href="https://console.cloud.google.com">Google Cloud</L>, open{' '}
+                <B>APIs &amp; Services → Library</B> and enable <C>Cloud Vision API</C>. The service
+                account this deployment already uses needs no extra role beyond being able to call it.
+            </>
+        ),
+        check: <>"API Enabled" on the Cloud Vision API page.</>,
+    },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+]);
+
+defineSteps('redaction', 'aws', () => [
+    {
+        body: (
+            <>
+                Amazon Rekognition needs nothing enabled in its console. Add{' '}
+                <C>rekognition:DetectFaces</C> and <C>rekognition:DetectText</C> to the IAM user this
+                deployment uses — plate detection works by reading text in the image.
+            </>
+        ),
+    },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+]);
+
+defineSteps('redaction', 'azure', () => [
+    {
+        body: (
+            <>
+                In the <L href="https://portal.azure.com">Azure portal</L> create a{' '}
+                <B>Computer Vision</B> resource (listed under Azure AI services), and use its key and
+                endpoint. If you already have a multi-service Azure AI resource, that works too.
+            </>
+        ),
+    },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
+]);
+
+defineSteps('redaction', 'local', () => [
+    {
+        body: (
+            <>
+                Detection runs on this server. Nothing to configure and no photo ever leaves the
+                building, which is the reason to choose it. It finds fewer faces than the cloud
+                detectors, particularly small or partly turned ones — so it is the safer choice for
+                privacy and the weaker one for coverage.
+            </>
+        ),
+    },
+    { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
 ]);

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -233,13 +233,25 @@ defineSteps('identity', 'okta', (ctx) => [
     {
         body: (
             <>
-                The issuer is somewhere else. Open <B>Security → API</B> in the left menu and copy the{' '}
-                <B>Issuer URI</B> of the authorization server you are using — usually the one named{' '}
-                <C>default</C>.
+                The issuer is not on the application page. Open <B>Security → API</B> in the left menu.
+                You will see more than one authorization server, and <B>either can be correct</B> — what
+                matters is that the one you enter here is the one your app is set to use:
+                <span className="mt-2 grid gap-1.5">
+                    <span className="text-white/50 text-xs">
+                        <B>Org</B> — issuer is your plain Okta domain, <C>https://your-org.okta.com</C>.
+                        This is Okta's recommendation for ordinary single sign-on, which is all Pinpoint
+                        does.
+                    </span>
+                    <span className="text-white/50 text-xs">
+                        <B>default</B> (a custom server) — issuer ends <C>/oauth2/default</C>. Use this if
+                        your Okta administrator has put claims or policies on it.
+                    </span>
+                </span>
+                If you are unsure, ask whoever administers Okta which one the app was assigned to.
             </>
         ),
         fields: ['OKTA_ISSUER'],
-        trouble: <>Not your org URL. It typically ends <C>/oauth2/default</C>, and the plain org address looks close enough to be pasted by mistake — after which sign-in fails at discovery with a message that names neither.</>,
+        trouble: <>You can check the value before saving: paste <C>{'<issuer>'}/.well-known/openid-configuration</C> into a browser. A page of JSON means it is right; a 404 or an error means it is not. That takes ten seconds and saves diagnosing a login loop.</>,
     },
 ]);
 
@@ -351,8 +363,8 @@ defineSteps('maps', 'esri', () => [
                 remember — ArcGIS API keys are valid for up to a year and then simply stop.
             </>
         ),
-        check: <>a key string starting <C>AAPT</C> or <C>AAPK</C>.</>,
-        trouble: <>Note the expiry date somewhere the town will see it. When one of these lapses the map goes blank with no warning and nothing in the console says why.</>,
+        check: <>a key string starting <C>AAPK</C>. (<C>AAPT</C> is Esri's prefix for short-lived access tokens — if that is what you have, it is not the right credential.)</>,
+        trouble: <>Write the expiry date somewhere the town will see it. Keys expire at 00:00:00 GMT on the date you set, and when one lapses the map goes blank with no warning and nothing in the console saying why.</>,
     },
     {
         body: (
@@ -490,12 +502,11 @@ defineSteps('ai', 'azure', () => [
         body: (
             <>
                 In the <L href="https://portal.azure.com">Azure portal</L>, create an <B>Azure OpenAI</B>{' '}
-                resource in a region your town is allowed to use. Access to Azure OpenAI is granted per
-                subscription and can take a day or two to be approved if it has not been requested
-                before.
+                resource in a region your town is allowed to use. No application or approval is needed —
+                every Azure subscription is eligible for the standard models.
             </>
         ),
-        trouble: <>Check this first if you are on a deadline. Everything else here takes ten minutes; the approval does not.</>,
+        trouble: <>Older write-ups describe a registration form and a wait of a day or two. Microsoft removed that for general access; a form is now only required for specific restricted features, none of which Pinpoint uses. If someone tells you to apply and wait, they are working from stale instructions.</>,
     },
     {
         body: (
@@ -637,7 +648,7 @@ defineSteps('email', 'smtp', () => [
                 status update, the replies land wherever this sends from.
             </>
         ),
-        trouble: <>Microsoft 365 and Google Workspace both restrict plain SMTP by default. If your IT provider says it is blocked, they are right, and Amazon SES or Azure Communication Services will be less work than arguing for an exception.</>,
+        trouble: <>Microsoft 365 and Google Workspace both restrict plain SMTP by default — on Microsoft it is switched off unless an administrator turns it back on. Worse, Microsoft is removing password-based SMTP from Exchange Online at the end of December 2026: existing tenants have it disabled by default from then, and tenants created afterwards cannot use it at all. If your town is on Microsoft 365, choosing SMTP today buys you a few months. Amazon SES or Azure Communication Services is the durable answer.</>,
     },
     {
         body: (
@@ -795,13 +806,24 @@ defineSteps('sms', 'acs', () => [
     {
         body: (
             <>
-                Use the same <B>Communication Services</B> resource as email if you have one. Open it in
-                the <L href="https://portal.azure.com">Azure portal</L> and go to{' '}
-                <B>Telephony and SMS → Phone numbers → Get</B> to acquire a number with SMS enabled.
+                <B>Register before you try to buy a number.</B> On the Communication Services resource,
+                open <B>Telephony and SMS → Regulatory Documents</B> and complete the 10DLC{' '}
+                <B>brand</B> and <B>campaign</B> registration for the town. In the US, both have to be
+                approved before you can acquire or SMS-enable a number at all — this is not a step you
+                can come back to.
             </>
         ),
-        check: <>a number listed with SMS among its capabilities.</>,
-        trouble: <>Acquiring a US number needs a regulatory profile and, for most SMS use, 10DLC registration. Azure walks you through it, but it is not instant — start it before you need it.</>,
+        trouble: <>You also need a paid Azure subscription. Phone numbers cannot be acquired on a trial or with free credits, and availability depends on your subscription's billing country.</>,
+    },
+    {
+        body: (
+            <>
+                Once registration is approved, go to <B>Telephony and SMS → Phone numbers</B> and acquire
+                a number with SMS among its capabilities. Use the same Communication Services resource as
+                email if you already made one.
+            </>
+        ),
+        check: <>the number listed with SMS in its capabilities.</>,
     },
     {
         body: (
@@ -943,7 +965,7 @@ defineSteps('kms', 'aws', () => [
             </>
         ),
         fields: ['AWS_REGION', 'AWS_KMS_KEY_ID'],
-        trouble: <>Never schedule this key for deletion. AWS enforces a waiting period of at least seven days, and at the end of it the resident data encrypted under it is unrecoverable — by you, and by AWS.</>,
+        trouble: <>Never schedule this key for deletion. AWS enforces a waiting period between 7 and 30 days — 30 by default — during which the key cannot be used at all, so resident data stops decrypting the moment deletion is scheduled rather than when it completes. It can be cancelled inside that window. After it, the data encrypted under the key is unrecoverable, by you and by AWS.</>,
     },
 ]);
 

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -1,0 +1,174 @@
+import { Check, Copy } from 'lucide-react';
+
+import { defineSteps } from './setupSteps';
+import type { StepContext } from './setupSteps';
+
+/**
+ * The steps themselves, one registration per provider.
+ *
+ * Separate from setupSteps.tsx on purpose: that file is the mechanism and does
+ * not go stale, this one is content about somebody else's console and will.
+ * Vendors reorganise their menus on their own schedule, so entries here are
+ * expected to be corrected over time, and a provider with no entry is a normal
+ * state -- the card falls back to its plain field list.
+ *
+ * The rule for writing one: every step either does something or produces
+ * something. `check` is what tells a clerk they are in the right place, and it
+ * only earns its line when the next thing they do is paste a value. Where a
+ * value must be copied exactly -- callback URLs, key restrictions -- give them
+ * the copy button rather than a string to retype, because one missing character
+ * fails silently and looks like a wrong password.
+ */
+
+/** A copy-to-clipboard chip for a value that must be exact. */
+function CopyValue({ ctx, id, value }: { ctx: StepContext; id: string; value: string }) {
+    return (
+        <span className="inline-flex items-center gap-1 align-middle">
+            <code className="bg-black/30 px-1.5 py-0.5 rounded text-[11px] text-primary-200 break-all">{value}</code>
+            <button
+                type="button"
+                onClick={() => ctx.copy(value, id)}
+                aria-label="Copy to clipboard"
+                className="inline-flex text-white/40 hover:text-white/80 transition-colors"
+            >
+                {ctx.copied === id ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+            </button>
+        </span>
+    );
+}
+
+const B = ({ children }: { children: React.ReactNode }) => (
+    <strong className="text-white/90">{children}</strong>
+);
+
+// ---------------------------------------------------------------------------
+// Staff sign-in — Auth0
+//
+// Transcribed from the long-form guide, which was written against the Auth0
+// dashboard and is the one path here that has been walked end to end. The
+// ordering is what matters: the callback URLs go in before the credentials come
+// out, because a tenant configured in the other order accepts the password and
+// then fails on the redirect, which reads as a wrong secret.
+// ---------------------------------------------------------------------------
+
+defineSteps('identity', 'auth0', (ctx) => [
+    {
+        body: (
+            <>
+                Create the account at <a href="https://auth0.com" target="_blank" rel="noopener noreferrer"
+                    className="text-primary-300 underline underline-offset-2">auth0.com</a>, using a{' '}
+                <B>shared town email address</B> rather than a personal one — whoever replaces you will
+                need to get in. When it asks for a region, pick one in the US if your town or state has a
+                rule about where data is held; it cannot be changed afterwards.
+            </>
+        ),
+        check: <>the Auth0 dashboard, with your town's name in the top-left corner.</>,
+    },
+    {
+        body: (
+            <>
+                In the left menu open <B>Applications → Applications</B> and press <B>Create
+                Application</B>. Choose <B>Regular Web Application</B> — not Single Page, not Machine to
+                Machine. If it then offers to pick a technology, close that; it only shows sample code.
+            </>
+        ),
+        check: <>a settings page with boxes labelled Domain, Client ID and Client Secret.</>,
+    },
+    {
+        body: (
+            <>
+                Still on <B>Settings</B>, scroll to <B>Application URIs</B> and paste these in, using the
+                copy buttons rather than retyping:
+                <span className="mt-2 grid gap-1.5">
+                    <span className="flex items-center gap-2 flex-wrap">
+                        <span className="text-white/45 text-xs w-40 shrink-0">Allowed Callback URLs</span>
+                        <CopyValue ctx={ctx} id="a0cb" value={`${ctx.origin}/api/auth/callback`} />
+                    </span>
+                    <span className="flex items-center gap-2 flex-wrap">
+                        <span className="text-white/45 text-xs w-40 shrink-0">Allowed Logout URLs</span>
+                        <CopyValue ctx={ctx} id="a0lo" value={ctx.origin} />
+                    </span>
+                    <span className="flex items-center gap-2 flex-wrap">
+                        <span className="text-white/45 text-xs w-40 shrink-0">Allowed Web Origins</span>
+                        <CopyValue ctx={ctx} id="a0wo" value={ctx.origin} />
+                    </span>
+                </span>
+                Then press <B>Save Changes</B> at the bottom.
+            </>
+        ),
+        trouble: <>Do this before the next step. A tenant missing the callback URL accepts the password and then fails on the redirect, which looks like a wrong secret.</>,
+    },
+    {
+        body: <>Copy the three values from that same Settings page into these boxes.</>,
+        fields: ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET'],
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Maps — Google
+//
+// Also transcribed from the long-form guide. Billing is step one rather than a
+// footnote: without it Google issues a key that looks correct and the map shows
+// a grey box, which is the single most common failure on this page.
+// ---------------------------------------------------------------------------
+
+defineSteps('maps', 'google', (ctx) => [
+    {
+        body: (
+            <>
+                In <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer"
+                    className="text-primary-300 underline underline-offset-2">Google Cloud</a>, open{' '}
+                <B>APIs &amp; Services → Library</B> and enable all three of{' '}
+                <code className="bg-black/30 px-1 rounded text-[11px]">Maps JavaScript API</code>,{' '}
+                <code className="bg-black/30 px-1 rounded text-[11px]">Geocoding API</code> and{' '}
+                <code className="bg-black/30 px-1 rounded text-[11px]">Places API</code>. Then open{' '}
+                <B>Billing</B> and attach a payment method.
+            </>
+        ),
+        check: <>an "API Enabled" banner on each of the three, and a billing account listed under Billing.</>,
+        trouble: <>The payment method is not optional and it is the step people skip. Google will issue a key without it, the key will look correct, and the map will show a grey box saying "this page can't load Google Maps correctly".</>,
+    },
+    {
+        body: (
+            <>
+                Go to <B>APIs &amp; Services → Credentials → Create Credentials → API key</B>. Then open
+                the key and restrict it: under <B>Application restrictions</B> choose <B>Websites</B> and
+                add <CopyValue ctx={ctx} id="gmref" value={`${ctx.origin}/*`} /> — the{' '}
+                <code className="bg-black/30 px-1 rounded text-[11px]">/*</code> matters. Under{' '}
+                <B>API restrictions</B> choose <B>Restrict key</B> and tick the same three APIs.
+            </>
+        ),
+        check: <>your site under Website restrictions, and only those three APIs ticked.</>,
+        trouble: <>An unrestricted key can be lifted off your site and run up a bill on the town's card.</>,
+    },
+    {
+        body: <>Paste the key here. The Map ID is optional and only changes how the map looks — leave it empty.</>,
+        fields: ['GOOGLE_MAPS_API_KEY', 'GOOGLE_MAPS_MAP_ID'],
+        trouble: <>Changes to a Google key can take up to five minutes. If the map is still grey straight after saving, wait before changing anything else.</>,
+    },
+]);
+
+// ---------------------------------------------------------------------------
+// Text messages — Twilio
+//
+// Short because the console is short: everything needed is on the dashboard
+// home page, and the only real trap is the number format.
+// ---------------------------------------------------------------------------
+
+defineSteps('sms', 'twilio', () => [
+    {
+        body: (
+            <>
+                Sign in at <a href="https://console.twilio.com" target="_blank" rel="noopener noreferrer"
+                    className="text-primary-300 underline underline-offset-2">console.twilio.com</a>. The{' '}
+                <B>Account SID</B> and <B>Auth Token</B> are on the dashboard home page.
+            </>
+        ),
+        fields: ['TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN'],
+    },
+    {
+        body: <>Buy or select a number under <B>Phone Numbers → Manage → Active numbers</B>, and enter it in <code className="bg-black/30 px-1 rounded text-[11px]">+1XXXXXXXXXX</code> form.</>,
+        fields: ['TWILIO_PHONE_NUMBER'],
+        trouble: <>It has to be a number you own in Twilio. A trial account can only text numbers you have verified.</>,
+    },
+]);

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -92,6 +92,7 @@ import RoadCorridorMap from '../components/RoadCorridorMap';
 import SetupIntegrationsPage from '../components/SetupIntegrationsPage';
 import AuditLogViewer from '../components/AuditLogViewer';
 import VersionSwitcher from '../components/VersionSwitcher';
+import StayInformedHost from '../components/StayInformed';
 
 // Human-friendly retention period from a day count (reflects any override):
 // 365 -> "1 year", 2190 -> "6 years", 2555 -> "7 years", 900 -> "2.5 years".
@@ -1262,6 +1263,19 @@ export default function AdminConsole() {
 
     return (
         <div className="min-h-screen flex">
+            {/* The one voluntary outbound call this application makes. Gated on
+              * a configured deployment rather than on sign-in: `township_name`
+              * only leaves its placeholder once somebody has been through
+              * branding, which is the end of installation, and asking for a
+              * contact address in the middle of installing is asking at the
+              * worst possible moment. Never shown on the setup tab for the same
+              * reason. See components/StayInformed.tsx. */}
+            <StayInformedHost
+                ready={Boolean(settings?.township_name)
+                    && settings?.township_name !== 'Your Municipality'
+                    && currentTab !== 'integration'}
+            />
+
             {/* Mobile sidebar backdrop */}
             <AnimatePresence>
                 {sidebarOpen && (

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -60,6 +60,14 @@ You have the right to:
 
 We implement appropriate technical and organizational measures to protect your personal information, including encryption of data in transit and at rest.
 
+## Administrator Registration with Pinpoint 311
+
+This section does not concern residents and no resident data is involved. It is here because the platform's privacy claim is that it makes no automatic calls to its maintainers, and the one voluntary exception belongs in the same document as the claim.
+
+The admin console offers municipal staff an optional form for sharing a contact address with Pinpoint 311, so that security advisories and release notes can reach this deployment. It is never filled in automatically and nothing is sent unless a member of staff completes it and presses Submit.
+
+If submitted, Pinpoint 311 stores what was entered — organization, contact name and email, and optionally a role, deployment URL, state or country, and how the deployment is being used — together with the two consent choices made on the form. It is used to send security advisories and release notes, and to offer help with the deployment. It is not sold, not used for advertising, and not shared with third parties. The deployment is listed publicly only if that box was ticked. To be removed from the list, or to have the record deleted, contact Pinpoint 311.
+
 ## Contact Us
 
 For privacy-related questions or concerns, please contact your municipal clerk or the department of administration.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1181,12 +1181,24 @@ class ApiClient {
     }
 
     async reencryptPii(): Promise<{
-        total: number;
         reencrypted: number;
-        migrated_from_fernet: number;
+        rows: number;
+        fields: number;
         errors: number;
     }> {
         return this.request('/setup/reencrypt-pii', { method: 'POST' });
+    }
+
+    /** What is not yet on the storage this town chose. Drives one advisory
+     *  line; the work itself happens on a schedule without being asked. */
+    async getStorageStatus(): Promise<StorageStatus> {
+        return this.request<StorageStatus>('/setup/storage-status');
+    }
+
+    /** Generate and store a backup passphrase. Returns it once, in the clear,
+     *  because a copy has to end up somewhere other than this server. */
+    async generateBackupKey(): Promise<{ key: string }> {
+        return this.request('/setup/backup-key', { method: 'POST' });
     }
 
     // ========== Health Dashboard & Runbook (Bus Factor Mitigation) ==========
@@ -1526,6 +1538,13 @@ export interface HealthSummary {
     level: 'ok' | 'warning' | 'critical';
     label: string;
     detail: string;
+}
+
+/** Counts of what has not yet reached the storage the town selected. */
+export interface StorageStatus {
+    secrets: { count: number; store: string | null; reachable: boolean };
+    pii: { total: number; stale: number; on_application_key: number; legacy: number; current: string | null };
+    needs_attention: boolean;
 }
 
 export interface ProactiveHealth {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -619,6 +619,13 @@ class ApiClient {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 
+    /** Whether this server already has an identity on its cloud, in which case
+     *  the credential boxes for that cloud should be left empty rather than
+     *  filled — the platform issues a short-lived token instead. */
+    async getCloudIdentity(): Promise<CloudIdentity> {
+        return this.request<CloudIdentity>('/system/providers/cloud-identity');
+    }
+
     async getCloudProfile(): Promise<CloudProfileState> {
         return this.request<CloudProfileState>('/system/providers/cloud-profile');
     }
@@ -1538,6 +1545,16 @@ export interface HealthSummary {
     level: 'ok' | 'warning' | 'critical';
     label: string;
     detail: string;
+}
+
+/** An identity attached to the compute by the cloud itself. When present, the
+ *  listed keys need no value — and leaving them empty is the better answer, not
+ *  merely an allowed one. */
+export interface CloudIdentity {
+    attached: boolean;
+    provider: string | null;
+    identity: string | null;
+    skippable_keys: string[];
 }
 
 /** Counts of what has not yet reached the storage the town selected. */


### PR DESCRIPTION
Twenty-four commits. The setup guide and the registration form are the features; the rest are things found while building them, several of which affect resident data.

## The setup guide

Instructions now sit with the boxes they fill, one step at a time, for **all 28 provider paths** — up from three. Each step owns the fields it produces, so a clerk never scrolls between an instruction and the input it describes.

Console paths were reconciled against vendor documentation twice. The second pass found six factual errors in content from the first, including one correction to a correction of my own: I had written that Okta's issuer is "not your org URL", which is wrong — Okta documents both the org and custom authorization servers as legitimate, and what matters is that the issuer matches the server the app is assigned to.

The long-form guide previously carried its own copy of every console walk. It had already drifted from the cards — telling towns to invent a backup passphrase months after that field was replaced by a generated one. It now keeps only what a card cannot say (check whether you already run Entra; require a second factor; ask your GIS department before buying a map licence; start 10DLC now because it takes weeks) and defers the rest.

`docs/PROVIDER_SETUP_VERIFICATION.md` records per path whether it was walked end to end, reconciled against documentation, or is generic. Three are walked. Entra and SES are named as the two worth walking before launch.

## Deployment registration form

Optional, user-initiated, browser-side. Prompted once after setup; dismissing it is permanent, with a corner banner as the standing way back.

The payload is exactly the typed fields plus two consent booleans — no version, no fingerprint, no counts. It posts from the browser rather than the server, so the application still holds no connection to pinpoint311.org. A failure degrades to a link rather than an error, because a municipal network blocking outbound traffic has not done anything wrong.

`test_registration_form_contract.py` pins the field list, that the body is the form and not a spread with something appended, that the only `fetch` is in the submit handler, and that COMPLIANCE.md still describes it.

## Silent failures fixed

Each of these stored fine, read back fine, and did nothing.

**Photo redaction was off on every fresh install.** The provider fell through Google, moderation, then AI and returned `None`, because local was deliberately excluded from the fall-through. Meanwhile the card displayed Google Cloud Vision, because the catalog default said so. Every resident photo was stored unmodified with the toggles reading as on. Local is now the floor; off is still reachable by choosing it.

**A cloud detector without credentials now degrades to on-server blurring** rather than returning nothing. `no-detector` is distinct from `no-detections` so the two are no longer the same value downstream.

**Azure photo redaction never worked at all.** `image_redaction.py` reads four keys no card offered. Google and AWS reuse credentials entered elsewhere, so the gap was invisible from every other angle. `test_dispatch_keys_are_enterable.py` now fails if any dispatch path reads a secret nothing can set.

**Save & Test could not test five of eight cards.** The accept-list was widened when those capabilities got catalogs; the branches were not. Every check is now a named function behind one dispatch table, so the two lists cannot drift again. Two turn out to be the most valuable checks on the page: encryption wraps a throwaway key and compares which backend did it, and redaction reports a degraded detector.

**Unlisted reports were unreachable by their own tracking link** and absent from the filer's own list. The portal searched the public list, which excludes them by design. The backend was already correct; the fix is in the portal, and it also fixes a link opened on a different device.

## No lock-in

`migrate_to_secret_manager` was gated on Google, so towns on Azure or AWS could never move database copies of credentials into their vault. The health checks were Google-shaped too and reported failures to correctly-configured Azure and AWS deployments.

`SECRETS_PROVIDER` was read from env-then-database and never from the store — it *is* the answer to which store that is — and was not protected from the migration. Scrubbing it would have reverted a town to the Google default with nothing able to read anything.

Managed mode had the same shape: the platform-key guard was hand-listed and missed fifteen infrastructure keys, so on a state-hosted AWS or Azure deployment a town admin could repoint the state's encryption at their own key.

## Key destruction

The health scan now watches for a KMS key that has stopped answering — the one failure here that cannot be undone, and one nothing previously reported. The probe does a live wrap rather than reading the process cache, which would keep reporting "ok" through an entire deletion window.

Setup steps gained the protections themselves: an explicit deny on `kms:ScheduleKeyDeletion`, purge protection and a vault lock on Azure, a project lien on Google — plus the account-closure risk none of those cover. `DISASTER_RECOVERY.md` has the full picture, including that restoring a backup does not help.

## Also

Watchtower removed. It shipped in the default compose, the README called it optional and nothing made it so, and its scope was every container it could pull — so PostGIS, Redis and Caddy upgraded themselves at 3am while the application did not. Updates are manual, and the README says how.

Secret vaulting and PII re-encryption now run on a schedule instead of being two buttons a clerk had to know when to press. Cloud managed identity is detected and surfaced, so credential boxes say "nothing to enter" — Azure gained managed-identity support it lacked entirely.

## Verification

803 backend tests (up from ~600), 483 pass / 52 skip against a venv matching CI's four-package install, 80 frontend tests, clean build, typecheck steady at 11 pre-existing errors.

**CI has not run on any of these commits** — PR #418 merged and closed, and the workflows trigger on `pull_request`, so this PR is the first time they will. Everything above is local verification.

Where a fix was non-obvious it was checked by mutation rather than by the tests passing: reverting the redaction fallback fails 5 of 10, adding `is_public` to the by-id rule fails 2, restoring the Save & Test drift fails the table check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_