### PR TITLE
Setup guide: enter credentials in the guide, not on a card elsewhere

### DIFF
--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -1,0 +1,205 @@
+"""The setup guide is where setup happens, not a signpost to somewhere else.
+
+This file exists because of a specific wrong turn. Asked to put the credential
+boxes inline in the guide, I instead built the "step owns its fields" layout on
+the provider cards and left the guide saying "scroll to the Maps card below and
+choose your provider" -- and then wrote a test asserting the guide did NOT carry
+the steps, which locked the mistake in. A test can encode a misreading as firmly
+as it encodes a requirement.
+
+So the requirement, stated plainly: a clerk following this guide top to bottom
+never has to leave it. Each section that needs a credential renders the console
+walk and the boxes it fills, for the provider the questionnaire already
+established, with a Save & Test button.
+
+There is still exactly one copy of the walk -- both the guide and the cards
+mount ProviderCredentialSteps over setupStepsContent.tsx. The thing the old test
+was really guarding, two hand-written copies drifting apart, is guarded by
+`test_the_guide_does_not_repeat_the_cards_console_steps` in
+test_setup_steps_content.py, which still passes and should keep passing.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+GUIDE = ROOT / "frontend/src/components/SetupIntegrationsPage.tsx"
+INLINE = ROOT / "frontend/src/components/InlineProviderSetup.tsx"
+SHARED = ROOT / "frontend/src/components/ProviderCredentialSteps.tsx"
+CARDS = ROOT / "frontend/src/components/ServiceProviders.tsx"
+
+
+@pytest.fixture(scope="module")
+def guide() -> str:
+    if not GUIDE.exists():
+        pytest.skip("frontend not present in this checkout")
+    return GUIDE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# No handoffs
+# ---------------------------------------------------------------------------
+
+# The exact shapes the guide used to end its sections with. Any of these coming
+# back means a section has gone back to describing work that happens elsewhere.
+HANDOFF_PHRASES = (
+    "Scroll to the",
+    "card below and choose your",
+    "card further down the page and",
+)
+
+
+def test_no_section_defers_to_a_card(guide):
+    """A guide that says "go and do this somewhere else" is a table of contents.
+
+    The specific failure: someone reading step 2 of sign-in was sent three
+    thousand pixels down the page, to a card that then asked them again which
+    provider they wanted -- a question they had answered in the questionnaire at
+    the top of this very panel.
+    """
+    found = [p for p in HANDOFF_PHRASES if p in guide]
+    assert not found, (
+        f"the setup guide has gone back to pointing at the cards: {found}. "
+        "Sections that need a credential should mount InlineProviderSetup instead."
+    )
+
+
+def test_every_credential_section_sets_up_inline(guide):
+    """Each capability a town can configure from the guide does it here.
+
+    Not an arbitrary list: these are the capabilities whose absence stops a town
+    taking a report or sending a reply. Redaction is included because a fresh
+    install blurs on this server and a town should be able to point that at a
+    cloud without hunting for a card.
+    """
+    expected = {"identity", "maps", "ai", "translation", "kms", "email", "sms", "redaction"}
+    mounted = set(re.findall(r'<InlineProviderSetup[^>]*?\scap="([a-z]+)"', guide))
+    missing = expected - mounted
+    assert not missing, f"no inline setup in the guide for: {sorted(missing)}"
+
+
+def test_inline_setup_can_actually_save(guide):
+    """Boxes with no save button are a form that loses what you typed.
+
+    Each call site has to pass onSaved through, or the progress chips
+    and "Done" badges at the top never move and the clerk cannot tell that
+    anything landed.
+    """
+    if not INLINE.exists():
+        pytest.skip("frontend not present in this checkout")
+    inline = INLINE.read_text()
+    assert "api.saveProvider" in inline, "the inline block cannot save"
+    assert "api.testProvider" in inline, "a save that is not verified is the failure this page exists to avoid"
+    assert "onSaved={onRefresh}" in guide, "saves in the guide never refresh the page's own status"
+
+
+# ---------------------------------------------------------------------------
+# One copy of the walk, rendered twice
+# ---------------------------------------------------------------------------
+
+def test_the_guide_and_the_cards_render_the_same_component():
+    """Inline in two places is right. Written in two places is what drifted.
+
+    Last time this page carried two hand-written copies, the guide told towns
+    Okta's issuer was their org URL while the card told them the opposite.
+    """
+    if not (SHARED.exists() and CARDS.exists() and INLINE.exists()):
+        pytest.skip("frontend not present in this checkout")
+    for path in (CARDS, INLINE):
+        assert "ProviderCredentialSteps" in path.read_text(), (
+            f"{path.name} renders setup steps without the shared component"
+        )
+    # The shared component is the only place stepsFor is turned into markup.
+    assert "stepsFor" in SHARED.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Dynamic: the questionnaire actually drives what is shown
+# ---------------------------------------------------------------------------
+
+def test_the_cloud_answer_picks_the_provider_rather_than_asking_again(guide):
+    """Asking "which cloud?" at the top is pointless if every section re-asks.
+
+    AI, translation and key management are cloud decisions, so they take the
+    answer. Email, SMS and redaction genuinely are not -- a town on Google may
+    well send through SES -- so those keep a picker seeded from the cloud.
+    """
+    for derived in ("aiProvider", "emailProvider", "smsProvider", "redactionProvider"):
+        assert f"const {derived} =" in guide, f"{derived} is not derived from the questionnaire"
+    assert 'cap="ai" provider={aiProvider}' in guide
+    assert 'cap="translation" provider={setupCloud}' in guide
+    assert 'cap="kms" provider={setupCloud}' in guide
+    assert 'cap="identity" provider={setupIdp}' in guide
+    assert 'cap="maps" provider={setupMaps}' in guide
+
+
+def test_changing_the_cloud_moves_the_email_and_sms_defaults(guide):
+    """Held as an override, not a value.
+
+    Storing the resolved provider would freeze it: a town that picked Google,
+    then switched to Azure at the top, would still be looking at SMTP with
+    nothing saying why. Holding "has the clerk overridden this?" instead lets
+    the default follow the cloud while a deliberate pick stays put.
+    """
+    assert "emailOverride ?? EMAIL_BY_CLOUD[setupCloud]" in guide
+    assert "smsOverride ?? SMS_BY_CLOUD[setupCloud]" in guide
+    assert "redactionOverride ?? setupCloud" in guide
+
+
+def test_every_extra_has_a_chip_and_every_chip_gates_something(guide):
+    """A feature in the list with no chip cannot be turned off; a chip that
+    gates nothing is a control that does nothing when clicked.
+
+    Both existed. `errors` (crash reporting) had a section that rendered
+    unconditionally and no chip at all, so the questionnaire's promise -- "untick
+    it to hide the guide again" -- was false for it.
+    """
+    features = set(re.findall(r"'([a-z]+)'", re.search(r"const ALL_FEATURES = \[(.*?)\]", guide, re.S).group(1)))
+    chips = set(re.findall(r"\['([a-z]+)', '[^']+'\]", guide))
+    assert features == chips, (
+        f"features without a chip: {sorted(features - chips)}; "
+        f"chips that are not features: {sorted(chips - features)}"
+    )
+    ungated = [f for f in features if f"wants('{f}')" not in guide]
+    assert not ungated, f"ticking these changes nothing on the page: {sorted(ungated)}"
+
+
+def test_redaction_is_not_gated_on_the_moderation_tick(guide):
+    """They are different decisions and were sharing one switch.
+
+    Unticking "content moderation" silently hid face blurring, and there was no
+    way to have blurring without it -- which matters because moderation screens
+    what a resident wrote and redaction blurs a bystander who wrote nothing.
+    """
+    assert "show={wants('redaction')}" in guide, "redaction has no tick of its own"
+    assert "redaction: 'redaction'" in guide, "the redaction capability is not mapped to its own feature"
+    assert "moderation: 'redaction'" not in guide, "redaction is still riding on the moderation tick"
+
+
+# ---------------------------------------------------------------------------
+# Settings with no card still get boxes
+# ---------------------------------------------------------------------------
+
+# Keys the guide used to print as bare environment-variable names in the middle
+# of a sentence. That is not an instruction a clerk can act on -- it reads as
+# something to hand to IT, and it was the only place on this page that asked
+# somebody to go and edit a file.
+KEYS_THAT_NEED_A_BOX = (
+    "AZURE_CONTENT_SAFETY_ENDPOINT",
+    "AZURE_CONTENT_SAFETY_KEY",
+    "SENTRY_DSN",
+)
+
+
+def test_settings_without_a_provider_card_still_have_inputs(guide):
+    for key in KEYS_THAT_NEED_A_BOX:
+        assert f"key: '{key}'" in guide, f"{key} is named in the guide but has no box to type it into"
+
+
+def test_the_guide_does_not_tell_anyone_to_set_an_environment_variable(guide):
+    """MODERATION_PROVIDER was printed as something to "set", with no box and no
+    explanation of where. It is derived from the cloud answer, so nobody should
+    be asked to set it at all."""
+    assert "MODERATION_PROVIDER" not in guide

--- a/frontend/src/components/InlineProviderSetup.test.tsx
+++ b/frontend/src/components/InlineProviderSetup.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Tells React this is an act() environment, so state updates outside act are
+// reported as the test bug they are rather than silently tolerated.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/* Re-imported per test rather than imported once at the top.
+ *
+ * The component memoises the attached-identity probe at module scope -- eight
+ * of these mount at once in the guide and the answer is a property of the
+ * server, so asking eight times is eight round trips to learn the same thing.
+ * That cache is right in a browser and sticky in a test file: whatever the
+ * first test resolves is what every later test sees. Resetting the module
+ * registry gives each test its own cache instead of loosening the cache to suit
+ * the tests. */
+let InlineProviderSetup: typeof import('./InlineProviderSetup').default;
+
+/**
+ * The guide's credential boxes are really there, and they really save.
+ *
+ * Everything else asserting this reads the TSX as text, which proves the
+ * component is mounted and nothing about what it puts on the screen. That gap
+ * is exactly where the original failure lived: the page looked configured,
+ * every string was present, and the thing a clerk needed to type into was
+ * somewhere else entirely.
+ *
+ * So this renders it. A stubbed catalog goes in, and the assertions are on the
+ * DOM that comes out -- the walk from setupStepsContent, an input per credential
+ * the catalog declares, and a save that posts what was typed.
+ */
+
+const AUTH0 = {
+    current_provider: 'auth0',
+    configured: {},
+    providers: [{
+        provider: 'auth0',
+        name: 'Auth0',
+        credential_fields: [
+            { key: 'AUTH0_DOMAIN', label: 'Auth0 Domain', secret: false },
+            { key: 'AUTH0_CLIENT_ID', label: 'Client ID', secret: false },
+            { key: 'AUTH0_CLIENT_SECRET', label: 'Client Secret', secret: true },
+        ],
+    }],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+const getCloudIdentity = vi.fn();
+const getProviderCatalog = vi.fn();
+const saveProvider = vi.fn();
+const testProvider = vi.fn();
+
+vi.mock('../services/api', () => ({
+    api: {
+        getProviderCatalog: (...a: unknown[]) => getProviderCatalog(...a),
+        getCloudIdentity: (...a: unknown[]) => getCloudIdentity(...a),
+        saveProvider: (...a: unknown[]) => saveProvider(...a),
+        testProvider: (...a: unknown[]) => testProvider(...a),
+    },
+}));
+
+async function mount(ui: React.ReactElement) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(ui); });
+    // Let the catalog and identity promises settle.
+    await act(async () => { await Promise.resolve(); });
+}
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    // Order matters. SETUP_STEPS is a module-scoped registry that
+    // setupStepsContent fills as an import side effect, so after a reset the
+    // content has to be re-imported before anything reads the registry --
+    // otherwise the walk is empty and every provider falls back to a bare list
+    // of boxes, which is precisely the regression these tests exist to catch.
+    await import('./setupStepsContent');
+    InlineProviderSetup = (await import('./InlineProviderSetup')).default;
+    getProviderCatalog.mockResolvedValue(AUTH0);
+    getCloudIdentity.mockResolvedValue({ attached: false, provider: null, identity: null, skippable_keys: [] });
+    saveProvider.mockResolvedValue({ ok: true, provider: 'auth0', warnings: [] });
+    testProvider.mockResolvedValue({ ok: true, detail: 'Signed a test token.' });
+});
+
+afterEach(async () => {
+    await act(async () => { root?.unmount(); });
+    container?.remove();
+});
+
+const inputs = () => Array.from(container.querySelectorAll('input'));
+const labels = () => Array.from(container.querySelectorAll('label')).map(l => l.textContent || '');
+
+describe('the guide sets a provider up where it describes it', () => {
+    it('renders one input per credential the catalog declares', async () => {
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        // Three credentials in, three boxes out. The failure this guards is a
+        // step naming a key the catalog does not have, which renders nothing
+        // and looks identical to a step that needs no input.
+        expect(inputs()).toHaveLength(3);
+        const text = labels().join(' | ');
+        expect(text).toContain('Auth0 Domain');
+        expect(text).toContain('Client ID');
+        expect(text).toContain('Client Secret');
+    });
+
+    it('renders the console walk, not just the boxes', async () => {
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+        // The numbered steps come from setupStepsContent. Boxes without them is
+        // the state this whole change exists to move away from.
+        const numbered = container.querySelectorAll('span.rounded-full');
+        expect(numbered.length).toBeGreaterThan(0);
+        expect(container.textContent).toMatch(/auth0\.com|Applications|Application/i);
+    });
+
+    it('still renders a credential no step claims', async () => {
+        /* The documented guarantee: adding a key to a catalog can never make it
+         * silently unreachable, even before anybody writes the step that
+         * explains it. Without this, a new credential appears in the backend,
+         * the save endpoint expects it, and the only place to enter it does not
+         * exist -- which reads to a clerk as a provider that simply refuses to
+         * work.
+         *
+         * Auth0's three fields are all claimed by steps, so a fourth is added
+         * here that none of them mentions. */
+        getProviderCatalog.mockResolvedValue({
+            ...AUTH0,
+            providers: [{
+                ...AUTH0.providers[0],
+                credential_fields: [
+                    ...AUTH0.providers[0].credential_fields,
+                    { key: 'AUTH0_ORGANIZATION', label: 'Organization ID', secret: false },
+                ],
+            }],
+        });
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        expect(inputs()).toHaveLength(4);
+        expect(labels().join(' | ')).toContain('Organization ID');
+    });
+
+    it('marks a secret field as a password so it is not shoulder-read', async () => {
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+        const secret = inputs().find(i => i.type === 'password');
+        expect(secret).toBeTruthy();
+    });
+
+    it('posts what was typed, then verifies it', async () => {
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        const domain = inputs()[0];
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+        await act(async () => {
+            setter.call(domain, '  town.us.auth0.com  ');
+            domain.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+
+        const save = Array.from(container.querySelectorAll('button'))
+            .find(b => (b.textContent || '').includes('Save'))!;
+        await act(async () => { save.click(); });
+        await act(async () => { await Promise.resolve(); });
+
+        expect(saveProvider).toHaveBeenCalledTimes(1);
+        const [cap, body] = saveProvider.mock.calls[0] as [string, any];
+        expect(cap).toBe('identity');
+        expect(body.provider).toBe('auth0');
+        // Trimmed: a stray space from a copy-paste is the commonest reason a
+        // correct credential is rejected.
+        expect(body.settings.AUTH0_DOMAIN).toBe('town.us.auth0.com');
+        // Untouched boxes are not sent, so saving one field cannot blank another.
+        expect(body.settings.AUTH0_CLIENT_SECRET).toBeUndefined();
+
+        // A save that is not verified is the silent failure this page exists to
+        // avoid, so the test call is part of saving rather than a second button.
+        expect(testProvider).toHaveBeenCalledWith('identity');
+        expect(container.textContent).toContain('Signed a test token.');
+    });
+
+    it('reports a failed verification instead of claiming success', async () => {
+        testProvider.mockResolvedValue({ ok: false, detail: 'Auth0 rejected the client secret.' });
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        const save = Array.from(container.querySelectorAll('button'))
+            .find(b => (b.textContent || '').includes('Save'))!;
+        await act(async () => { save.click(); });
+        await act(async () => { await Promise.resolve(); });
+
+        expect(container.textContent).toContain('Auth0 rejected the client secret.');
+    });
+
+    it('says there is nothing to type when the server has an attached identity', async () => {
+        getCloudIdentity.mockResolvedValue({
+            attached: true, provider: 'google', identity: 'pinpoint@town.iam.gserviceaccount.com',
+            skippable_keys: ['AUTH0_CLIENT_SECRET'],
+        });
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        expect(container.textContent).toContain('nothing to enter');
+        // The box is replaced, not merely annotated -- leaving it would invite
+        // someone to paste a long-lived key that the platform already replaces.
+        expect(inputs()).toHaveLength(2);
+    });
+
+    it('does not offer a provider this deployment has no catalog entry for', async () => {
+        await mount(<InlineProviderSetup cap="identity" provider="okta" />);
+        expect(inputs()).toHaveLength(0);
+        expect(container.textContent).toContain('does not offer that option');
+    });
+
+    it('falls back to the card rather than rendering an empty section', async () => {
+        getProviderCatalog.mockRejectedValue(new Error('offline'));
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+        expect(container.textContent).toContain('card further down the page');
+    });
+});

--- a/frontend/src/components/InlineProviderSetup.tsx
+++ b/frontend/src/components/InlineProviderSetup.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useState } from 'react';
+import { CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+
+import ProviderCredentialSteps from './ProviderCredentialSteps';
+import type { StepContext } from './setupSteps';
+import { api } from '../services/api';
+import type { Capability, CloudIdentity, ProviderCatalog, ProviderInfo } from '../services/api';
+
+/**
+ * A provider set up where it is described, rather than somewhere else.
+ *
+ * The setup guide used to end each section with "scroll to the Maps card
+ * below". That is a handoff, and it is the wrong shape for a document whose
+ * whole premise is that a clerk can follow it top to bottom: it sends them
+ * three thousand pixels away mid-instruction, to a card that then repeats the
+ * question they already answered in the questionnaire at the top.
+ *
+ * So the guide now does the work inline. The provider is not asked for again --
+ * it comes from the questionnaire, which is the point of having asked -- and
+ * the steps, the boxes and the Save & Test button are all here.
+ *
+ * The cards below are not redundant afterwards. They stay as the place to
+ * change a provider later, to see health, and to switch to something the
+ * questionnaire did not offer. The guide is the first run; the cards are the
+ * standing configuration. Both mount the same walk from the same file.
+ */
+/* One probe for the whole page.
+ *
+ * The guide mounts eight of these at once. The attached-identity answer is a
+ * property of the server, identical for all of them, so asking eight times is
+ * eight round trips to learn the same thing -- and on a deployment with no
+ * attached identity each one waits out the metadata timeout before failing.
+ * Memoised on the promise rather than the result so concurrent mounts share the
+ * single in-flight request instead of racing to start their own. */
+let identityProbe: Promise<CloudIdentity | null> | null = null;
+function probeIdentity(): Promise<CloudIdentity | null> {
+    identityProbe ??= api.getCloudIdentity().catch(() => null);
+    return identityProbe;
+}
+
+export default function InlineProviderSetup({
+    cap, provider, choices, onChoose, onSaved, note,
+}: {
+    cap: Capability;
+    /** The provider to set up, from the questionnaire. */
+    provider: string;
+    /** Providers this section may switch between inline, when the choice is not
+     *  one the questionnaire asks (email and SMS are not a cloud decision).
+     *  Omitted means the questionnaire already decided and this shows no picker. */
+    choices?: { id: string; label: string }[];
+    onChoose?: (id: string) => void;
+    /** Tell the page a save landed, so progress chips and "Done" badges move. */
+    onSaved?: () => void;
+    /** A sentence above the steps, where the choice needs explaining. */
+    note?: React.ReactNode;
+}) {
+    const [catalog, setCatalog] = useState<ProviderCatalog | null>(null);
+    const [identity, setIdentity] = useState<CloudIdentity | null>(null);
+    const [values, setValues] = useState<Record<string, string>>({});
+    const [busy, setBusy] = useState<'save' | null>(null);
+    const [result, setResult] = useState<{ ok: boolean; detail: string } | null>(null);
+    const [warnings, setWarnings] = useState<{ key: string; severity: string; message: string }[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [copied, setCopied] = useState<string | null>(null);
+
+    const ctx: StepContext = {
+        origin: window.location.origin,
+        copy: (text, id) => {
+            navigator.clipboard?.writeText(text).then(
+                () => { setCopied(id); setTimeout(() => setCopied(null), 1600); },
+                () => { /* clipboard blocked; the value is visible and selectable */ },
+            );
+        },
+        copied,
+    };
+
+    const load = useCallback(async () => {
+        try {
+            setCatalog(await api.getProviderCatalog(cap));
+        } catch (e: any) {
+            setError(e?.message || 'Could not load this provider.');
+        }
+    }, [cap]);
+
+    useEffect(() => { load(); }, [load]);
+
+    /* Best-effort. A failure here means the boxes render normally, which is the
+     * safe direction -- the worst case is being asked for a credential that
+     * would have turned out to be unnecessary, rather than being told to leave
+     * one blank when it was needed. */
+    useEffect(() => {
+        let alive = true;
+        probeIdentity().then(i => { if (alive) setIdentity(i); });
+        return () => { alive = false; };
+    }, []);
+
+    /* Switching provider clears what was typed. Carrying values across would
+     * mean a key entered for Azure sitting in a box the AWS save then posts. */
+    useEffect(() => { setValues({}); setResult(null); setWarnings([]); }, [provider]);
+
+    if (error) {
+        return (
+            <div className="ml-9 rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-200 flex items-start gap-2">
+                <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>{error} You can still set this up on the card further down the page.</span>
+            </div>
+        );
+    }
+    if (!catalog) {
+        return <div className="ml-9 h-20 rounded-lg bg-white/[0.03] animate-pulse" aria-busy="true" />;
+    }
+
+    const active: ProviderInfo | undefined = catalog.providers.find(p => p.provider === provider);
+    if (!active) {
+        return (
+            <div className="ml-9 rounded-lg border border-amber-400/25 bg-amber-500/[0.07] px-3 py-2 text-xs text-amber-100/80">
+                This deployment does not offer that option. Use the card further down the page to pick one it does.
+            </div>
+        );
+    }
+
+    const alreadySet = catalog.configured?.[provider] === true;
+    const isCurrent = catalog.current_provider === provider;
+
+    const save = async () => {
+        setBusy('save'); setResult(null); setError(null);
+        try {
+            const settings: Record<string, string> = {};
+            // Trim on save -- a stray space from a copy-paste is the commonest
+            // reason a correct key is rejected. Trimming here rather than in the
+            // input keeps mid-word typing intact.
+            active.credential_fields.forEach(f => {
+                const v = (values[f.key] || '').trim();
+                if (v) settings[f.key] = v;
+            });
+            const saved = await api.saveProvider(cap, { provider, settings });
+            setWarnings(saved.warnings || []);
+            setValues({});
+            await load();
+            // Save and verify are one action here. A guide that says "saved"
+            // and leaves a clerk to discover later that the key was wrong is
+            // the failure this whole page exists to avoid.
+            setResult(await api.testProvider(cap));
+            onSaved?.();
+        } catch (e: any) {
+            setResult({ ok: false, detail: e?.message || 'Save failed' });
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <div className="ml-9 rounded-xl border border-white/10 bg-white/[0.03] p-3.5">
+            {note && <p className="text-xs text-white/50 leading-relaxed mb-3">{note}</p>}
+
+            {choices && choices.length > 1 && (
+                <div className="flex flex-wrap gap-2 mb-3.5">
+                    {choices.map(c => (
+                        <button
+                            key={c.id}
+                            type="button"
+                            onClick={() => onChoose?.(c.id)}
+                            aria-pressed={provider === c.id}
+                            className={`px-3 py-1.5 rounded-lg text-xs border transition-colors ${provider === c.id
+                                ? 'bg-primary-500/20 border-primary-400/50 text-white'
+                                : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}
+                        >
+                            {c.label}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            <ProviderCredentialSteps
+                cap={cap}
+                provider={provider}
+                active={active}
+                values={values}
+                onChange={(key, value) => setValues(prev => ({ ...prev, [key]: value }))}
+                ctx={ctx}
+                identity={identity}
+                alreadySet={alreadySet && isCurrent}
+                compact
+            />
+
+            <div className="flex flex-wrap items-center gap-2.5 mt-3 pt-3 border-t border-white/[0.07]">
+                <button
+                    type="button"
+                    onClick={save}
+                    disabled={busy !== null}
+                    className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                >
+                    {busy === 'save' ? <><Loader2 className="w-3.5 h-3.5 animate-spin" /> Saving…</> : <>Save &amp; Test</>}
+                </button>
+                {alreadySet && isCurrent && !result && (
+                    <span className="text-[11px] text-emerald-300/80 inline-flex items-center gap-1.5">
+                        <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                        Already saved — leave a box blank to keep what is stored.
+                    </span>
+                )}
+            </div>
+
+            {result && (
+                <div className={`mt-2.5 rounded-lg px-3 py-2 text-xs flex items-start gap-2 ${result.ok
+                    ? 'bg-emerald-500/10 border border-emerald-400/25 text-emerald-100/90'
+                    : 'bg-red-500/10 border border-red-400/25 text-red-100/90'}`}>
+                    {result.ok
+                        ? <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                        : <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />}
+                    <span>{result.detail}</span>
+                </div>
+            )}
+
+            {/* Shown even though the save succeeded: these are "that value does
+                not look like what this box wants", most often the right
+                credential in the wrong field, which a connection test does not
+                reliably tell apart from a wrong key. */}
+            {warnings.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                    {warnings.map(w => (
+                        <li key={w.key} className="text-[11px] text-amber-200/80 flex items-start gap-1.5">
+                            <AlertCircle className="w-3 h-3 mt-0.5 shrink-0" aria-hidden="true" />
+                            <span>{w.message}</span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/ProviderCredentialSteps.tsx
+++ b/frontend/src/components/ProviderCredentialSteps.tsx
@@ -1,0 +1,146 @@
+import { CheckCircle, AlertCircle, ShieldCheck } from 'lucide-react';
+
+import SecretField from './SecretField';
+import { claimedFields, stepsFor } from './setupSteps';
+import type { StepContext } from './setupSteps';
+import type { Capability, CloudIdentity, ProviderInfo } from '../services/api';
+
+/**
+ * The console walk and the boxes it fills, as one thing.
+ *
+ * This is the only place that renders a provider's setup steps, and it exists
+ * because there were nearly two. The provider cards grew the "step owns its
+ * fields" layout first; the setup guide at the top of the page was then left
+ * pointing at them -- "scroll down to the Maps card" -- which is not what a
+ * guide is for. Someone following it had to leave it to do the thing it was
+ * describing, and come back to find their place.
+ *
+ * Putting the walk in both places is right. Writing it twice is not: the last
+ * time this page carried two copies they drifted, and the guide spent months
+ * telling towns to invent a backup passphrase that no longer existed. So the
+ * content stays in setupStepsContent.tsx, the layout stays here, and both the
+ * card and the guide mount this.
+ *
+ * Deliberately dumb. It owns no catalog, no save, no request -- the caller
+ * holds the values and decides what a save means, because the card saves one
+ * capability at a time from a picker while the guide saves the provider the
+ * town already chose in the questionnaire.
+ */
+export default function ProviderCredentialSteps({
+    cap, provider, active, values, onChange, ctx, identity, alreadySet = false, compact = false,
+}: {
+    cap: Capability;
+    /** Which provider's walk to render. Not read off the catalog: the guide
+     *  pins this to the questionnaire answer, the card to its picker. */
+    provider: string;
+    active: ProviderInfo;
+    values: Record<string, string>;
+    onChange: (key: string, value: string) => void;
+    ctx: StepContext;
+    /** Attached cloud identity, if any -- turns credential boxes it replaces
+     *  into "nothing to enter" rather than leaving them looking unfinished. */
+    identity?: CloudIdentity | null;
+    /** Credentials for this provider are already stored, so an empty box means
+     *  "keep what is there" rather than "not done yet". */
+    alreadySet?: boolean;
+    /** Tighter spacing for the guide, which nests this inside a step list. */
+    compact?: boolean;
+}) {
+    const field = (key: string) => {
+        const f = active.credential_fields.find(x => x.key === key);
+        if (!f) return null;  // the catalog changed under the steps
+
+        /* This server already has an identity on the cloud, so this box needs
+         * no value -- and empty is the better answer, not merely a permitted
+         * one: the platform issues a token minutes at a time and rotates it, so
+         * no long-lived secret exists to be mis-copied, vaulted, or left to
+         * expire. Two of the three clouds already behaved this way and nothing
+         * said so, so towns pasted keys into boxes that did not need them. */
+        if (identity?.skippable_keys?.includes(f.key)) {
+            return (
+                <div key={f.key} className="rounded-xl border border-emerald-400/25 bg-emerald-500/[0.07] px-3 py-2.5">
+                    <div className="flex items-start gap-2">
+                        <ShieldCheck className="w-3.5 h-3.5 text-emerald-300 mt-0.5 shrink-0" aria-hidden="true" />
+                        <div>
+                            <p className="text-xs text-emerald-100/90">
+                                <span className="font-semibold">{f.label}</span> — nothing to enter.
+                            </p>
+                            <p className="text-[11px] text-white/45 mt-0.5">
+                                This server already has an identity on{' '}
+                                {CLOUD_LABEL[identity.provider ?? ''] ?? 'your cloud'}
+                                {identity.identity ? <> (<code className="bg-black/30 px-1 rounded">{identity.identity}</code>)</> : null}.
+                                It signs in with that, so there is no key to create, copy, or renew.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+        return (
+            <SecretField
+                key={f.key}
+                label={f.label}
+                secret={f.secret}
+                value={values[f.key] || ''}
+                onChange={(v) => onChange(f.key, v)}
+                placeholder={`Enter ${f.label.toLowerCase()}`}
+                help={active.field_help?.[f.key]}
+                savedHint={alreadySet}
+            />
+        );
+    };
+
+    const steps = stepsFor(cap, provider, ctx);
+    const claimed = claimedFields(steps);
+    const leftover = active.credential_fields.filter(f => !claimed.has(f.key));
+
+    return (
+        <div>
+            {steps.map((st, i) => (
+                <div key={i} className={compact ? 'mb-3' : 'mb-4'}>
+                    <div className="flex gap-3">
+                        <span className="mt-0.5 w-6 h-6 shrink-0 rounded-full bg-white/10 border border-white/15 text-[11px] font-semibold text-white/70 flex items-center justify-center">
+                            {i + 1}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                            <div className="text-sm text-white/75 leading-relaxed">{st.body}</div>
+                            {st.check && (
+                                <p className="mt-1.5 text-xs text-emerald-300/75 flex items-start gap-1.5">
+                                    <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                                    <span><span className="font-medium">You should see:</span> {st.check}</span>
+                                </p>
+                            )}
+                            {st.trouble && (
+                                <p className="mt-1.5 text-xs text-amber-200/75 flex items-start gap-1.5">
+                                    <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                                    <span>{st.trouble}</span>
+                                </p>
+                            )}
+                            {!!st.fields?.length && (
+                                <div className="mt-2.5 grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                                    {st.fields.map(field)}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            ))}
+
+            {/* A field no step claims still renders, at the end. Adding a
+                credential to a catalog can never make it silently unreachable. */}
+            {leftover.length > 0 && (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                    {leftover.map(f => field(f.key))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+/** Cloud names for the "nothing to enter" note. */
+const CLOUD_LABEL: Record<string, string> = {
+    google: 'Google Cloud',
+    azure: 'Azure',
+    aws: 'AWS',
+};

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react';
-import { claimedFields, stepsFor } from './setupSteps';
+import { stepsFor } from './setupSteps';
 // Registers every provider's steps as a side effect of importing it.
 import './setupStepsContent';
 import type { StepContext } from './setupSteps';
+import ProviderCredentialSteps from './ProviderCredentialSteps';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -13,7 +14,6 @@ import {
 } from 'lucide-react';
 
 import { CollapsibleSection } from './ui';
-import SecretField from './SecretField';
 import { api, ProviderCatalog, ProviderInfo, ProviderModelSpec, CloudProfileState, CloudIdentity } from '../services/api';
 import type { ConnectorHealth } from '../types';
 
@@ -126,14 +126,6 @@ export interface CapStatus {
      *  the endpoint did not say, which is not the same as no. */
     configured?: boolean;
 }
-
-/** Cloud names for a heading, kept out of the render so the three places that
- *  need them cannot drift apart. */
-const CLOUD_LABEL: Record<string, string> = {
-    google: 'Google Cloud',
-    azure: 'Azure',
-    aws: 'AWS',
-};
 
 function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, reloadToken, onStatus, health, step, guided, identity }: {
     cap: Capability; title: string; blurb: string; icon: typeof Sparkles; delay: number;
@@ -614,101 +606,32 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                 {/* Credential/config fields */}
                 {active && (active?.credential_fields || []).length > 0 && (() => {
                     const alreadySet = !!(catalog.configured?.[selected] && selected === catalog.current_provider);
-                    const field = (key: string) => {
-                        const f = active.credential_fields.find(x => x.key === key);
-                        if (!f) return null;  // catalog changed under the steps
-
-                        /* This server already has an identity on the cloud, so
-                         * this particular box needs no value -- and empty is the
-                         * better answer, not merely a permitted one: the
-                         * platform issues a token minutes at a time and rotates
-                         * it, so no long-lived secret exists to be mis-copied,
-                         * vaulted, or left to expire.
-                         *
-                         * It has to say so. Two of the three clouds already
-                         * behaved this way and nothing mentioned it, so every
-                         * town pasted a key into a box that did not need one. */
-                        if (identity?.skippable_keys?.includes(f.key)) {
-                            return (
-                                <div key={f.key} className="mb-3 rounded-xl border border-emerald-400/25 bg-emerald-500/[0.07] px-3 py-2.5">
-                                    <div className="flex items-start gap-2">
-                                        <ShieldCheck className="w-3.5 h-3.5 text-emerald-300 mt-0.5 shrink-0" />
-                                        <div>
-                                            <p className="text-xs text-emerald-100/90">
-                                                <span className="font-semibold">{f.label}</span> — nothing to enter.
-                                            </p>
-                                            <p className="text-[11px] text-white/45 mt-0.5">
-                                                This server already has an identity on {CLOUD_LABEL[identity.provider ?? ''] ?? 'your cloud'}
-                                                {identity.identity ? <> (<code className="bg-black/30 px-1 rounded">{identity.identity}</code>)</> : null}.
-                                                It signs in with that, so there is no key to create, copy, or renew.
-                                            </p>
-                                        </div>
-                                    </div>
-                                </div>
-                            );
-                        }
-
-                        return (
-                            <SecretField
-                                key={f.key}
-                                label={f.label}
-                                secret={f.secret}
-                                value={values[f.key] || ''}
-                                onChange={(v) => setValues(p => ({ ...p, [f.key]: v }))}
-                                placeholder={`Enter ${f.label.toLowerCase()}`}
-                                help={active.field_help?.[f.key]}
-                                savedHint={alreadySet}
-                            />
-                        );
-                    };
 
                     /* Steps own the boxes they produce, so each instruction is
                      * followed immediately by the inputs it just told you how to
                      * obtain. A provider with no steps written yet falls back to
-                     * the plain list, which is what every provider had before. */
-                    const steps = stepsFor(cap, selected, stepCtx);
-                    const claimed = claimedFields(steps);
-                    const leftover = active.credential_fields.filter(f => !claimed.has(f.key));
+                     * the plain list, which is what every provider had before.
+                     *
+                     * The layout lives in ProviderCredentialSteps because the
+                     * setup guide renders the same walk inline. One component,
+                     * one content file, two mount points -- the alternative was
+                     * two hand-written copies, which is what this page had
+                     * before and which drifted. */
+                    const hasSteps = stepsFor(cap, selected, stepCtx).length > 0;
 
                     return (
                         <div>
-                            <Step n={cap === 'ai' ? 3 : 2}>{steps.length ? 'Set it up' : 'Credentials'}</Step>
-
-                            {steps.map((st, i) => (
-                                <div key={i} className="mb-4">
-                                    <div className="flex gap-3">
-                                        <span className="mt-0.5 w-6 h-6 shrink-0 rounded-full bg-white/10 border border-white/15 text-[11px] font-semibold text-white/70 flex items-center justify-center">
-                                            {i + 1}
-                                        </span>
-                                        <div className="min-w-0 flex-1">
-                                            <div className="text-sm text-white/75 leading-relaxed">{st.body}</div>
-                                            {st.check && (
-                                                <p className="mt-1.5 text-xs text-emerald-300/75 flex items-start gap-1.5">
-                                                    <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
-                                                    <span><span className="font-medium">You should see:</span> {st.check}</span>
-                                                </p>
-                                            )}
-                                            {st.trouble && (
-                                                <p className="mt-1.5 text-xs text-amber-200/75 flex items-start gap-1.5">
-                                                    <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
-                                                    <span>{st.trouble}</span>
-                                                </p>
-                                            )}
-                                            {!!st.fields?.length && (
-                                                <div className="mt-2.5 grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
-                                                    {st.fields.map(field)}
-                                                </div>
-                                            )}
-                                        </div>
-                                    </div>
-                                </div>
-                            ))}
-
-                            {leftover.length > 0 && (
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
-                                    {leftover.map(f => field(f.key))}
-                                </div>
-                            )}
+                            <Step n={cap === 'ai' ? 3 : 2}>{hasSteps ? 'Set it up' : 'Credentials'}</Step>
+                            <ProviderCredentialSteps
+                                cap={cap}
+                                provider={selected}
+                                active={active}
+                                values={values}
+                                onChange={(key, value) => setValues(p => ({ ...p, [key]: value }))}
+                                ctx={stepCtx}
+                                identity={identity}
+                                alreadySet={alreadySet}
+                            />
                         </div>
                     );
                 })()}

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -16,6 +16,11 @@ import { api } from '../services/api';
 import type { Capability } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
+import InlineProviderSetup from './InlineProviderSetup';
+import SecretField from './SecretField';
+// Registers every provider's setup steps as a side effect, so the guide can
+// render them inline rather than pointing at the cards that do.
+import './setupStepsContent';
 import StorageStatusLine from './StorageStatusLine';
 import { openStayInformed } from './StayInformed';
 
@@ -70,7 +75,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * up with the whole platform switched on, not the three we happened to
      * pre-tick -- so the list below is every feature, and a town removes what
      * it genuinely does not want. */
-    const ALL_FEATURES = ['ai', 'translation', 'moderation', 'email', 'sms', 'secrets', 'govtech', 'backups'];
+    const ALL_FEATURES = ['ai', 'translation', 'moderation', 'redaction', 'email', 'sms', 'secrets', 'govtech', 'backups', 'errors'];
     const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(new Set(ALL_FEATURES));
     const toggleFeature = (f: string) =>
         setWantedFeatures(prev => {
@@ -80,16 +85,50 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         });
     const wants = (f: string) => wantedFeatures.has(f);
 
+    /* The questionnaire's answers, translated into the provider ids the
+     * catalogs actually use.
+     *
+     * The point of asking "which cloud hosts your town's services" at the top
+     * is that nothing below should ask again. So AI, translation and key
+     * management take their provider from that answer rather than showing a
+     * second picker -- the guide sets up Vertex on Google, Azure OpenAI on
+     * Azure, Bedrock on AWS, without a further decision.
+     *
+     * Email, SMS and photo redaction are different: they are genuinely not a
+     * cloud decision. A town on Google may well send mail through SES, and
+     * redaction on this server is a reasonable choice on any cloud. Those keep
+     * a picker, seeded from the cloud answer so the common case is already
+     * right and only a town that wants something else has to touch it. */
+    const AI_BY_CLOUD = { google: 'vertex', azure: 'azure', aws: 'bedrock' } as const;
+    const EMAIL_BY_CLOUD = { google: 'smtp', azure: 'acs', aws: 'ses' } as const;
+    const SMS_BY_CLOUD = { google: 'twilio', azure: 'acs', aws: 'sns' } as const;
+
+    /* null means "still following the cloud answer". Holding the override
+     * rather than the value is what lets changing the cloud at the top move
+     * these along with it, while a deliberate pick here stays put. */
+    const [emailOverride, setEmailOverride] = useState<string | null>(null);
+    const [smsOverride, setSmsOverride] = useState<string | null>(null);
+    const [redactionOverride, setRedactionOverride] = useState<string | null>(null);
+
+    const aiProvider = AI_BY_CLOUD[setupCloud];
+    const emailProvider = emailOverride ?? EMAIL_BY_CLOUD[setupCloud];
+    const smsProvider = smsOverride ?? SMS_BY_CLOUD[setupCloud];
+    const redactionProvider = redactionOverride ?? setupCloud;
+
     /* The setup questions are asked in feature terms ("AI triage", "Secret
      * storage + PII encryption") and the provider cards are keyed by
      * capability. This is the one mapping between them. `secrets` covers the
      * KMS card because the same question is what a town answers about where
-     * keys and resident data are protected, and `moderation` covers photo
-     * redaction for the same reason -- both are about screening what gets
-     * stored. */
+     * keys and resident data are protected.
+     *
+     * Redaction used to hang off the `moderation` tick, which was wrong in both
+     * directions: unticking "content moderation" silently hid face blurring,
+     * and there was no way to have blurring without it. They are different
+     * decisions -- one screens what a resident wrote, the other blurs a
+     * bystander who never wrote anything -- so they are now separate ticks. */
     const FEATURE_TO_CAPABILITY: Record<string, Capability> = {
         ai: 'ai', translation: 'translation', email: 'email',
-        sms: 'sms', secrets: 'kms', moderation: 'redaction',
+        sms: 'sms', secrets: 'kms', redaction: 'redaction',
     };
     const wantedCapabilities = new Set<Capability>(
         Object.entries(FEATURE_TO_CAPABILITY)
@@ -230,36 +269,65 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         </div>
     );
 
-    /* Hands off to the card that owns a credential.
+    /* Boxes for settings that belong to no provider card.
      *
-     * This guide used to carry its own copy of every vendor's console walk --
-     * Auth0, Entra, Okta, Esri, Apple, all of them -- written before the cards
-     * could hold steps of their own. Now that they can, and the boxes sit
-     * directly beneath the step that produces them, keeping a second copy up
-     * here was worse than having none: the two drifted. The guide told people
-     * Okta's issuer was their org URL while the card told them it was not, and
-     * it still asked towns to invent a backup passphrase months after that
-     * field was replaced by a generated one.
+     * Most of this page's credentials hang off a capability with a catalog, so
+     * InlineSetup covers them. A few do not -- Azure's Content Safety pair, the
+     * Sentry DSN -- and those were being printed as bare environment-variable
+     * names in the middle of a sentence, which is not an instruction a clerk
+     * can act on. It reads as something to hand to IT, and it is the only place
+     * on the page that asks somebody to go and edit a file.
      *
-     * So the guide keeps what only it has -- the decisions, the cloud
-     * foundation that belongs to no single card, and the steps with no
-     * credential attached -- and defers the console walk to one place. */
-    const SeeCard = ({ children }: { children: React.ReactNode }) => (
-        <div className="ml-9 rounded-lg bg-white/[0.04] border border-white/10 px-3 py-2 flex items-start gap-2">
-            <ListChecks className="w-3.5 h-3.5 text-white/40 mt-0.5 shrink-0" aria-hidden="true" />
-            <p className="text-xs text-white/55 leading-relaxed">{children}</p>
-        </div>
-    );
+     * They are ordinary settings with ordinary boxes, so they get ordinary
+     * boxes, saved the same way as everything else here. */
+    const PlainSecrets = ({ fields }: {
+        fields: { key: string; label: string; secret?: boolean; help?: string }[];
+    }) => {
+        const pending = fields.filter(f => secretValues[f.key]);
+        return (
+            <div className="ml-9 rounded-xl border border-white/10 bg-white/[0.03] p-3.5">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                    {fields.map(f => (
+                        <SecretField
+                            key={f.key}
+                            label={f.label}
+                            secret={f.secret}
+                            help={f.help}
+                            savedHint={!!isConfigured(f.key)}
+                            value={secretValues[f.key] || ''}
+                            onChange={(v) => setSecretValues(prev => ({ ...prev, [f.key]: v }))}
+                        />
+                    ))}
+                </div>
+                <div className="flex flex-wrap items-center gap-2.5 mt-3 pt-3 border-t border-white/[0.07]">
+                    <button
+                        type="button"
+                        onClick={async () => { for (const f of pending) await handleSave(f.key); }}
+                        disabled={pending.length === 0 || savingKey !== null}
+                        className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                    >
+                        {savingKey ? 'Saving…' : 'Save'}
+                    </button>
+                    {fields.every(f => isConfigured(f.key)) && (
+                        <span className="text-[11px] text-emerald-300/80 inline-flex items-center gap-1.5">
+                            <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                            Already saved — leave a box blank to keep what is stored.
+                        </span>
+                    )}
+                </div>
+            </div>
+        );
+    };
 
-    /** The step-by-step for whichever provider you pick lives on the card, with
-     *  the boxes it fills. One sentence, worded the same way each time. */
-    const OnTheCard = ({ card }: { card: string }) => (
-        <SeeCard>
-            Scroll to the <strong className="text-white/80">{card}</strong> card below and choose your
-            provider. The steps for that provider appear there, each one directly above the boxes it
-            fills in — so you are never scrolling between an instruction and the field it describes.
-        </SeeCard>
-    );
+    /* Sections that need a credential mount InlineProviderSetup directly --
+     * not through a wrapper defined in here. A component declared during render
+     * is a fresh type on every render, so React unmounts and remounts it, and
+     * everything typed into it is gone. Ticking any chip in the questionnaire
+     * re-renders this component, which would have made that a routine way to
+     * lose a half-entered client secret.
+     *
+     * Why the guide sets providers up at all, rather than pointing at the cards
+     * below, is written where it applies: InlineProviderSetup.tsx. */
 
     /* "If it goes wrong" for a step, called out rather than buried in prose.
      *
@@ -516,9 +584,11 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <div className="flex flex-wrap gap-2 mt-1.5">
                                         {([
                                             ['ai', 'AI triage'], ['translation', 'Translation'],
-                                            ['moderation', 'Content moderation'], ['email', 'Email'],
-                                            ['sms', 'Text / SMS'], ['secrets', 'Secret storage + PII encryption'],
+                                            ['moderation', 'Content moderation'], ['redaction', 'Blur faces & plates'],
+                                            ['email', 'Email'], ['sms', 'Text / SMS'],
+                                            ['secrets', 'Secret storage + PII encryption'],
                                             ['govtech', 'Town-system connector'], ['backups', 'Database backups'],
+                                            ['errors', 'Crash reporting'],
                                         ] as const).map(([f, label]) => (
                                             <button key={f} type="button" onClick={() => toggleFeature(f)}
                                                 className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${wants(f) ? 'bg-emerald-500/15 border-emerald-400/40 text-emerald-100' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
@@ -536,8 +606,8 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <InstructionStep num={1}>
                                         <strong className="text-white/90">Check whether you already have this.</strong> If your staff sign in to Microsoft 365, you already run <strong className="text-white/90">Microsoft Entra ID</strong> and should pick that above — no new account, no new password for anyone, and your IT provider can do it in ten minutes. The same is true if the town uses Okta. Auth0 is the answer when there is nothing already in place.
                                     </InstructionStep>
-                                    <InstructionStep num={2}>Register Pinpoint with {setupIdp === 'auth0' ? 'Auth0' : setupIdp === 'entra' ? 'Entra' : setupIdp === 'okta' ? 'Okta' : 'your provider'} and collect its credentials.</InstructionStep>
-                                    <OnTheCard card="Staff Sign-In" />
+                                    <InstructionStep num={2}>Register Pinpoint with {setupIdp === 'auth0' ? 'Auth0' : setupIdp === 'entra' ? 'Microsoft Entra ID' : setupIdp === 'okta' ? 'Okta' : 'your provider'} and collect its credentials. Do it here — the boxes are below each step.</InstructionStep>
+                                    <InlineProviderSetup onSaved={onRefresh} cap="identity" provider={setupIdp} />
                                     <InstructionStep num={3}
                                         check={<>"Always" selected under the policy setting, and at least one factor switched on.</>}
                                     >Require a second step at login. This is the single most valuable thing on this page: it means a stolen or guessed staff password is not enough on its own to reach resident records. Every provider here can do it — in Auth0 it is <strong className="text-white/90">Security → Multi-factor Auth</strong>, in Entra it is a Conditional Access policy, in Okta it is a sign-on policy. Turn on an authenticator app or passkeys, and set the policy to apply always. Warn staff first: the next time they sign in they will be asked to set it up.</InstructionStep>
@@ -586,7 +656,9 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     time="About 15 minutes once your cloud account exists"
                                     cost="Cents per hundred reports on any of the three providers.">
                                     <InstructionStep num={1}>Enable the model service in the cloud account you set up above, and give Pinpoint permission to call it — nothing more than that. A leaked key scoped to "ask the model a question" can run up a bill; the same key with a broad role can delete the project.</InstructionStep>
-                                    <OnTheCard card="AI Provider" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="ai" provider={aiProvider}
+                                        note={<>Set up for <strong className="text-white/70">{{ vertex: 'Google Vertex AI', azure: 'Azure OpenAI', bedrock: 'AWS Bedrock' }[aiProvider]}</strong>, because that is the cloud you picked above. To use a different one, change the cloud at the top or use the AI Provider card further down.</>}
+                                    />
                                     <Trouble>Model availability differs by region on every provider, and on AWS the models have to be requested before they can be used. If the picker is empty, that is usually why rather than a bad key.</Trouble>
                                 </Guide>
 
@@ -595,8 +667,8 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     what={<>Lets a resident file a report in their own language and read the replies in it, and lets staff work entirely in English. For many towns this is a Title VI obligation rather than a nicety.</>}
                                     time="About 10 minutes"
                                     cost="Free for a small town's volume on all three providers.">
-                                    <InstructionStep num={1}>Enable the translation service in the cloud account you set up above. On Google it is an API to switch on; on Azure a Translator resource; on AWS nothing at all, it is on by default.</InstructionStep>
-                                    <OnTheCard card="Translation" />
+                                    <InstructionStep num={1}>Enable the translation service in the cloud account you set up above. {setupCloud === 'google' ? 'On Google it is an API to switch on.' : setupCloud === 'azure' ? 'On Azure it is a Translator resource to create.' : 'On AWS there is nothing to enable — it is on by default.'}</InstructionStep>
+                                    <InlineProviderSetup onSaved={onRefresh} cap="translation" provider={setupCloud} />
                                 </Guide>
 
                                 {/* ── Secrets + PII encryption ── */}
@@ -606,7 +678,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     cost="Under a dollar a month.">
                                     <InstructionStep num={1}>Create the key and the vault in the cloud account you set up above, and grant Pinpoint permission to <strong className="text-white/90">wrap and unwrap</strong> with that key — not just to read it.</InstructionStep>
                                     <Trouble>Wrap and unwrap are the two permissions people miss, and missing them fails quietly: the key exists, the settings save, and resident data is encrypted with the application key instead. The health dashboard is the only place that says so — it will tell you the key manager you selected is not the one being used.</Trouble>
-                                    <OnTheCard card="Resident Data Encryption" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="kms" provider={setupCloud} />
                                     <InstructionStep num={2}>Once the vault is reachable, credentials already in the database move across on their own, within the hour. There is no button to press and nothing to remember.</InstructionStep>
                                     <Trouble>Never delete or disable this key once resident data has been written under it. Every cloud enforces a waiting period and then destroys it permanently, and nobody — including the cloud provider — can recover what it protected.</Trouble>
                                 </Guide>
@@ -617,7 +689,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     time="About 15 minutes, longer if DNS records are involved"
                                     cost="Free to a few dollars a month.">
                                     <InstructionStep num={1}>Decide who sends. A dedicated town address like <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">311@yourtown.gov</code> rather than <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">noreply@</code> — residents reply to these, and a reply that goes nowhere is a complaint you never hear.</InstructionStep>
-                                    <OnTheCard card="Email" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="email" provider={emailProvider}
+                                        onChoose={setEmailOverride}
+                                        choices={[
+                                            { id: 'smtp', label: 'SMTP (your existing mail server)' },
+                                            { id: 'ses', label: 'Amazon SES' },
+                                            { id: 'acs', label: 'Azure Communication Services' },
+                                        ]}
+                                        note={<>How mail leaves the building is not a cloud decision — plenty of towns on Google send through SES. Starting on the one that suits {cloudLabel}; change it here if yours differs.</>}
+                                    />
                                     <Trouble>Microsoft 365 and Google Workspace both block plain SMTP by default. If your IT provider says it is not allowed, they are right — Amazon SES or Azure Communication Services will be less work than getting an exception.</Trouble>
                                 </Guide>
 
@@ -629,7 +709,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <InstructionStep num={1}>
                                         <strong className="text-white/90">Start the carrier registration first, whichever provider you use.</strong> Texting US numbers from a business or government sender needs 10DLC registration, which identifies your town to the carriers. It is not a technical step and it is not quick — allow a couple of weeks. Unregistered messages are filtered heavily and often silently.
                                     </InstructionStep>
-                                    <OnTheCard card="Text Messages" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="sms" provider={smsProvider}
+                                        onChoose={setSmsOverride}
+                                        choices={[
+                                            { id: 'twilio', label: 'Twilio' },
+                                            { id: 'sns', label: 'Amazon SNS' },
+                                            { id: 'acs', label: 'Azure Communication Services' },
+                                            { id: 'http', label: 'Other (HTTP gateway)' },
+                                        ]}
+                                    />
                                     <Trouble>Every provider starts you in a trial or sandbox that can only text numbers you have verified. Everything looks like it works — the send succeeds — and residents receive nothing. Leave it before launch.</Trouble>
                                 </Guide>
 
@@ -638,11 +726,27 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     what={<>Anything a resident submits can end up on a public municipal website. Offensive language is always screened, with or without this; turning it on adds checking of photos too, and catches abuse a word list misses.</>}
                                     time="About 10 minutes once your cloud account exists"
                                     cost="Fractions of a cent per report.">
-                                    <InstructionStep num={1}><strong className="text-white/90">Built in, no setup:</strong> resident text is always screened — explicit/abusive descriptions and comments are blocked at submission; mild profanity posts but is flagged for staff.</InstructionStep>
-                                    {setupCloud === 'google' && <InstructionStep num={2}><strong className="text-white/90">Cloud layer (optional):</strong> enable the <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">Vision</code> + <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">Natural Language</code> APIs. No extra keys — it uses your service account for image (SafeSearch) + text moderation.</InstructionStep>}
-                                    {setupCloud === 'azure' && <InstructionStep num={2}><strong className="text-white/90">Cloud layer (optional):</strong> create an <strong className="text-white/90">Azure AI Content Safety</strong> resource and set <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">AZURE_CONTENT_SAFETY_ENDPOINT</code> + <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">AZURE_CONTENT_SAFETY_KEY</code> for text + image screening.</InstructionStep>}
-                                    {setupCloud === 'aws' && <InstructionStep num={2}><strong className="text-white/90">Cloud layer (optional):</strong> allow <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">rekognition:DetectModerationLabels</code> (image) + <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">comprehend:DetectToxicContent</code> (text) on your AWS credentials.</InstructionStep>}
-                                    <InstructionStep num={3}>Set <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">MODERATION_PROVIDER</code> to your cloud, or leave it to follow your AI cloud automatically. If the cloud layer is off, text still uses the built-in scan and images use the AI vision assessment.</InstructionStep>
+                                    <InstructionStep num={1}><strong className="text-white/90">Built in, no setup:</strong> resident text is always screened — explicit/abusive descriptions and comments are blocked at submission; mild profanity posts but is flagged for staff. This works with nothing configured and is not something you can switch off by accident.</InstructionStep>
+                                    {setupCloud === 'google' && (
+                                        <InstructionStep num={2} check={<>both APIs showing as Enabled in the API library.</>}>
+                                            <strong className="text-white/90">Add photo screening.</strong> In the Google project you created above, enable the <strong className="text-white/90">Cloud Vision</strong> and <strong className="text-white/90">Cloud Natural Language</strong> APIs. There is nothing to enter here — screening reuses the service account you already downloaded.
+                                        </InstructionStep>
+                                    )}
+                                    {setupCloud === 'azure' && <>
+                                        <InstructionStep num={2} check={<>an <strong className="text-white/90">Endpoint</strong> and two keys on the resource's Keys and Endpoint page.</>}>
+                                            <strong className="text-white/90">Add photo screening.</strong> In the Azure Portal, create an <strong className="text-white/90">Azure AI Content Safety</strong> resource in <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">pinpoint311-rg</code>. Open it, go to <strong className="text-white/90">Keys and Endpoint</strong>, and copy the endpoint and either key into the boxes below.
+                                        </InstructionStep>
+                                        <PlainSecrets fields={[
+                                            { key: 'AZURE_CONTENT_SAFETY_ENDPOINT', label: 'Content Safety endpoint', help: 'Looks like https://your-resource.cognitiveservices.azure.com/' },
+                                            { key: 'AZURE_CONTENT_SAFETY_KEY', label: 'Content Safety key', secret: true, help: 'Either KEY 1 or KEY 2 — they are interchangeable.' },
+                                        ]} />
+                                    </>}
+                                    {setupCloud === 'aws' && (
+                                        <InstructionStep num={2}>
+                                            <strong className="text-white/90">Add photo screening.</strong> On the IAM identity you created above, allow <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">rekognition:DetectModerationLabels</code> for images and <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">comprehend:DetectToxicContent</code> for text. Nothing to enter here — it reuses the AWS credentials you already have.
+                                        </InstructionStep>
+                                    )}
+                                    <InstructionStep num={3}>Leave the rest alone. Screening follows the cloud you picked at the top of this page automatically. If the cloud layer is not reachable, text still uses the built-in scan and photos fall back to the AI provider's own assessment, so nothing goes unchecked.</InstructionStep>
                                 </Guide>
 
                                 {/* ── Maps (always) ── */}
@@ -653,7 +757,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <InstructionStep num={1}>
                                         <strong className="text-white/90">Ask your GIS department before you buy anything.</strong> If the town or county has an ArcGIS agreement — many New Jersey towns do — choose Esri above. You get the map free under that licence, and more importantly you can point address lookup at the county's own locator, which knows your street names, your address ranges and your recent subdivisions. A national geocoder does not.
                                     </InstructionStep>
-                                    <OnTheCard card="Maps Provider" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="maps" provider={setupMaps} />
                                     <InstructionStep num={2}
                                         check={<>the address box offering suggestions as you type, and a pin appearing when you click the map.</>}
                                     >Test it as a resident would. Open the resident portal in another tab and file a test report — the map failing is the one thing on this page a resident notices immediately.</InstructionStep>
@@ -671,22 +775,34 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
 
                                 {/* ── Database backups ── */}
                                 {/* ── Photo redaction ── */}
-                                <Guide show={wants('moderation')} tone="rose" icon={ImageIcon} title="Blurring faces and licence plates" done={redactionConfigured}
+                                <Guide show={wants('redaction')} tone="rose" icon={ImageIcon} title="Blurring faces and licence plates" done={redactionConfigured}
                                     what={<>Residents photograph potholes with cars parked beside them and neighbours walking past. Those people did not ask to be in a public record, and a 311 photo is one. This blurs faces and plates before the photo is stored.</>}
                                     time="About 10 minutes"
                                     cost="A dollar or two per thousand photos, or free if you run it on this server.">
                                     <InstructionStep num={1}>Choose where detection happens. All three clouds do it well; the option that runs on this server finds fewer faces — particularly small or partly turned ones — but no photo ever leaves the building, which for some towns settles it.</InstructionStep>
-                                    <OnTheCard card="Photo Redaction" />
+                                    <InlineProviderSetup onSaved={onRefresh} cap="redaction" provider={redactionProvider}
+                                        onChoose={setRedactionOverride}
+                                        choices={[
+                                            { id: 'local', label: 'On this server (no account, no cost)' },
+                                            { id: 'google', label: 'Google Cloud Vision' },
+                                            { id: 'azure', label: 'Azure Face + Vision' },
+                                            { id: 'aws', label: 'AWS Rekognition' },
+                                        ]}
+                                        note={<>A fresh install already blurs on this server, so photos are never stored unblurred while you decide. Pointing it at a cloud finds more.</>}
+                                    />
+                                    <Trouble>This is the one setting whose failure is invisible from inside Pinpoint: "found nobody in this photo" and "could not ask" both produce an unblurred picture and a green tick. After saving, file a test report with a photo of a face in it and look at the stored image.</Trouble>
                                 </Guide>
 
                                 {/* ── Error reporting ── */}
-                                <Guide tone="violet" icon={AlertTriangle} title="Knowing when something breaks" done={sentryConfigured}
+                                <Guide show={wants('errors')} tone="violet" icon={AlertTriangle} title="Knowing when something breaks" done={sentryConfigured}
                                     what={<>Without this, a page that crashes for a resident is something you hear about only if they phone. Browser crashes are already collected and shown under Browser errors in the admin console; this sends them somewhere off the server as well, so they survive a container restart.</>}
                                     time="About 5 minutes"
                                     cost="Sentry's free tier covers a town's volume comfortably.">
-                                    <InstructionStep num={1} check={<>a DSN that looks like <code className="bg-black/30 px-1 rounded">https://…@…ingest.sentry.io/…</code></>}>Create a free account at <a href="https://sentry.io" target="_blank" rel="noopener noreferrer" className="text-violet-300 underline underline-offset-2">sentry.io</a>, make a project, and copy its <strong className="text-white/90">DSN</strong>.</InstructionStep>
-                                    <InstructionStep num={2}>Paste it into the <strong className="text-white/90">Sentry</strong> card under Other settings, and save.</InstructionStep>
-                                    <InstructionStep num={3}><em className="text-white/50">Optional:</em> this is genuinely skippable. Crashes are still recorded in the admin console without it — Sentry adds alerting and keeps the history longer.</InstructionStep>
+                                    <InstructionStep num={1} check={<>a DSN that looks like <code className="bg-black/30 px-1 rounded">https://…@…ingest.sentry.io/…</code></>}>Create a free account at <a href="https://sentry.io" target="_blank" rel="noopener noreferrer" className="text-violet-300 underline underline-offset-2">sentry.io</a>, make a project, and copy its <strong className="text-white/90">DSN</strong> into the box below.</InstructionStep>
+                                    <PlainSecrets fields={[
+                                        { key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true, help: 'Project Settings → Client Keys (DSN). Not a password — but it is still worth keeping to yourself.' },
+                                    ]} />
+                                    <InstructionStep num={2}><em className="text-white/50">Optional:</em> this is genuinely skippable. Crashes are still recorded in the admin console without it — Sentry adds alerting and keeps the history longer.</InstructionStep>
                                 </Guide>
 
                                 <Guide show={wants('backups')} tone="amber" icon={HardDrive} title="Automatic backups" done={backupConfigured}


### PR DESCRIPTION
Asked to put the credential boxes inline in the setup guide, I built the "step owns the boxes it fills" layout on the provider cards instead and left the guide saying "scroll to the Maps card below and choose your provider" — then wrote a test asserting the guide did **not** carry the steps, which locked the misreading in. This undoes that.

## Credentials are entered where they are described

Every section that needs one now renders the console walk and its inputs in place, for the provider the questionnaire at the top already established, with Save &amp; Test. Eight capabilities: sign-in, maps, AI, translation, key management, email, SMS, redaction.

There is still one copy of the walk. Both the guide and the cards mount `ProviderCredentialSteps` over `setupStepsContent.tsx` — the layout was lifted out of `ServiceProviders.tsx` rather than reimplemented, because two hand-written copies is what drifted last time and left the guide contradicting the card about Okta&#39;s issuer. The cards remain the place to change a provider later and to see health; nothing has to happen there before a town takes its first report.

## Ticking a box now changes the page

- **Photo redaction hung off the "content moderation" tick.** Unticking moderation silently hid face blurring, and there was no way to have blurring without it — different decisions, one screens what a resident wrote and the other blurs a bystander who wrote nothing. Redaction has its own tick.
- **Crash reporting rendered unconditionally with no chip at all**, so the panel&#39;s promise that unticking hides a section was false for it.
- **The moderation section printed `AZURE_CONTENT_SAFETY_ENDPOINT`, `AZURE_CONTENT_SAFETY_KEY` and `MODERATION_PROVIDER` as bare variable names mid-sentence** — the only place on the page telling a clerk to go and edit a file. The first two are boxes; the third is derived from the cloud answer and nobody should be setting it.
- **Sentry&#39;s DSN** said "paste it into the Sentry card" and now has a box.

Email, SMS and redaction keep a picker because they genuinely are not a cloud decision — a town on Google may well send through SES. They hold an override rather than a value, so changing the cloud at the top moves the default while a deliberate pick stays put.

## Two bugs found while building it

The guide&#39;s inline wrapper was declared during render, making it a fresh component type every time — React would remount it and discard a half-typed client secret whenever any chip was ticked. It now calls the component directly. And eight inline blocks each probed the attached-identity endpoint, so the probe is memoised on the in-flight promise.

## Verification

9 new tests drive the real component in jsdom and assert on the DOM, because every other check on this page reads the TSX as text and would pass with nothing on screen — which is exactly how the original mistake survived.

Checked by mutation rather than by passing: hiding a step&#39;s fields fails 4, dropping unclaimed fields fails 1, ignoring attached identity fails 1, skipping verification after save fails 2, not trimming a paste fails 1, and five regressions of the guide wiring each fail their own assertion. The first pass of those tests caught only 4 of 5 mutations, so the missing case was added.

493 backend / 89 frontend pass, clean build, typecheck steady at 11 pre-existing errors.

**Not verified in a real browser.** The tests prove the boxes render, save and verify; nobody has looked at eight inline setup blocks stacked inside the guide panel. That is a layout risk rather than a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_