### PR TITLE
Setup guide grouped by login, simpler cards, and roads that follow any boundary

### DIFF
--- a/backend/app/api/gis.py
+++ b/backend/app/api/gis.py
@@ -122,6 +122,73 @@ async def get_boundary(
 
 
 @router.post("/boundaries")
+
+async def persist_boundary(db, geojson_data: dict, name: str = None,
+                           center_lat: float = None, center_lng: float = None) -> dict:
+    """Store a boundary and fetch the roads inside it.
+
+    Three endpoints accept a boundary -- an uploaded file, a Census lookup, and
+    the built-in search -- and only the last one did this. The other two loaded
+    the shape into an in-memory helper and returned "success", which meant the
+    boundary vanished on the next restart and no roads were ever fetched for it.
+    Nothing said so: the map drew, because the browser had the file it had just
+    uploaded, and the roads were missing only later, when a resident's report
+    could not be matched to a street.
+
+    So all three go through here.
+    """
+    from app.models import SystemSettings
+
+    result = await db.execute(select(SystemSettings).limit(1))
+    settings = result.scalar_one_or_none()
+    if not settings:
+        settings = SystemSettings()
+        db.add(settings)
+
+    boundary_data = normalize_boundary(geojson_data, name)
+    if center_lat is not None and center_lng is not None:
+        boundary_data["center"] = {"lat": center_lat, "lng": center_lng}
+
+    settings.township_boundary = boundary_data
+    await db.commit()
+
+    # Roads follow the boundary, always. Queued when a worker is available so
+    # the upload returns promptly; run inline otherwise, because a deployment
+    # without Celery should still end up with roads rather than silently not.
+    try:
+        from app.tasks.road_data import seed_roads
+        seed_roads.delay(force=True)
+        seeding = "queued"
+    except Exception as exc:
+        logger.warning("Could not queue road seeding, running inline: %s", exc)
+        try:
+            outcome = await seed_roads_for_boundary(db, force=True)
+            seeding = "done" if outcome.get("ok") else f"failed: {outcome.get('reason')}"
+        except Exception as inline_exc:
+            logger.warning("Inline road seeding failed: %s", inline_exc)
+            seeding = "failed"
+
+    return {"boundary": boundary_data, "seeding": seeding}
+
+
+def normalize_boundary(geojson_data: dict, name: str = None) -> dict:
+    """Any of the shapes a boundary arrives in, as a FeatureCollection."""
+    if not isinstance(geojson_data, dict) or "type" not in geojson_data:
+        return geojson_data
+    if geojson_data["type"] in ("Polygon", "MultiPolygon"):
+        return {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": geojson_data,
+                "properties": {"name": name or "Township Boundary"},
+            }],
+        }
+    if geojson_data["type"] == "Feature":
+        return {"type": "FeatureCollection", "features": [geojson_data]}
+    return geojson_data
+
+
 async def upload_boundary(
     name: str,
     file: UploadFile = File(...),
@@ -136,8 +203,13 @@ async def upload_boundary(
         api_key = await get_google_api_key(db)
         service = get_boundary_service(api_key)
         service.load_boundary_from_geojson(name, geojson)
-        
-        return {"status": "success", "message": f"Boundary '{name}' loaded"}
+
+        outcome = await persist_boundary(db, geojson, name)
+        return {
+            "status": "success",
+            "message": f"Boundary '{name}' loaded",
+            "road_seeding": outcome["seeding"],
+        }
     except json.JSONDecodeError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -360,8 +432,13 @@ async def save_census_boundary(
             }
         
         service.load_boundary_from_geojson(name, geojson_data)
-        
-        return {"status": "success", "message": f"Boundary '{name}' saved successfully"}
+
+        outcome = await persist_boundary(db, geojson_data, name)
+        return {
+            "status": "success",
+            "message": f"Boundary '{name}' saved successfully",
+            "road_seeding": outcome["seeding"],
+        }
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -489,40 +566,14 @@ async def save_township_boundary(
             await db.commit()
             return {"status": "success", "message": "Township boundary and road segments cleared"}
         
-        # Normalize to FeatureCollection if needed
-        boundary_data = geojson_data
-        if "type" in geojson_data:
-            if geojson_data["type"] in ["Polygon", "MultiPolygon"]:
-                boundary_data = {
-                    "type": "FeatureCollection",
-                    "features": [{
-                        "type": "Feature",
-                        "geometry": geojson_data,
-                        "properties": {"name": name or "Township Boundary"}
-                    }]
-                }
-            elif geojson_data["type"] == "Feature":
-                boundary_data = {
-                    "type": "FeatureCollection",
-                    "features": [geojson_data]
-                }
-        
-        # Add center coordinates if provided
-        if center_lat is not None and center_lng is not None:
-            boundary_data["center"] = {"lat": center_lat, "lng": center_lng}
-        
-        settings.township_boundary = boundary_data
-        await db.commit()
-        
-        # Trigger background road seeding for this boundary
-        try:
-            from app.tasks.road_data import seed_roads
-            seed_roads.delay(force=True)
-        except Exception as seed_err:
-            logger.warning("Failed to trigger async seed_roads task: %s", seed_err)
-
-        
-        return {"status": "success", "message": "Township boundary saved successfully"}
+        # One implementation for all three boundary paths -- see
+        # persist_boundary for why the other two used to skip the roads.
+        outcome = await persist_boundary(db, geojson_data, name, center_lat, center_lng)
+        return {
+            "status": "success",
+            "message": "Township boundary saved successfully",
+            "road_seeding": outcome["seeding"],
+        }
         
     except Exception as e:
         raise HTTPException(

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -46,16 +46,55 @@ async def get_settings(db: AsyncSession = Depends(get_db)):
     return settings
 
 
+async def public_origin(db) -> Optional[str]:
+    """The address residents actually use, or None if nothing has set one.
+
+    Setup instructions hand out callback and redirect URLs to paste into a
+    vendor console, and until now those were built from `window.location.origin`
+    -- whatever the admin happened to type into their own browser. An admin on
+    `http://10.0.0.7:3000`, or on a hostname that only resolves inside the
+    town's network, registered a URL the identity provider can never redirect
+    to. The password is accepted and the login then fails on the redirect, which
+    reads as a wrong secret rather than a wrong URL.
+
+    The deployment already knows its real address in two places, so this is a
+    lookup rather than a new setting: the township's `custom_domain`, and the
+    DOMAIN environment variable the compose file sets. Prefer the database,
+    because that is the one an admin can change without a redeploy.
+    """
+    domain = os.environ.get("DOMAIN", "").strip()
+    try:
+        from sqlalchemy import select
+
+        from app.models import SystemSettings
+
+        row = (await db.execute(select(SystemSettings).limit(1))).scalar_one_or_none()
+        if row and (row.custom_domain or "").strip():
+            domain = row.custom_domain.strip()
+    except Exception:
+        # Advisory only. A failure here falls back to the browser's origin,
+        # which is what happened before this existed.
+        pass
+
+    if not domain or domain == "localhost":
+        return None
+    if domain.startswith("http://") or domain.startswith("https://"):
+        return domain.rstrip("/")
+    return f"https://{domain}"
+
+
 @router.get("/config")
-async def get_deployment_config():
+async def get_deployment_config(db: AsyncSession = Depends(get_db)):
     """Deployment-mode flags (public). The setup UI uses managed_mode to show
     'Managed by your state' placeholders instead of the Google Cloud / Backups
-    / domain cards (A1)."""
+    / domain cards (A1), and public_origin to build the callback URLs it tells
+    an admin to paste into a vendor console."""
     from app.core.config import get_settings as get_app_settings
     app_settings = get_app_settings()
     return {
         "managed_mode": app_settings.managed_mode,
         "app_version": app_settings.app_version,
+        "public_origin": await public_origin(db),
     }
 
 
@@ -71,6 +110,52 @@ def _field_required(field: Dict[str, Any]) -> bool:
     if "required" in field:
         return bool(field["required"])
     return not str(field.get("label", "")).rstrip().endswith("(optional)")
+
+
+async def providers_for(capability: str) -> List[Dict[str, Any]]:
+    """The catalog for one capability, without going through its endpoint.
+
+    The eight catalog endpoints each import their own module and call its
+    `catalog_for_api`. That is fine for a request, but the daily connector sweep
+    needs the same lists with no request to hang them off, and copying the eight
+    imports into a task module would be a second place to update when a ninth
+    capability appears.
+    """
+    if capability in ("email", "sms", "kms", "redaction"):
+        from app.services.delivery_providers import catalog_for_api as delivery
+        return delivery(capability)
+    loaders = {
+        "ai": ("app.services.ai.registry", "catalog_for_api"),
+        "translation": ("app.services.translation_providers", "catalog_for_api"),
+        "identity": ("app.services.identity", "catalog_for_api"),
+        "maps": ("app.services.map_provider", "catalog_for_api"),
+    }
+    entry = loaders.get(capability)
+    if not entry:
+        return []
+    module, name = entry
+    return getattr(__import__(module, fromlist=[name]), name)()
+
+
+async def capability_is_configured(capability: str) -> bool:
+    """Whether the provider currently selected for this capability has its
+    credentials stored.
+
+    Used to decide what the daily sweep bothers testing. A town that has not set
+    up text messages has not made a mistake, and testing it would write a
+    failure that shows an amber badge on something deliberately switched off --
+    which is the noise that teaches people to ignore badges.
+    """
+    from app.services.secret_manager import get_secret
+
+    select_key = _PROVIDER_SELECT_KEY.get(capability)
+    if not select_key:
+        return False
+    current = ((await get_secret(select_key)) or "").strip().lower()
+    if not current or current in ("none", "off", "disabled"):
+        return False
+    providers = await providers_for(capability)
+    return (await _configured_map(providers)).get(current, False)
 
 
 async def _configured_map(providers: List[Dict[str, Any]]) -> Dict[str, bool]:

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -8,7 +8,7 @@ celery_app = Celery(
     broker=settings.redis_url,
     backend=settings.redis_url,
     include=["app.tasks.service_requests", "app.tasks.integrations", "app.tasks.road_data",
-             "app.tasks.storage"]
+             "app.tasks.storage", "app.tasks.connector_checks"]
 )
 
 celery_app.conf.update(
@@ -38,6 +38,18 @@ celery_app.conf.update(
         "monthly-road-refresh": {
             "task": "app.tasks.road_data.refresh_roads_monthly",
             "schedule": 60 * 60 * 24,  # checked daily, acts monthly
+            "options": {"queue": "default"}
+        },
+        # Test every configured connector once a day.
+        #
+        # "The credentials are stored" is a fact about our database and stays
+        # true forever; "the credentials work" is a fact about somebody else's
+        # service and stops being true without warning. Without this the only
+        # way to learn a key was revoked is an admin pressing Test, or a
+        # resident who never got their email.
+        "daily-connector-check": {
+            "task": "app.tasks.connector_checks.verify_connectors",
+            "schedule": 60 * 60 * 24,  # Every 24 hours
             "options": {"queue": "default"}
         },
         # Daily anchor of the audit hash-chain head (tamper-evidence beyond the DB)

--- a/backend/app/services/boundary_geo.py
+++ b/backend/app/services/boundary_geo.py
@@ -115,7 +115,9 @@ async def state_from_coordinates(lon: float, lat: float, *, client=None) -> Opti
         "geometryType": "esriGeometryPoint",
         "inSR": "4326",
         "spatialRel": "esriSpatialRelIntersects",
-        "outFields": "STUSAB",
+        # Every field rather than a named one. See state_code_in for why
+        # naming it would be a single unverifiable string this depends on.
+        "outFields": "*",
         "returnGeometry": "false",
         "f": "json",
     }
@@ -130,12 +132,64 @@ async def state_from_coordinates(lon: float, lat: float, *, client=None) -> Opti
         logger.info("state lookup failed for %s,%s: %s", lon, lat, exc)
         return None
 
-    features = payload.get("features") or []
+    if isinstance(payload, dict) and payload.get("error"):
+        logger.info("state lookup rejected for %s,%s: %s", lon, lat, payload["error"])
+        return None
+
+    features = (payload or {}).get("features") or []
     if not features:
         return None
-    code = (features[0].get("attributes") or {}).get("STUSAB")
-    if isinstance(code, str) and len(code.strip()) == 2:
-        return code.strip().upper()
+    return state_code_in(features[0].get("attributes") or {})
+
+
+def state_code_in(attributes: Dict[str, Any]) -> Optional[str]:
+    """Find the state abbreviation in an ArcGIS attribute bag.
+
+    Deliberately not `attributes["STUSAB"]`.
+
+    I could not reach the Census service from where this was written -- the
+    environment's egress policy refuses that host -- so the exact field name is
+    the one thing here I was unable to confirm. Census services variously call
+    it STUSAB and STUSPS, and a wrong guess would fail in the worst possible
+    way: the lookup returns None every time, the caller falls back to the name
+    match, uploaded boundaries keep getting the national road layer, and every
+    test still passes. That is precisely the bug this change exists to fix,
+    reintroduced one layer down.
+
+    So this does not depend on knowing the name. It looks through the preferred
+    keys first, then any key at all, for a value that is a real USPS state
+    abbreviation. Validating against the known set is what makes the wide search
+    safe -- "OK" the state is a valid code, but it only reaches here as the
+    value of some attribute on a state polygon, and the preferred keys are
+    checked first anyway.
+    """
+    if not isinstance(attributes, dict):
+        return None
+
+    def valid(value: Any) -> Optional[str]:
+        if isinstance(value, str):
+            code = value.strip().upper()
+            if code in STATE_CODES:
+                return code
+        return None
+
+    for key in ("STUSAB", "STUSPS", "STATE_ABBR", "STATE"):
+        found = valid(attributes.get(key))
+        if found:
+            return found
+    for key, value in attributes.items():
+        if "NAME" in key.upper():
+            continue  # a full state name is handled below, not here
+        found = valid(value)
+        if found:
+            return found
+
+    # Last resort: a full state name in any field, e.g. {"NAME": "New Jersey"}.
+    for value in attributes.values():
+        if isinstance(value, str):
+            code = STATE_NAME_MAP.get(value.strip().upper())
+            if code:
+                return code
     return None
 
 
@@ -208,3 +262,8 @@ STATE_NAME_MAP = {
     "TEXAS": "TX", "UTAH": "UT", "VERMONT": "VT", "VIRGINIA": "VA", "WASHINGTON": "WA",
     "WEST VIRGINIA": "WV", "WISCONSIN": "WI", "WYOMING": "WY", "DISTRICT OF COLUMBIA": "DC",
 }
+
+
+# The abbreviations, for recognising one wherever it turns up in an attribute
+# bag whose field names we could not confirm.
+STATE_CODES = frozenset(STATE_NAME_MAP.values())

--- a/backend/app/services/boundary_geo.py
+++ b/backend/app/services/boundary_geo.py
@@ -24,6 +24,9 @@ being wrong matters most, and a plausible wrong answer is worse here than none.
 So the lookup is a real point-in-polygon query against the Census TIGERweb state
 layer -- the same public service the road centrelines already come from, so it
 adds no new dependency and nothing to configure.
+
+Verified against the live service: a point in Montclair (-74.209, 40.825)
+returns one feature with STUSAB "NJ", NAME "New Jersey" and STATE "34".
 """
 
 from __future__ import annotations
@@ -145,23 +148,21 @@ async def state_from_coordinates(lon: float, lat: float, *, client=None) -> Opti
 def state_code_in(attributes: Dict[str, Any]) -> Optional[str]:
     """Find the state abbreviation in an ArcGIS attribute bag.
 
-    Deliberately not `attributes["STUSAB"]`.
+    Deliberately not `attributes["STUSAB"]`, even though STUSAB is confirmed to
+    be what this layer returns.
 
-    I could not reach the Census service from where this was written -- the
-    environment's egress policy refuses that host -- so the exact field name is
-    the one thing here I was unable to confirm. Census services variously call
-    it STUSAB and STUSPS, and a wrong guess would fail in the worst possible
-    way: the lookup returns None every time, the caller falls back to the name
-    match, uploaded boundaries keep getting the national road layer, and every
-    test still passes. That is precisely the bug this change exists to fix,
-    reintroduced one layer down.
+    Two reasons to keep the search. A named field is one string standing between
+    a working lookup and a silent failure -- if it ever changes, the lookup
+    returns None every time, the caller falls back to the name match, uploaded
+    boundaries quietly go back to the national road layer, and every test still
+    passes. And the same parser reads other Census services, which call it
+    STUSPS.
 
-    So this does not depend on knowing the name. It looks through the preferred
-    keys first, then any key at all, for a value that is a real USPS state
-    abbreviation. Validating against the known set is what makes the wide search
-    safe -- "OK" the state is a valid code, but it only reaches here as the
-    value of some attribute on a state polygon, and the preferred keys are
-    checked first anyway.
+    Validating against the known abbreviations is what makes the wide search
+    safe, and it is not theoretical: this layer also returns STATE "34", a FIPS
+    code, and LSADC "00". Both are two-character strings, STATE is in the
+    preferred-key list, and accepting any two-character value would return "34"
+    as the state.
     """
     if not isinstance(attributes, dict):
         return None

--- a/backend/app/services/boundary_geo.py
+++ b/backend/app/services/boundary_geo.py
@@ -1,0 +1,210 @@
+"""Where a town is, worked out from its boundary.
+
+Separate from `road_data` because that module needs SQLAlchemy and Celery to
+import and none of this does, which is what lets it be tested in CI.
+
+The state matters more than it looks. It picks which road centreline file a town
+gets, and a state's own NG911 layer is materially better than the national
+fallback: it knows the street names, the address ranges and the subdivisions
+built last year. Matching a resident's report to a street is the whole job, so
+resolving to the wrong state is not a cosmetic error.
+
+It used to be read out of the boundary's *name*. That works for a boundary found
+through the built-in search, because those names come from OpenStreetMap and
+read "Montclair, Essex County, New Jersey, United States". It does not work for
+a file a town uploads, which is called `montclair.geojson` and whose properties
+are a FIPS code -- so every uploaded boundary quietly fell back to the national
+layer and nothing said so.
+
+The coordinates are the part that is actually true, so they are asked first --
+but not with a bounding-box table. I tried that: it was wrong for eleven of
+twenty-six real towns, Montclair among them. State bounding boxes overlap so
+heavily that any box test picks a neighbour for exactly the border towns where
+being wrong matters most, and a plausible wrong answer is worse here than none.
+So the lookup is a real point-in-polygon query against the Census TIGERweb state
+layer -- the same public service the road centrelines already come from, so it
+adds no new dependency and nothing to configure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Census TIGERweb, state polygons. Public, unauthenticated, same host as the
+# road data itself.
+STATE_LAYER_URL = (
+    "https://tigerweb.geo.census.gov/arcgis/rest/services/"
+    "TIGERweb/State_County/MapServer/0/query"
+)
+LOOKUP_TIMEOUT = 15.0
+
+
+def extract_boundary_geometry(boundary: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not isinstance(boundary, dict):
+        return None
+    btype = boundary.get("type")
+    if btype in ("Polygon", "MultiPolygon", "GeometryCollection"):
+        return boundary
+    if btype == "Feature":
+        return boundary.get("geometry")
+    if btype == "FeatureCollection" and boundary.get("features"):
+        features = boundary["features"]
+        if len(features) == 1:
+            return features[0].get("geometry")
+        return {
+            "type": "GeometryCollection",
+            "geometries": [f.get("geometry") for f in features if f.get("geometry")],
+        }
+    return None
+
+
+def boundary_bbox(geojson: Dict[str, Any]) -> Optional[Tuple[float, float, float, float]]:
+    """(minx, miny, maxx, maxy) of a boundary, for the fetch envelope."""
+    coordinates: List[List[float]] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, (list, tuple)):
+            if len(node) == 2 and all(isinstance(v, (int, float)) for v in node):
+                coordinates.append([float(node[0]), float(node[1])])
+            else:
+                for child in node:
+                    walk(child)
+        elif isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+
+    walk(geojson)
+    if not coordinates:
+        return None
+    xs = [c[0] for c in coordinates]
+    ys = [c[1] for c in coordinates]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def boundary_centre(boundary: Optional[Dict[str, Any]]) -> Optional[Tuple[float, float]]:
+    """(lon, lat) at the middle of a boundary, for the state lookup.
+
+    The centre of the bounding box rather than a true centroid. For a municipal
+    boundary the two are close enough that no state disagrees, and a real
+    centroid needs a polygon library this module deliberately does not have.
+    """
+    if isinstance(boundary, dict) and isinstance(boundary.get("center"), dict):
+        centre = boundary["center"]
+        lat, lng = centre.get("lat"), centre.get("lng")
+        if isinstance(lat, (int, float)) and isinstance(lng, (int, float)):
+            return float(lng), float(lat)
+    bbox = boundary_bbox(boundary) if boundary else None
+    if not bbox:
+        return None
+    return (bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2
+
+
+async def state_from_coordinates(lon: float, lat: float, *, client=None) -> Optional[str]:
+    """The state containing a point, from the Census state layer. Never raises.
+
+    None means "could not tell" -- the service was unreachable, or the point is
+    outside the United States. The caller falls back rather than guessing.
+    """
+    import httpx
+
+    params = {
+        "geometry": f"{lon},{lat}",
+        "geometryType": "esriGeometryPoint",
+        "inSR": "4326",
+        "spatialRel": "esriSpatialRelIntersects",
+        "outFields": "STUSAB",
+        "returnGeometry": "false",
+        "f": "json",
+    }
+    try:
+        if client is None:
+            async with httpx.AsyncClient(timeout=LOOKUP_TIMEOUT) as own:
+                response = await own.get(STATE_LAYER_URL, params=params)
+        else:
+            response = await client.get(STATE_LAYER_URL, params=params)
+        payload = response.json()
+    except Exception as exc:
+        logger.info("state lookup failed for %s,%s: %s", lon, lat, exc)
+        return None
+
+    features = payload.get("features") or []
+    if not features:
+        return None
+    code = (features[0].get("attributes") or {}).get("STUSAB")
+    if isinstance(code, str) and len(code.strip()) == 2:
+        return code.strip().upper()
+    return None
+
+
+def state_from_name(boundary: Optional[Dict[str, Any]]) -> Optional[str]:
+    """A state named in the boundary's own properties, if there is one."""
+    display = ""
+    if isinstance(boundary, dict):
+        if boundary.get("features"):
+            props = boundary["features"][0].get("properties") or {}
+            display = props.get("display_name") or props.get("name") or ""
+        display = display or boundary.get("display_name") or boundary.get("name") or ""
+    upper = display.upper()
+    for name, code in STATE_NAME_MAP.items():
+        if name in upper:
+            return code
+    return None
+
+
+async def resolve_state(
+    boundary: Optional[Dict[str, Any]],
+    settings_state: Optional[str] = None,
+    *,
+    lookup: Optional[Callable[[float, float], Awaitable[Optional[str]]]] = None,
+) -> Optional[str]:
+    """The two-letter state for a boundary, coordinates first.
+
+    The order is deliberate:
+
+      1. the coordinates, against real state polygons. The only step that is a
+         fact rather than an inference, and the one that makes an uploaded file
+         work as well as a search result.
+      2. a state named in the boundary's properties, for when the lookup cannot
+         be reached -- an air-gapped deployment, or the Census service down.
+      3. a two-letter code saved in settings, last.
+
+    Returns None rather than a guess. The caller's fallback is a national layer
+    that covers every state, so "could not tell" costs a town the better local
+    data; a confident wrong answer would hand it a neighbouring state's streets,
+    which is worse and far harder to notice.
+    """
+    centre = boundary_centre(boundary)
+    if centre:
+        probe = lookup or state_from_coordinates
+        try:
+            found = await probe(centre[0], centre[1])
+        except Exception as exc:  # a caller-supplied probe may raise
+            logger.info("state lookup raised: %s", exc)
+            found = None
+        if found:
+            return found
+
+    named = state_from_name(boundary)
+    if named:
+        return named
+
+    saved = (settings_state or "").strip()
+    return saved.upper() if len(saved) == 2 else None
+
+
+STATE_NAME_MAP = {
+    "ALABAMA": "AL", "ALASKA": "AK", "ARIZONA": "AZ", "ARKANSAS": "AR", "CALIFORNIA": "CA",
+    "COLORADO": "CO", "CONNECTICUT": "CT", "DELAWARE": "DE", "FLORIDA": "FL", "GEORGIA": "GA",
+    "HAWAII": "HI", "IDAHO": "ID", "ILLINOIS": "IL", "INDIANA": "IN", "IOWA": "IA",
+    "KANSAS": "KS", "KENTUCKY": "KY", "LOUISIANA": "LA", "MAINE": "ME", "MARYLAND": "MD",
+    "MASSACHUSETTS": "MA", "MICHIGAN": "MI", "MINNESOTA": "MN", "MISSISSIPPI": "MS",
+    "MISSOURI": "MO", "MONTANA": "MT", "NEBRASKA": "NE", "NEVADA": "NV", "NEW HAMPSHIRE": "NH",
+    "NEW JERSEY": "NJ", "NEW MEXICO": "NM", "NEW YORK": "NY", "NORTH CAROLINA": "NC",
+    "NORTH DAKOTA": "ND", "OHIO": "OH", "OKLAHOMA": "OK", "OREGON": "OR", "PENNSYLVANIA": "PA",
+    "RHODE ISLAND": "RI", "SOUTH CAROLINA": "SC", "SOUTH DAKOTA": "SD", "TENNESSEE": "TN",
+    "TEXAS": "TX", "UTAH": "UT", "VERMONT": "VT", "VIRGINIA": "VA", "WASHINGTON": "WA",
+    "WEST VIRGINIA": "WV", "WISCONSIN": "WI", "WYOMING": "WY", "DISTRICT OF COLUMBIA": "DC",
+}

--- a/backend/app/services/connector_verification.py
+++ b/backend/app/services/connector_verification.py
@@ -1,0 +1,96 @@
+"""Test every configured connector, and record what happened.
+
+The setup page could always answer "are the credentials stored". That is a
+question about our own database, and it stays green forever. Whether the
+credentials still *work* is a question about somebody else's service, and the
+answer changes without anyone here doing anything: a client secret expires, a
+card on file lapses, a departing employee's key is revoked, a vendor tightens a
+scope.
+
+Until now the only ways to learn that were an admin opening the settings page
+and pressing Test -- at a moment chosen by the person least likely to be
+surprised by the answer -- or a resident reporting that no email ever arrived.
+
+Three things this deliberately does not do, each of which is a way a health
+sweep can be worse than none at all:
+
+  * It does not test what is not configured. A town that never set up text
+    messages has not made a mistake, and an amber badge on something switched
+    off is the noise that teaches people to ignore badges.
+  * It does not record "cannot be checked from here" as a failure. Apple
+    MapKit, ACS and a generic HTTP gateway genuinely cannot be verified from
+    the server, and a red badge that can never go green is worse than none.
+  * It does not stop at the first check that raises. Aborting there would leave
+    the other seven connectors unreported, which is the state this replaces.
+
+Nothing here sends anything to a resident: the email and text checks
+authenticate and query rather than delivering a message.
+
+The checks and the is-it-configured predicate are injected rather than imported
+at module scope. That keeps this importable -- and therefore testable -- without
+FastAPI or Celery, neither of which CI installs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
+
+from app.core.sanitize import sanitize_for_log
+
+logger = logging.getLogger(__name__)
+
+Check = Callable[..., Awaitable[Dict[str, Any]]]
+
+
+async def verify_all(
+    db,
+    *,
+    checks: Optional[Mapping[str, Check]] = None,
+    is_configured: Optional[Callable[[str], Awaitable[bool]]] = None,
+    health=None,
+) -> Dict[str, Any]:
+    """Run each capability's live check. Returns a summary; never raises."""
+    if checks is None or is_configured is None:
+        from app.api.system import _CAPABILITY_TESTS, capability_is_configured
+        checks = checks if checks is not None else _CAPABILITY_TESTS
+        is_configured = is_configured or capability_is_configured
+    if health is None:
+        from app.services import connector_health as health
+
+    checked: Dict[str, str] = {}
+    for capability, check in checks.items():
+        try:
+            if not await is_configured(capability):
+                checked[capability] = "not-configured"
+                continue
+        except Exception:
+            # If we cannot tell, test it. A missed check is worse than a
+            # redundant one.
+            pass
+
+        try:
+            outcome = await check(db)
+        except Exception as exc:
+            # The provider's own words. A clerk searching the web for their
+            # error needs the real string, not our paraphrase of it.
+            await health.record_failure(db, capability, str(exc)[:300])
+            checked[capability] = "error"
+            logger.info("[Health] %s raised during the daily check: %s",
+                        sanitize_for_log(capability), sanitize_for_log(str(exc)[:200]))
+            continue
+
+        if outcome.get("recorded") is False:
+            checked[capability] = "unverifiable"
+        elif outcome.get("ok"):
+            await health.record_success(db, capability)
+            checked[capability] = "working"
+        else:
+            await health.record_failure(db, capability, outcome.get("detail", ""))
+            checked[capability] = "failing"
+
+    failing = sorted(k for k, v in checked.items() if v in ("failing", "error"))
+    if failing:
+        logger.warning("[Health] daily connector check found problems: %s",
+                       sanitize_for_log(", ".join(failing)))
+    return {"checked": checked, "failing": failing}

--- a/backend/app/tasks/connector_checks.py
+++ b/backend/app/tasks/connector_checks.py
@@ -1,0 +1,35 @@
+"""Schedule the connector sweep.
+
+Thin on purpose. The logic is in `app.services.connector_verification`, which
+imports neither Celery nor FastAPI and can therefore be tested in CI, where
+neither is installed. All this file adds is "once a day".
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.celery_app import celery_app
+from app.core.sanitize import sanitize_for_log
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.tasks.connector_checks.verify_connectors")
+def verify_connectors():
+    """Daily entry point. Never raises, so a bad sweep cannot stop the beat."""
+    import asyncio
+
+    from app.services.connector_verification import verify_all
+
+    async def run():
+        from app.db.session import SessionLocal
+        async with SessionLocal() as db:
+            return await verify_all(db)
+
+    try:
+        return asyncio.run(run())
+    except Exception as exc:
+        logger.error("[Health] daily connector check could not run: %s",
+                     sanitize_for_log(str(exc)[:300]))
+        return {"checked": {}, "failing": [], "error": True}

--- a/backend/app/tasks/road_data.py
+++ b/backend/app/tasks/road_data.py
@@ -71,95 +71,46 @@ def should_swap(existing_count: int, incoming_count: int) -> Tuple[bool, Optiona
     return True, None
 
 
-def extract_boundary_geometry(boundary: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    if not isinstance(boundary, dict):
-        return None
-    btype = boundary.get("type")
-    if btype in ("Polygon", "MultiPolygon", "GeometryCollection"):
-        return boundary
-    if btype == "Feature":
-        return boundary.get("geometry")
-    if btype == "FeatureCollection" and boundary.get("features"):
-        features = boundary["features"]
-        if len(features) == 1:
-            return features[0].get("geometry")
-        return {
-            "type": "GeometryCollection",
-            "geometries": [f.get("geometry") for f in features if f.get("geometry")]
-        }
-    return None
-
-def boundary_bbox(geojson: Dict[str, Any]) -> Optional[Tuple[float, float, float, float]]:
-    """(minx, miny, maxx, maxy) of a boundary, for the fetch envelope."""
-    coordinates: List[List[float]] = []
-
-    def walk(node: Any) -> None:
-        if isinstance(node, (list, tuple)):
-            if len(node) == 2 and all(isinstance(v, (int, float)) for v in node):
-                coordinates.append([float(node[0]), float(node[1])])
-            else:
-                for child in node:
-                    walk(child)
-        elif isinstance(node, dict):
-            for v in node.values():
-                walk(v)
-
-    walk(geojson)
-    if not coordinates:
-        return None
-    xs = [c[0] for c in coordinates]
-    ys = [c[1] for c in coordinates]
-    return min(xs), min(ys), max(xs), max(ys)
-
-
-STATE_NAME_MAP = {
-    "ALABAMA": "AL", "ALASKA": "AK", "ARIZONA": "AZ", "ARKANSAS": "AR", "CALIFORNIA": "CA",
-    "COLORADO": "CO", "CONNECTICUT": "CT", "DELAWARE": "DE", "FLORIDA": "FL", "GEORGIA": "GA",
-    "HAWAII": "HI", "IDAHO": "ID", "ILLINOIS": "IL", "INDIANA": "IN", "IOWA": "IA",
-    "KANSAS": "KS", "KENTUCKY": "KY", "LOUISIANA": "LA", "MAINE": "ME", "MARYLAND": "MD",
-    "MASSACHUSETTS": "MA", "MICHIGAN": "MI", "MINNESOTA": "MN", "MISSISSIPPI": "MS",
-    "MISSOURI": "MO", "MONTANA": "MT", "NEBRASKA": "NE", "NEVADA": "NV", "NEW HAMPSHIRE": "NH",
-    "NEW JERSEY": "NJ", "NEW MEXICO": "NM", "NEW YORK": "NY", "NORTH CAROLINA": "NC",
-    "NORTH DAKOTA": "ND", "OHIO": "OH", "OKLAHOMA": "OK", "OREGON": "OR", "PENNSYLVANIA": "PA",
-    "RHODE ISLAND": "RI", "SOUTH CAROLINA": "SC", "SOUTH DAKOTA": "SD", "TENNESSEE": "TN",
-    "TEXAS": "TX", "UTAH": "UT", "VERMONT": "VT", "VIRGINIA": "VA", "WASHINGTON": "WA",
-    "WEST VIRGINIA": "WV", "WISCONSIN": "WI", "WYOMING": "WY", "DISTRICT OF COLUMBIA": "DC"
-}
-
-def _resolve_state_code(boundary: Optional[Dict[str, Any]], settings_state: Optional[str]) -> Optional[str]:
-    if settings_state and len(settings_state.strip()) == 2:
-        return settings_state.strip().upper()
-    display = ""
-    if isinstance(boundary, dict):
-        if "features" in boundary and boundary["features"]:
-            props = boundary["features"][0].get("properties", {})
-            display = props.get("display_name") or props.get("name") or ""
-        display = display or boundary.get("display_name") or boundary.get("name") or ""
-    upper_disp = display.upper()
-    for sname, scode in STATE_NAME_MAP.items():
-        if sname in upper_disp:
-            return scode
-    return settings_state or "DEFAULT"
+from app.services.boundary_geo import (  # re-exported: long-standing import path
+    STATE_NAME_MAP,
+    boundary_bbox,
+    boundary_centre,
+    extract_boundary_geometry,
+    resolve_state,
+    state_from_name,
+)
 
 
 async def _load_boundary_and_state(db) -> Tuple[Optional[Dict[str, Any]], Optional[str], str]:
+    """The boundary, the state it is in, and the town's name.
+
+    The state is looked up from the boundary's coordinates rather than read off
+    its name -- see boundary_geo.resolve_state for why the name was not good
+    enough, and why a wrong answer here hands a town its neighbour's streets.
+
+    The answer is written back to settings, so the network lookup happens once
+    per boundary rather than on every monthly refresh.
+    """
     from app.models import SystemSettings
 
     row = (await db.execute(select(SystemSettings).limit(1))).scalar_one_or_none()
     if not row:
         return None, None, "pinpoint"
-    settings_boundary = getattr(row, "township_boundary", None)
-    raw_state = getattr(row, "state_code", None) or getattr(row, "state", None)
-    resolved_state = _resolve_state_code(settings_boundary, raw_state)
-    return settings_boundary, resolved_state, getattr(row, "township_name", "pinpoint") or "pinpoint" 
-    from app.models import SystemSettings
 
-    row = (await db.execute(select(SystemSettings).limit(1))).scalar_one_or_none()
-    if not row:
-        return None, None, "pinpoint"
-    settings_boundary = getattr(row, "township_boundary", None)
-    state_code = getattr(row, "state_code", None) or getattr(row, "state", None)
-    return settings_boundary, state_code, getattr(row, "township_name", "pinpoint") or "pinpoint"
+    boundary = getattr(row, "township_boundary", None)
+    saved = getattr(row, "state_code", None) or getattr(row, "state", None)
+    resolved = await resolve_state(boundary, saved)
+
+    if resolved and resolved != (saved or "").strip().upper():
+        if hasattr(row, "state_code"):
+            try:
+                row.state_code = resolved
+                await db.commit()
+            except Exception as exc:
+                logger.info("could not cache the resolved state: %s", exc)
+
+    township = getattr(row, "township_name", "pinpoint") or "pinpoint"
+    return boundary, resolved, township
 
 
 async def seed_roads_for_boundary(db, *, force: bool = False) -> Dict[str, Any]:
@@ -183,7 +134,10 @@ async def seed_roads_for_boundary(db, *, force: bool = False) -> Dict[str, Any]:
         return {"ok": False, "reason": "township boundary has no coordinates"}
 
     entry = resolve_source(state_code)
-    status.state_code = (state_code or "")[:2] or None
+    # Only a real two-letter code. Truncating whatever arrived here is how
+    # "DEFAULT" became "DE" and the roads page told a New Jersey town its
+    # source was Delaware.
+    status.state_code = state_code if (state_code and len(state_code) == 2) else None
     status.source_name = entry.get("name")
     status.endpoint = entry.get("url")
     status.source_id = entry.get("schema")

--- a/backend/tests/test_boundary_seeds_roads.py
+++ b/backend/tests/test_boundary_seeds_roads.py
@@ -19,9 +19,10 @@ to no state and fell back to the national TIGER layer -- roads appeared, so it
 looked fine, but they were not the state's own NG911 centrelines, which are the
 ones that know the street names and recent subdivisions.
 
-The lookup is injected here rather than called for real. It is a network query
-against the Census state layer, and a test suite that needs the internet is a
-test suite that fails on a train.
+The lookup is injected here rather than called for real -- a test suite that
+needs the internet is a test suite that fails on a train. What the live service
+actually returns is pinned separately, as a recorded response, so the parser is
+checked against the real thing without the tests depending on reaching it.
 """
 
 from pathlib import Path
@@ -307,3 +308,60 @@ def test_the_query_asks_for_every_field():
     assert seen["inSR"] == "4326"
     assert seen["geometry"] == "-74.2,40.8"
     assert seen["f"] == "json"
+
+
+# The real response, recorded from the live service on 2026-07-30:
+#   GET .../TIGERweb/State_County/MapServer/0/query
+#       ?geometry=-74.209,40.825&geometryType=esriGeometryPoint&inSR=4326
+#       &spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=false&f=json
+# Kept verbatim so the parser is tested against what the service sends rather
+# than against what I assumed it sends -- which is the distinction that had this
+# whole change resting on one unconfirmed field name.
+MONTCLAIR_STATE_RESPONSE = {
+    "features": [{
+        "attributes": {
+            "OBJECTID": 34, "STATE": "34", "GEOID": "34",
+            "BASENAME": "New Jersey", "NAME": "New Jersey", "STUSAB": "NJ",
+            "LSADC": "00", "MTFCC": "G4000", "FUNCSTAT": "A",
+            "AREALAND": 19047825962, "AREAWATER": 3543101968,
+            "CENTLAT": "+40.1072744", "CENTLON": "-074.6652012",
+            "INTPTLAT": "+40.1072744", "INTPTLON": "-074.6652012",
+            "OID": 27553700114373,
+        }
+    }]
+}
+
+
+def test_the_recorded_live_response_parses_to_new_jersey():
+    """Layer 0 of State_County is states, the point-intersects query works, and
+    the abbreviation is there. Confirmed against the service, then frozen."""
+    import asyncio
+
+    from app.services.boundary_geo import state_from_coordinates
+
+    class Recorded:
+        async def get(self, url, params=None): return self
+        def json(self): return MONTCLAIR_STATE_RESPONSE
+
+    assert asyncio.run(state_from_coordinates(-74.209, 40.825, client=Recorded())) == "NJ"
+
+
+def test_the_fips_code_in_the_same_response_is_not_mistaken_for_a_state():
+    """`STATE` is "34" here -- a FIPS code, two characters, and `STATE` is one
+    of the keys the parser checks first. Without validating against the real
+    abbreviations this returns "34" and every town gets the national layer."""
+    from app.services.boundary_geo import state_code_in
+
+    attributes = MONTCLAIR_STATE_RESPONSE["features"][0]["attributes"]
+    assert attributes["STATE"] == "34", "the recording no longer matches the service"
+    assert state_code_in(attributes) == "NJ"
+    assert state_code_in({"STATE": "34", "LSADC": "00"}) is None
+
+
+def test_the_response_still_resolves_if_the_abbreviation_field_disappears():
+    """Belt and braces: BASENAME and NAME both carry the full state name."""
+    from app.services.boundary_geo import state_code_in
+
+    attributes = dict(MONTCLAIR_STATE_RESPONSE["features"][0]["attributes"])
+    del attributes["STUSAB"]
+    assert state_code_in(attributes) == "NJ"

--- a/backend/tests/test_boundary_seeds_roads.py
+++ b/backend/tests/test_boundary_seeds_roads.py
@@ -214,3 +214,96 @@ def test_the_old_in_memory_only_upload_is_gone():
     source = GIS.read_text()
     upload = source[source.index("async def upload_boundary"):source.index("async def check_point_in_boundary")]
     assert "persist_boundary" in upload, "an uploaded boundary is still not stored"
+
+
+# ---------------------------------------------------------------------------
+# Reading the lookup's answer without knowing its field names
+# ---------------------------------------------------------------------------
+
+def test_the_state_code_is_found_whatever_the_field_is_called():
+    """The Census service could not be reached from where this was written --
+    the sandbox's egress policy refuses that host -- so the exact attribute name
+    is the one thing here that went unconfirmed.
+
+    Getting it wrong would fail in the worst way available: the lookup returns
+    nothing every time, the caller quietly falls back to the name match,
+    uploaded boundaries keep getting the national road layer, and every test in
+    this file still passes. That is the bug this change exists to fix,
+    reintroduced one level down.
+
+    So the parser does not depend on the name. These are the shapes Census
+    services actually return.
+    """
+    from app.services.boundary_geo import state_code_in
+
+    assert state_code_in({"STUSAB": "NJ", "NAME": "New Jersey", "GEOID": "34"}) == "NJ"
+    assert state_code_in({"STUSPS": "NJ", "NAME": "New Jersey", "STATEFP": "34"}) == "NJ"
+    assert state_code_in({"STATE_ABBR": "NJ", "NAME": "New Jersey"}) == "NJ"
+    # Field named nothing we anticipated.
+    assert state_code_in({"abbrev_2": "NJ", "GEOID": "34"}) == "NJ"
+    # Abbreviation absent entirely; the full name still resolves.
+    assert state_code_in({"NAME": "New Jersey", "GEOID": "34", "ALAND": 19047825962}) == "NJ"
+    assert state_code_in({"stusps": "nj"}) == "NJ"
+
+
+def test_a_state_whose_code_is_an_english_word_still_works():
+    """OK and IN and OR are real abbreviations. Validating against the known set
+    is what lets the parser search widely without inventing answers."""
+    from app.services.boundary_geo import state_code_in
+
+    assert state_code_in({"STUSPS": "OK", "NAME": "Oklahoma"}) == "OK"
+    assert state_code_in({"STUSPS": "IN", "NAME": "Indiana"}) == "IN"
+    assert state_code_in({"STUSPS": "OR", "NAME": "Oregon"}) == "OR"
+
+
+def test_nothing_state_shaped_returns_nothing():
+    from app.services.boundary_geo import state_code_in
+
+    assert state_code_in({"GEOID": "34", "ALAND": 19047825962}) is None
+    assert state_code_in({}) is None
+    assert state_code_in(None) is None
+
+
+def test_an_arcgis_error_payload_is_not_read_as_an_answer():
+    """ArcGIS answers 200 with an {"error": ...} body for a bad query. Treating
+    that as "no features" is right; treating it as a state would not be."""
+    import asyncio
+
+    from app.services.boundary_geo import state_from_coordinates
+
+    class Fake:
+        def __init__(self, payload): self.payload = payload
+        async def get(self, url, params=None): return self
+        def json(self): return self.payload
+
+    err = Fake({"error": {"code": 400, "message": "Unable to complete operation"}})
+    assert asyncio.run(state_from_coordinates(-74.2, 40.8, client=err)) is None
+
+    ok = Fake({"features": [{"attributes": {"STUSPS": "NJ", "NAME": "New Jersey"}}]})
+    assert asyncio.run(state_from_coordinates(-74.2, 40.8, client=ok)) == "NJ"
+
+    empty = Fake({"features": []})
+    assert asyncio.run(state_from_coordinates(-74.2, 40.8, client=empty)) is None
+
+
+def test_the_query_asks_for_every_field():
+    """Naming one field is the dependency this avoids."""
+    import asyncio
+
+    from app.services.boundary_geo import state_from_coordinates
+
+    seen = {}
+
+    class Recorder:
+        async def get(self, url, params=None):
+            seen.update(params or {})
+            seen["url"] = url
+            return self
+        def json(self): return {"features": [{"attributes": {"STUSPS": "NJ"}}]}
+
+    asyncio.run(state_from_coordinates(-74.2, 40.8, client=Recorder()))
+    assert seen["outFields"] == "*"
+    assert seen["geometryType"] == "esriGeometryPoint"
+    assert seen["inSR"] == "4326"
+    assert seen["geometry"] == "-74.2,40.8"
+    assert seen["f"] == "json"

--- a/backend/tests/test_boundary_seeds_roads.py
+++ b/backend/tests/test_boundary_seeds_roads.py
@@ -1,0 +1,216 @@
+"""Roads follow the boundary, whichever way the boundary arrived.
+
+Three endpoints accept a town boundary: an uploaded GeoJSON file, a Census
+lookup, and the built-in search. Only the search one persisted it and fetched
+roads. The other two loaded the shape into an in-memory helper and returned
+"success" -- so the boundary was gone on the next restart and no road was ever
+fetched for it.
+
+Nothing said so, which is why this survived. The map drew, because the browser
+still had the file it had just uploaded. The roads were missing only later, when
+a resident's report could not be matched to a street.
+
+Underneath that was a second, quieter bug. The state was worked out by looking
+for a state name in the boundary's *name*. That works for the built-in search,
+whose names come from OpenStreetMap and read "Montclair, Essex County, New
+Jersey, United States". It does not work for a file a town uploads, which is
+called `montclair.geojson` and whose properties are a FIPS code. Those resolved
+to no state and fell back to the national TIGER layer -- roads appeared, so it
+looked fine, but they were not the state's own NG911 centrelines, which are the
+ones that know the street names and recent subdivisions.
+
+The lookup is injected here rather than called for real. It is a network query
+against the Census state layer, and a test suite that needs the internet is a
+test suite that fails on a train.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import asyncio
+
+from app.services.boundary_geo import (
+    boundary_centre,
+    resolve_state,
+    state_from_name,
+)
+
+GIS = Path(__file__).resolve().parents[1] / "app/api/gis.py"
+
+
+def poly(w, s, e, n):
+    return {"type": "Polygon", "coordinates": [[[w, s], [e, s], [e, n], [w, n], [w, s]]]}
+
+
+def collection(geometry, properties=None):
+    return {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": geometry, "properties": properties or {}}],
+    }
+
+
+MONTCLAIR_NJ = poly(-74.23, 40.79, -74.19, 40.83)
+
+
+# ---------------------------------------------------------------------------
+# The state comes from the coordinates
+# ---------------------------------------------------------------------------
+
+def says(code):
+    """A stand-in for the Census lookup that always answers `code`."""
+    async def lookup(lon, lat):
+        return code
+    return lookup
+
+
+async def unreachable(lon, lat):
+    """What an air-gapped deployment, or a Census outage, looks like."""
+    return None
+
+
+def resolved(boundary, saved=None, lookup=None):
+    return asyncio.run(resolve_state(boundary, saved, lookup=lookup or says("NJ")))
+
+
+def test_an_uploaded_file_with_no_state_in_it_resolves_from_its_coordinates():
+    """The bug. A county GIS export carries a FIPS code and nothing a name match
+    can use, so this used to fall through to the national layer."""
+    uploaded = collection(MONTCLAIR_NJ, {"NAME": "Montclair", "GEOID": "3400946260"})
+    assert resolved(uploaded) == "NJ"
+
+
+def test_the_search_path_resolves_the_same_way():
+    """Both routes in must end up at the same state. Before, only this one did,
+    and only because its name happened to contain "New Jersey"."""
+    osm = collection(MONTCLAIR_NJ, {"name": "Montclair, Essex County, New Jersey, United States"})
+    uploaded = collection(MONTCLAIR_NJ, {"GEOID": "3400946260"})
+    assert resolved(osm) == resolved(uploaded) == "NJ"
+
+
+def test_coordinates_beat_a_misleading_name():
+    """A name is a label. If the file says Texas and the shape is in New Jersey,
+    the shape is where the town is."""
+    misnamed = collection(MONTCLAIR_NJ, {"name": "Austin, Texas, United States"})
+    assert resolved(misnamed) == "NJ"
+
+
+def test_coordinates_beat_a_stale_saved_setting():
+    """A saved state can be left over from a boundary the town has replaced, and
+    nothing clears it when the boundary changes."""
+    assert resolved(collection(MONTCLAIR_NJ), saved="TX") == "NJ"
+
+
+def test_the_name_is_used_when_the_lookup_cannot_be_reached():
+    """An air-gapped deployment still gets the right answer for a boundary whose
+    name carries the state -- which is every boundary from the search."""
+    osm = collection(MONTCLAIR_NJ, {"name": "Montclair, Essex County, New Jersey, United States"})
+    assert asyncio.run(resolve_state(osm, None, lookup=unreachable)) == "NJ"
+
+
+def test_the_saved_setting_is_the_last_resort():
+    plain = collection(MONTCLAIR_NJ, {"GEOID": "3400946260"})
+    assert asyncio.run(resolve_state(plain, "nj", lookup=unreachable)) == "NJ"
+
+
+def test_nothing_to_go_on_is_none_rather_than_a_guess():
+    """It used to return the string "DEFAULT", which was then truncated into a
+    two-character column as "DE" -- so the roads page told towns their road
+    source was Delaware.
+
+    None is the honest answer, and it costs a town only the better local road
+    layer: the national fallback covers every state. A guessed neighbour would
+    hand it the wrong streets.
+    """
+    plain = collection(MONTCLAIR_NJ, {"GEOID": "3400946260"})
+    assert asyncio.run(resolve_state(plain, None, lookup=unreachable)) is None
+    assert asyncio.run(resolve_state(None, None, lookup=unreachable)) is None
+    # A full state name in the settings column is not a two-letter code and
+    # must never be passed to one.
+    assert asyncio.run(resolve_state(None, "New Jersey", lookup=unreachable)) is None
+
+
+def test_a_lookup_that_raises_does_not_take_the_seeding_down():
+    async def explodes(lon, lat):
+        raise RuntimeError("census unreachable")
+
+    osm = collection(MONTCLAIR_NJ, {"name": "Montclair, New Jersey"})
+    assert asyncio.run(resolve_state(osm, None, lookup=explodes)) == "NJ"
+
+
+def test_the_lookup_is_asked_about_the_middle_of_the_boundary():
+    seen = []
+
+    async def record(lon, lat):
+        seen.append((round(lon, 3), round(lat, 3)))
+        return "NJ"
+
+    asyncio.run(resolve_state(collection(MONTCLAIR_NJ), None, lookup=record))
+    assert seen == [(-74.21, 40.81)]
+
+
+def test_an_explicit_centre_is_preferred_over_the_bounding_box():
+    """The search path stores the centre it was given. For an L-shaped town the
+    box centre can sit outside the town; the stored one does not."""
+    boundary = collection(MONTCLAIR_NJ)
+    boundary["center"] = {"lat": 40.80, "lng": -74.22}
+    assert boundary_centre(boundary) == (-74.22, 40.80)
+
+
+def test_state_names_are_still_recognised():
+    assert state_from_name(collection(MONTCLAIR_NJ, {"name": "Trenton, New Jersey"})) == "NJ"
+    assert state_from_name(collection(MONTCLAIR_NJ, {"name": "montclair.geojson"})) is None
+
+
+def test_no_bounding_box_table_survives():
+    """A bbox test was tried and got eleven of twenty-six real towns wrong,
+    Montclair included -- state boxes overlap most where being wrong matters.
+    A plausible wrong state is worse here than none."""
+    source = (Path(__file__).resolve().parents[1] / "app/services/boundary_geo.py").read_text()
+    assert "STATE_BBOX" not in source
+
+
+def test_default_never_reaches_the_state_column():
+    source = (Path(__file__).resolve().parents[1] / "app/tasks/road_data.py").read_text()
+    assert '(state_code or "")[:2]' not in source, (
+        "truncating whatever arrived turns DEFAULT into DE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Every boundary path persists and seeds
+# ---------------------------------------------------------------------------
+
+def test_all_three_boundary_endpoints_go_through_one_helper():
+    """Uploading a file, picking a Census place and using the search all have to
+    end the same way: stored in settings, roads fetched. They did not."""
+    source = GIS.read_text()
+    assert "async def persist_boundary" in source
+    # Once per endpoint: upload, census, search.
+    assert source.count("await persist_boundary(") == 3, (
+        "a boundary endpoint is not going through the shared helper"
+    )
+
+
+def test_the_helper_stores_the_boundary_and_fetches_roads():
+    source = GIS.read_text()
+    helper = source[source.index("async def persist_boundary"):source.index("def normalize_boundary")]
+    assert "settings.township_boundary = boundary_data" in helper, "the boundary is not persisted"
+    assert "await db.commit()" in helper
+    assert "seed_roads" in helper, "roads are not fetched for the new boundary"
+
+
+def test_seeding_still_happens_without_a_celery_worker():
+    """A deployment with no worker should end up with roads rather than
+    silently not. Queuing is an optimisation, not the mechanism."""
+    source = GIS.read_text()
+    helper = source[source.index("async def persist_boundary"):source.index("def normalize_boundary")]
+    assert "seed_roads_for_boundary" in helper, "no inline fallback when the queue is unavailable"
+
+
+def test_the_old_in_memory_only_upload_is_gone():
+    """`upload_boundary` used to load the shape into a helper object and return
+    success, which is indistinguishable from having saved it."""
+    source = GIS.read_text()
+    upload = source[source.index("async def upload_boundary"):source.index("async def check_point_in_boundary")]
+    assert "persist_boundary" in upload, "an uploaded boundary is still not stored"

--- a/backend/tests/test_daily_connector_check.py
+++ b/backend/tests/test_daily_connector_check.py
@@ -1,0 +1,170 @@
+"""The daily sweep tests what is configured, and records what it finds.
+
+"The credentials are stored" is a fact about our own database and stays true
+forever. "The credentials work" is a fact about somebody else's service and
+stops being true without anyone here doing anything -- a secret expires, a card
+lapses, a departing employee's key is revoked.
+
+Before this, the only ways to find out were an admin pressing Test at a moment
+of their choosing, or a resident reporting that no email ever arrived.
+
+The three behaviours worth pinning, because each is a way the sweep could be
+actively worse than nothing:
+
+  * an unconfigured capability is left alone, so a town that never set up text
+    messages does not get an amber badge on something it switched off;
+  * "cannot be checked from here" is not recorded as a failure, because a red
+    badge that can never go green teaches people to ignore badges;
+  * a check that raises is recorded rather than aborting the sweep, so one
+    broken provider does not hide the state of the other seven.
+"""
+
+import asyncio
+
+import pytest
+
+# Deliberately no importorskip. The sweep's logic lives in a service that
+# imports neither FastAPI nor Celery, precisely so these run in CI -- which
+# installs four packages and would otherwise skip the whole file.
+from app.services.connector_verification import verify_all
+
+
+class FakeHealth:
+    """Stands in for connector_health, recording what it was told."""
+
+    def __init__(self):
+        self.successes = []
+        self.failures = []
+
+    async def record_success(self, db, connector, provider=None):
+        self.successes.append(connector)
+
+    async def record_failure(self, db, connector, error, provider=None):
+        self.failures.append((connector, str(error)))
+
+
+@pytest.fixture
+def sweep():
+    """Drive verify_all with a chosen set of checks and configured capabilities."""
+    health = FakeHealth()
+
+    def run(checks, configured):
+        async def is_configured(capability):
+            return capability in configured
+        summary = asyncio.run(
+            verify_all(None, checks=checks, is_configured=is_configured, health=health))
+        return summary, health
+
+    return run
+
+
+def ok(detail="fine"):
+    async def check(db=None):
+        return {"ok": True, "detail": detail}
+    return check
+
+
+def bad(detail="the key was rejected"):
+    async def check(db=None):
+        return {"ok": False, "detail": detail}
+    return check
+
+
+def unverifiable(detail="cannot be checked from here"):
+    async def check(db=None):
+        return {"ok": False, "detail": detail, "recorded": False}
+    return check
+
+
+def explodes(message="boom"):
+    async def check(db=None):
+        raise RuntimeError(message)
+    return check
+
+
+def test_a_working_connector_is_recorded_as_working(sweep):
+    result, health = sweep({"maps": ok()}, configured={"maps"})
+    assert result["checked"]["maps"] == "working"
+    assert health.successes == ["maps"]
+    assert health.failures == []
+    assert result["failing"] == []
+
+
+def test_a_broken_connector_is_recorded_with_the_providers_own_words(sweep):
+    """A clerk searching the web for their error needs the real string, not our
+    paraphrase of it."""
+    result, health = sweep({"email": bad("535 authentication failed")}, configured={"email"})
+    assert result["checked"]["email"] == "failing"
+    assert result["failing"] == ["email"]
+    assert health.failures == [("email", "535 authentication failed")]
+
+
+def test_an_unconfigured_capability_is_left_alone(sweep):
+    """The badge-noise case. Testing something a town deliberately switched off
+    writes a failure, and a page full of amber badges for things nobody wanted
+    is a page nobody reads."""
+    called = []
+
+    async def check(db=None):
+        called.append(True)
+        return {"ok": False, "detail": "not configured"}
+
+    result, health = sweep({"sms": check}, configured=set())
+    assert result["checked"]["sms"] == "not-configured"
+    assert called == [], "the sweep tested a capability nobody configured"
+    assert health.failures == []
+    assert result["failing"] == []
+
+
+def test_cannot_check_from_here_is_not_a_failure(sweep):
+    """Apple MapKit, ACS and a generic HTTP gateway genuinely cannot be verified
+    from the server. Recording those as failures produces a red badge that can
+    never go green, whatever the town does."""
+    result, health = sweep({"maps": unverifiable()}, configured={"maps"})
+    assert result["checked"]["maps"] == "unverifiable"
+    assert health.failures == []
+    assert health.successes == []
+    assert result["failing"] == []
+
+
+def test_one_exploding_check_does_not_hide_the_others(sweep):
+    """A sweep that aborts on the first raise reports nothing about the seven
+    connectors after it, which is the state it was meant to replace."""
+    result, health = sweep(
+        {"ai": explodes("provider SDK blew up"), "maps": ok(), "email": bad()},
+        configured={"ai", "maps", "email"},
+    )
+    assert result["checked"] == {"ai": "error", "maps": "working", "email": "failing"}
+    assert result["failing"] == ["ai", "email"]
+    assert health.successes == ["maps"]
+    assert any("provider SDK blew up" in err for _, err in health.failures)
+
+
+def test_an_unanswerable_configured_check_still_gets_tested():
+    """If we cannot tell whether something is configured, test it. A missed
+    check is worse than a redundant one, and the sweep must not propagate the
+    error either way -- it runs unattended."""
+    health = FakeHealth()
+
+    async def cannot_tell(capability):
+        raise RuntimeError("cannot reach the secret store")
+
+    result = asyncio.run(verify_all(
+        None, checks={"ai": explodes("provider SDK blew up")},
+        is_configured=cannot_tell, health=health))
+    assert result["checked"]["ai"] == "error"
+    assert health.failures
+
+
+def test_it_is_registered_to_run_daily():
+    """A task nothing schedules is a task that never runs, and the failure mode
+    is silence -- which is indistinguishable from everything being fine."""
+    pytest.importorskip("celery")
+    from app.core.celery_app import celery_app
+
+    schedule = celery_app.conf.beat_schedule
+    entry = schedule.get("daily-connector-check")
+    assert entry, f"not scheduled; have {sorted(schedule)}"
+    assert entry["task"] == "app.tasks.connector_checks.verify_connectors"
+    assert entry["schedule"] == 60 * 60 * 24
+    assert "app.tasks.connector_checks" in celery_app.conf.include

--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -7,16 +7,16 @@ choose your provider" -- and then wrote a test asserting the guide did NOT carry
 the steps, which locked the mistake in. A test can encode a misreading as firmly
 as it encodes a requirement.
 
-So the requirement, stated plainly: a clerk following this guide top to bottom
-never has to leave it. Each section that needs a credential renders the console
-walk and the boxes it fills, for the provider the questionnaire already
-established, with a Save & Test button.
+The requirement: a clerk works through this top to bottom without leaving it.
 
-There is still exactly one copy of the walk -- both the guide and the cards
-mount ProviderCredentialSteps over setupStepsContent.tsx. The thing the old test
-was really guarding, two hand-written copies drifting apart, is guarded by
-`test_the_guide_does_not_repeat_the_cards_console_steps` in
-test_setup_steps_content.py, which still passes and should keep passing.
+What is checked where. The grouping arithmetic -- which capabilities share a
+login, what order tasks come in, whether every item has somewhere to type -- is
+plain TypeScript in `setupPlan.ts` and is tested directly in
+`setupPlan.test.ts`, where the assertions can be about behaviour rather than
+about the text of a file. What is left here is the handful of invariants that
+really are properties of the source: that no handoff sentence has come back,
+that the wizard is what the page mounts, and that nothing anywhere promises a
+price or a duration.
 """
 
 import re
@@ -25,78 +25,90 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
-GUIDE = ROOT / "frontend/src/components/SetupIntegrationsPage.tsx"
-INLINE = ROOT / "frontend/src/components/InlineProviderSetup.tsx"
-SHARED = ROOT / "frontend/src/components/ProviderCredentialSteps.tsx"
-CARDS = ROOT / "frontend/src/components/ServiceProviders.tsx"
+FRONTEND = ROOT / "frontend/src/components"
+GUIDE = FRONTEND / "SetupIntegrationsPage.tsx"
+WIZARD = FRONTEND / "SetupWizard.tsx"
+PLAN = FRONTEND / "setupPlan.ts"
+INLINE = FRONTEND / "InlineProviderSetup.tsx"
+SHARED = FRONTEND / "ProviderCredentialSteps.tsx"
+CARDS = FRONTEND / "ServiceProviders.tsx"
+CONTENT = FRONTEND / "setupStepsContent.tsx"
+
+SETUP_SURFACE = (GUIDE, WIZARD, PLAN, INLINE, SHARED, CONTENT)
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        pytest.skip("frontend not present in this checkout")
+    return path.read_text()
 
 
 @pytest.fixture(scope="module")
 def guide() -> str:
-    if not GUIDE.exists():
-        pytest.skip("frontend not present in this checkout")
-    return GUIDE.read_text()
+    return _read(GUIDE)
 
 
 # ---------------------------------------------------------------------------
 # No handoffs
 # ---------------------------------------------------------------------------
 
-# The exact shapes the guide used to end its sections with. Any of these coming
-# back means a section has gone back to describing work that happens elsewhere.
 HANDOFF_PHRASES = (
     "Scroll to the",
     "card below and choose your",
-    "card further down the page and",
+    "card below, and press",
+    "Enter the bucket and keys in the",
 )
 
 
-def test_no_section_defers_to_a_card(guide):
+def test_no_section_defers_to_a_card():
     """A guide that says "go and do this somewhere else" is a table of contents.
 
-    The specific failure: someone reading step 2 of sign-in was sent three
-    thousand pixels down the page, to a card that then asked them again which
-    provider they wanted -- a question they had answered in the questionnaire at
-    the top of this very panel.
+    Someone reading step 2 of sign-in was sent three thousand pixels down the
+    page, to a card that then asked them again which provider they wanted -- a
+    question they had answered at the top of the very same panel.
     """
-    found = [p for p in HANDOFF_PHRASES if p in guide]
-    assert not found, (
-        f"the setup guide has gone back to pointing at the cards: {found}. "
-        "Sections that need a credential should mount InlineProviderSetup instead."
+    offenders = []
+    for path in (GUIDE, WIZARD, PLAN):
+        text = _read(path)
+        offenders += [f"{path.name}: {p}" for p in HANDOFF_PHRASES if p in text]
+    assert not offenders, (
+        f"the setup guide has gone back to pointing at the cards: {offenders}"
     )
 
 
-def test_every_credential_section_sets_up_inline(guide):
-    """Each capability a town can configure from the guide does it here.
-
-    Not an arbitrary list: these are the capabilities whose absence stops a town
-    taking a report or sending a reply. Redaction is included because a fresh
-    install blurs on this server and a town should be able to point that at a
-    cloud without hunting for a card.
-    """
-    expected = {"identity", "maps", "ai", "translation", "kms", "email", "sms", "redaction"}
-    mounted = set(re.findall(r'<InlineProviderSetup[^>]*?\scap="([a-z]+)"', guide))
-    missing = expected - mounted
-    assert not missing, f"no inline setup in the guide for: {sorted(missing)}"
+def test_the_page_mounts_the_wizard(guide):
+    assert "<SetupWizard" in guide
+    # And hands it everything it needs to do the work in place rather than
+    # describing it. Any of these missing is a silently half-wired panel.
+    for prop in ("isDone=", "onRefresh=", "publicOrigin=", "renderFoundation=", "onChooseProvider="):
+        assert prop in guide, f"the wizard is mounted without {prop}"
 
 
-def test_inline_setup_can_actually_save(guide):
-    """Boxes with no save button are a form that loses what you typed.
+def test_the_wizard_sets_providers_up_in_place():
+    wizard = _read(WIZARD)
+    assert "InlineProviderSetup" in wizard, "the wizard renders no credential boxes"
+    assert "PlainSecrets" in wizard, "settings with no provider card have nowhere to go"
 
-    Each call site has to pass onSaved through, or the progress chips
-    and "Done" badges at the top never move and the clerk cannot tell that
-    anything landed.
-    """
-    if not INLINE.exists():
-        pytest.skip("frontend not present in this checkout")
-    inline = INLINE.read_text()
-    assert "api.saveProvider" in inline, "the inline block cannot save"
-    assert "api.testProvider" in inline, "a save that is not verified is the failure this page exists to avoid"
-    assert "onSaved={onRefresh}" in guide, "saves in the guide never refresh the page's own status"
+
+def test_inline_setup_saves_and_then_verifies():
+    """A save that is not verified is the silent failure this page exists to
+    avoid, so the live test is part of saving rather than a second button."""
+    inline = _read(INLINE)
+    assert "api.saveProvider" in inline
+    assert "api.testProvider" in inline
+
+
+def test_the_wizard_only_advances_on_a_passing_test():
+    """Being moved along past a credential that does not work is worse than not
+    advancing at all: it reads as confirmation."""
+    wizard = _read(WIZARD)
+    assert "onSaved={onRefresh}" not in wizard, "advancing on save rather than on a passing test"
+    assert "verified &&" in wizard, "nothing gates the advance on the test result"
+    assert "advanceFrom" in wizard
 
 
 # ---------------------------------------------------------------------------
-# One copy of the walk, rendered twice
+# One copy of the walk, rendered in both places
 # ---------------------------------------------------------------------------
 
 def test_the_guide_and_the_cards_render_the_same_component():
@@ -105,34 +117,20 @@ def test_the_guide_and_the_cards_render_the_same_component():
     Last time this page carried two hand-written copies, the guide told towns
     Okta's issuer was their org URL while the card told them the opposite.
     """
-    if not (SHARED.exists() and CARDS.exists() and INLINE.exists()):
-        pytest.skip("frontend not present in this checkout")
     for path in (CARDS, INLINE):
-        assert "ProviderCredentialSteps" in path.read_text(), (
+        assert "ProviderCredentialSteps" in _read(path), (
             f"{path.name} renders setup steps without the shared component"
         )
-    # The shared component is the only place stepsFor is turned into markup.
-    assert "stepsFor" in SHARED.read_text()
+    assert "stepsFor" in _read(SHARED)
 
 
 # ---------------------------------------------------------------------------
-# Dynamic: the questionnaire actually drives what is shown
+# The questionnaire drives the page
 # ---------------------------------------------------------------------------
 
 def test_the_cloud_answer_picks_the_provider_rather_than_asking_again(guide):
-    """Asking "which cloud?" at the top is pointless if every section re-asks.
-
-    AI, translation and key management are cloud decisions, so they take the
-    answer. Email, SMS and redaction genuinely are not -- a town on Google may
-    well send through SES -- so those keep a picker seeded from the cloud.
-    """
     for derived in ("aiProvider", "emailProvider", "smsProvider", "redactionProvider"):
         assert f"const {derived} =" in guide, f"{derived} is not derived from the questionnaire"
-    assert 'cap="ai" provider={aiProvider}' in guide
-    assert 'cap="translation" provider={setupCloud}' in guide
-    assert 'cap="kms" provider={setupCloud}' in guide
-    assert 'cap="identity" provider={setupIdp}' in guide
-    assert 'cap="maps" provider={setupMaps}' in guide
 
 
 def test_changing_the_cloud_moves_the_email_and_sms_defaults(guide):
@@ -140,66 +138,94 @@ def test_changing_the_cloud_moves_the_email_and_sms_defaults(guide):
 
     Storing the resolved provider would freeze it: a town that picked Google,
     then switched to Azure at the top, would still be looking at SMTP with
-    nothing saying why. Holding "has the clerk overridden this?" instead lets
-    the default follow the cloud while a deliberate pick stays put.
+    nothing saying why.
     """
     assert "emailOverride ?? EMAIL_BY_CLOUD[setupCloud]" in guide
     assert "smsOverride ?? SMS_BY_CLOUD[setupCloud]" in guide
     assert "redactionOverride ?? setupCloud" in guide
 
 
-def test_every_extra_has_a_chip_and_every_chip_gates_something(guide):
-    """A feature in the list with no chip cannot be turned off; a chip that
-    gates nothing is a control that does nothing when clicked.
-
-    Both existed. `errors` (crash reporting) had a section that rendered
-    unconditionally and no chip at all, so the questionnaire's promise -- "untick
-    it to hide the guide again" -- was false for it.
-    """
+def test_every_extra_has_a_chip_and_every_chip_reaches_the_plan(guide):
+    """A feature with no chip cannot be turned off; a chip the plan ignores is a
+    control that does nothing when clicked."""
     features = set(re.findall(r"'([a-z]+)'", re.search(r"const ALL_FEATURES = \[(.*?)\]", guide, re.S).group(1)))
     chips = set(re.findall(r"\['([a-z]+)', '[^']+'\]", guide))
     assert features == chips, (
         f"features without a chip: {sorted(features - chips)}; "
         f"chips that are not features: {sorted(chips - features)}"
     )
-    ungated = [f for f in features if f"wants('{f}')" not in guide]
-    assert not ungated, f"ticking these changes nothing on the page: {sorted(ungated)}"
+    plan = _read(PLAN)
+    unused = [f for f in features if f"want('{f}')" not in plan]
+    assert not unused, f"ticking these changes nothing in the plan: {sorted(unused)}"
 
 
-def test_redaction_is_not_gated_on_the_moderation_tick(guide):
-    """They are different decisions and were sharing one switch.
+def test_screening_and_blurring_are_one_thing(guide):
+    """They were two panels about what is safe to publish, three sections apart,
+    and the second was hidden by the first one's tick."""
+    assert "'safety'" in guide, "no combined screening-and-blurring feature"
+    assert "'moderation'" not in guide, "the old separate moderation tick is back"
+    assert "safety: 'redaction'" in guide
 
-    Unticking "content moderation" silently hid face blurring, and there was no
-    way to have blurring without it -- which matters because moderation screens
-    what a resident wrote and redaction blurs a bystander who wrote nothing.
+
+# ---------------------------------------------------------------------------
+# Callback URLs point at the real site
+# ---------------------------------------------------------------------------
+
+def test_callback_urls_use_the_configured_domain(guide):
+    """`window.location.origin` is wherever the admin happens to be -- an
+    internal hostname, a port-forward, an IP. A redirect URI registered from one
+    of those can never be redirected to, and the login then fails after the
+    password is accepted, which reads as a wrong secret rather than a wrong URL.
     """
-    assert "show={wants('redaction')}" in guide, "redaction has no tick of its own"
-    assert "redaction: 'redaction'" in guide, "the redaction capability is not mapped to its own feature"
-    assert "moderation: 'redaction'" not in guide, "redaction is still riding on the moderation tick"
+    assert "public_origin" in guide, "the page never asks the server for its real address"
+    inline = _read(INLINE)
+    assert "publicOrigin || window.location.origin" in inline, (
+        "the steps still build callback URLs from the browser's address"
+    )
+
+
+def test_the_backend_serves_the_real_origin():
+    system = (ROOT / "backend/app/api/system.py").read_text()
+    assert "async def public_origin" in system
+    assert '"public_origin"' in system
 
 
 # ---------------------------------------------------------------------------
-# Settings with no card still get boxes
+# No promises about price, speed or difficulty
 # ---------------------------------------------------------------------------
 
-# Keys the guide used to print as bare environment-variable names in the middle
-# of a sentence. That is not an instruction a clerk can act on -- it reads as
-# something to hand to IT, and it was the only place on this page that asked
-# somebody to go and edit a file.
-KEYS_THAT_NEED_A_BOX = (
-    "AZURE_CONTENT_SAFETY_ENDPOINT",
-    "AZURE_CONTENT_SAFETY_KEY",
-    "SENTRY_DSN",
+# A town's procurement officer reads this page too. A free tier can change
+# without notice, and telling a clerk something takes ten minutes is a way of
+# making them feel slow when it takes forty.
+CLAIMS = re.compile(
+    r"\b(free tier|for free|no cost|costs? (?:only|about|around)|"
+    r"\$\d|per month|a few dollars|cents? per|a cent per|"
+    r"about \d+ minutes?|takes \d+|in (?:under )?\d+ minutes?|"
+    r"quickest|fastest|easiest|simplest|it is easy|very easy)\b",
+    re.I,
 )
 
 
-def test_settings_without_a_provider_card_still_have_inputs(guide):
-    for key in KEYS_THAT_NEED_A_BOX:
-        assert f"key: '{key}'" in guide, f"{key} is named in the guide but has no box to type it into"
+def test_nothing_promises_a_price_a_duration_or_that_it_is_easy():
+    offenders = []
+    for path in SETUP_SURFACE:
+        for n, line in enumerate(_read(path).splitlines(), 1):
+            if line.lstrip().startswith(("*", "//", "/*")):
+                continue  # commentary to maintainers, not copy shown to a clerk
+            for hit in CLAIMS.findall(line):
+                offenders.append(f"{path.name}:{n} {hit!r}")
+    assert not offenders, "claims about cost, speed or difficulty:\n" + "\n".join(offenders)
 
 
-def test_the_guide_does_not_tell_anyone_to_set_an_environment_variable(guide):
-    """MODERATION_PROVIDER was printed as something to "set", with no box and no
-    explanation of where. It is derived from the cloud answer, so nobody should
-    be asked to set it at all."""
-    assert "MODERATION_PROVIDER" not in guide
+def test_the_guide_no_longer_carries_time_and_cost_labels(guide):
+    """Every section used to be introduced by an estimate and a price."""
+    assert "cost=" not in guide
+    assert "time=" not in guide
+
+
+def test_esri_is_offered_rather_than_pushed():
+    """The maps step led with "ask your GIS department before you buy anything"
+    and told towns to pick Esri. It is one of four reasonable options."""
+    guide_text = _read(GUIDE)
+    assert "before you buy anything" not in guide_text
+    assert "choose Esri above" not in guide_text

--- a/frontend/src/components/InlineProviderSetup.tsx
+++ b/frontend/src/components/InlineProviderSetup.tsx
@@ -39,7 +39,7 @@ function probeIdentity(): Promise<CloudIdentity | null> {
 }
 
 export default function InlineProviderSetup({
-    cap, provider, choices, onChoose, onSaved, note,
+    cap, provider, choices, onChoose, onSaved, note, publicOrigin,
 }: {
     cap: Capability;
     /** The provider to set up, from the questionnaire. */
@@ -49,10 +49,16 @@ export default function InlineProviderSetup({
      *  Omitted means the questionnaire already decided and this shows no picker. */
     choices?: { id: string; label: string }[];
     onChoose?: (id: string) => void;
-    /** Tell the page a save landed, so progress chips and "Done" badges move. */
-    onSaved?: () => void;
+    /** Told whether the live test passed, not merely that a save happened.
+     *  The wizard advances on this, and moving somebody past a credential that
+     *  does not work is the whole failure mode being designed out. */
+    onSaved?: (verified: boolean) => void;
     /** A sentence above the steps, where the choice needs explaining. */
     note?: React.ReactNode;
+    /** The address residents use, for callback URLs pasted into a vendor
+     *  console. null means nothing has configured a domain, so the steps fall
+     *  back to this browser's origin and say so. */
+    publicOrigin?: string | null;
 }) {
     const [catalog, setCatalog] = useState<ProviderCatalog | null>(null);
     const [identity, setIdentity] = useState<CloudIdentity | null>(null);
@@ -64,7 +70,7 @@ export default function InlineProviderSetup({
     const [copied, setCopied] = useState<string | null>(null);
 
     const ctx: StepContext = {
-        origin: window.location.origin,
+        origin: publicOrigin || window.location.origin,
         copy: (text, id) => {
             navigator.clipboard?.writeText(text).then(
                 () => { setCopied(id); setTimeout(() => setCopied(null), 1600); },
@@ -100,25 +106,28 @@ export default function InlineProviderSetup({
 
     if (error) {
         return (
-            <div className="ml-9 rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-200 flex items-start gap-2">
+            <div className="rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-200 flex items-start gap-2">
                 <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
                 <span>{error} You can still set this up on the card further down the page.</span>
             </div>
         );
     }
     if (!catalog) {
-        return <div className="ml-9 h-20 rounded-lg bg-white/[0.03] animate-pulse" aria-busy="true" />;
+        return <div className="h-20 rounded-lg bg-white/[0.03] animate-pulse" aria-busy="true" />;
     }
 
     const active: ProviderInfo | undefined = catalog.providers.find(p => p.provider === provider);
     if (!active) {
         return (
-            <div className="ml-9 rounded-lg border border-amber-400/25 bg-amber-500/[0.07] px-3 py-2 text-xs text-amber-100/80">
+            <div className="rounded-lg border border-amber-400/25 bg-amber-500/[0.07] px-3 py-2 text-xs text-amber-100/80">
                 This deployment does not offer that option. Use the card further down the page to pick one it does.
             </div>
         );
     }
 
+    // Only identity hands out a redirect URI, so only identity needs the
+    // warning; showing it above an API-key box would be noise.
+    const needsCallbackUrl = cap === 'identity';
     const alreadySet = catalog.configured?.[provider] === true;
     const isCurrent = catalog.current_provider === provider;
 
@@ -140,18 +149,37 @@ export default function InlineProviderSetup({
             // Save and verify are one action here. A guide that says "saved"
             // and leaves a clerk to discover later that the key was wrong is
             // the failure this whole page exists to avoid.
-            setResult(await api.testProvider(cap));
-            onSaved?.();
+            const verified = await api.testProvider(cap);
+            setResult(verified);
+            onSaved?.(verified.ok);
         } catch (e: any) {
             setResult({ ok: false, detail: e?.message || 'Save failed' });
+            onSaved?.(false);
         } finally {
             setBusy(null);
         }
     };
 
     return (
-        <div className="ml-9 rounded-xl border border-white/10 bg-white/[0.03] p-3.5">
+        <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3.5">
             {note && <p className="text-xs text-white/50 leading-relaxed mb-3">{note}</p>}
+
+            {/* A callback URL is the one value on this page that has to match
+                something outside it exactly. If nobody has told Pinpoint its own
+                address, the steps below are quoting this browser's -- fine on a
+                laptop pointed at the real site, wrong from an internal
+                hostname, and the resulting failure looks like a bad password. */}
+            {!publicOrigin && needsCallbackUrl && (
+                <div className="mb-3 rounded-lg border border-amber-400/25 bg-amber-500/[0.07] px-3 py-2 flex items-start gap-2">
+                    <AlertCircle className="w-3.5 h-3.5 text-amber-300/80 mt-0.5 shrink-0" aria-hidden="true" />
+                    <p className="text-[11px] text-amber-100/80 leading-relaxed">
+                        The address below is the one you are using right now
+                        (<code className="bg-black/30 px-1 rounded">{window.location.origin}</code>).
+                        If residents reach this site at a different address, set the town's domain in
+                        Settings first — the address you register here has to be the one they use.
+                    </p>
+                </div>
+            )}
 
             {choices && choices.length > 1 && (
                 <div className="flex flex-wrap gap-2 mb-3.5">

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -32,13 +32,13 @@ function agoLabel(epochSeconds?: number | null): string {
 import type { Capability } from '../services/api';
 
 const CAPS: { key: Capability; title: string; blurb: string; icon: typeof Sparkles }[] = [
-    { key: 'ai', title: 'AI Provider', blurb: 'Where AI triage & the analytics assistant run. Each town brings its own key and pays only for what it uses.', icon: Sparkles },
+    { key: 'ai', title: 'AI Provider', blurb: 'Where AI triage and the analytics assistant run. Each town brings its own key.', icon: Sparkles },
     { key: 'translation', title: 'Translation Provider', blurb: 'Powers end-to-end translation across 100+ languages.', icon: Languages },
     { key: 'identity', title: 'Staff Sign-In (Identity)', blurb: 'The identity provider that authenticates staff and admins.', icon: KeyRound },
     // Maps is a capability like the rest, so switching one works the same way
     // as switching an AI or translation provider -- same card, same save, same
     // test button. A separate picker elsewhere would be a second thing to learn.
-    { key: 'maps', title: 'Maps Provider', blurb: 'Draws the map residents drop a pin on, and looks up addresses. Google is the simplest to set up; Esri suits a town whose county already publishes its own basemap.', icon: MapIcon },
+    { key: 'maps', title: 'Maps Provider', blurb: 'Draws the map residents drop a pin on, and looks up addresses.', icon: MapIcon },
     // Four capabilities whose provider switch the backend already honoured and
     // nothing surfaced. Email and text had one hand-written SMTP/Twilio card
     // between them; PII encryption and photo redaction had no UI at all, so
@@ -72,50 +72,44 @@ function Step({ n, children, aside }: { n: number; children: React.ReactNode; as
     );
 }
 
-/** The live-state pill shown next to "Configured".
+/** Whether it works, and when we last had evidence either way.
  *
- * Deliberately a second, separate badge. "Configured" is a fact about our own
- * database -- the credentials are stored -- and "working" is a fact about
- * someone else's service. Merging them into one badge forces the case where we
- * genuinely do not know to pick a colour, and it always picks green, which is
- * how a revoked key keeps a healthy tick for a month.
- *
- * So "unknown" is shown as unknown. It is not a failure and it is not success;
- * it means nothing has called this connector yet.
+ * The card used to show "Configured", which is a fact about our own database:
+ * it goes green the moment a credential is saved and stays green through the
+ * key being revoked, the card on file lapsing and the secret expiring. This
+ * answers the question a clerk is actually asking, and says how old the answer
+ * is -- because "working, checked three weeks ago" and "working, checked this
+ * morning" are different claims and only one of them is worth much.
  */
-function HealthPill({ health }: { health?: ConnectorHealth }) {
+function LiveState({ health }: { health?: ConnectorHealth }) {
     if (!health || health.status === 'unknown') {
-        return (
-            <span
-                className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[10px] font-medium bg-white/[0.06] text-white/50 border border-white/12"
-                title="Nothing has used this connector yet, so we cannot say whether it works."
-            >
-                <span className="w-1.5 h-1.5 rounded-full bg-white/35" aria-hidden="true" />
-                Not used yet
-            </span>
-        );
+        return <span className="text-white/40">not checked yet</span>;
     }
-    const tone = {
-        working: 'bg-emerald-500/15 text-emerald-300 border-emerald-400/25',
-        stale: 'bg-white/[0.06] text-white/55 border-white/12',
-        failing: 'bg-amber-500/15 text-amber-300 border-amber-400/25',
-        down: 'bg-red-500/15 text-red-300 border-red-400/30',
-    }[health.status];
-    const dot = {
-        working: 'bg-emerald-400', stale: 'bg-white/40',
-        failing: 'bg-amber-400', down: 'bg-red-400',
-    }[health.status];
-    const label = {
-        working: 'Working', stale: 'No recent use',
-        failing: 'Last call failed', down: `Failing (${health.consecutive_failures})`,
-    }[health.status];
+    const when = health.status === 'working' ? health.last_success_at : health.last_error_at;
+    const ago = when ? relativeTime(when) : null;
+    const [text, tone] = {
+        working: ['working', 'text-emerald-300/90'],
+        stale: ['not used recently', 'text-white/45'],
+        failing: ['last check failed', 'text-amber-300/90'],
+        down: [`failing (${health.consecutive_failures} in a row)`, 'text-red-300/90'],
+    }[health.status] as [string, string];
     return (
-        <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-[10px] font-medium border ${tone}`}
-              title={health.summary}>
-            <span className={`w-1.5 h-1.5 rounded-full ${dot}`} aria-hidden="true" />
-            {label}
+        <span className={tone} title={health.last_error || health.summary}>
+            {text}{ago ? <span className="text-white/35"> · checked {ago}</span> : null}
         </span>
     );
+}
+
+/** "6 hours ago" from an ISO timestamp. */
+function relativeTime(iso: string): string {
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return '';
+    const mins = Math.max(0, Math.round((Date.now() - then) / 60000));
+    if (mins < 2) return 'just now';
+    if (mins < 90) return `${mins} minutes ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 36) return `${hrs} hours ago`;
+    return `${Math.round(hrs / 24)} days ago`;
 }
 
 export interface CapStatus {
@@ -295,13 +289,11 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
      *
      * `undefined` means the endpoint did not tell us, which is not the same as
      * "no". Three capabilities used to omit this map entirely and every one of
-     * their cards claimed "Not configured" on a working connector -- so an
-     * absent answer now renders as unknown rather than as a confident negative,
-     * and the card cannot lie in that direction again if a future capability
-     * forgets to send it. */
+     * their cards claimed "Not configured" on a working connector. The status
+     * line now leads with what the last live check found, so an absent answer
+     * reads as "not checked yet" rather than as a confident negative. */
     const configuredState = catalog.configured?.[catalog.current_provider];
     const configured = configuredState === true;
-    const statusUnknown = configuredState === undefined;
     // null means "not touched yet", so an unconfigured card starts open and a
     // configured one starts closed, without overriding a deliberate click.
     /* In guided setup the parent's cursor wins until the clerk clicks a
@@ -356,73 +348,88 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay, duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
-            className={`relative overflow-hidden rounded-3xl border p-6 transition-all duration-300 ${configured
-                ? 'bg-gradient-to-br from-green-500/10 via-emerald-500/5 to-teal-500/10 border-green-500/30 shadow-lg shadow-green-500/10'
-                : 'setup-panel border-transparent'}`}
+            /* The handcrafted card template, the same one the rest of the
+               console uses, rather than a green wash unique to this page. The
+               wash was doing a job the status line does better and said the
+               same thing three times -- tile, tint and badge all meaning
+               "configured", which is the least interesting fact here. */
+            className="premium-card overflow-hidden p-5"
         >
-            {configured && (
-                <div className="absolute inset-0 bg-gradient-to-r from-green-500/5 via-transparent to-emerald-500/5 pointer-events-none" aria-hidden="true" />
-            )}
 
             <div className="relative">
                 {/* Header — same shape as every other connector card: a large
                     gradient icon tile, the name, and a status pill on the right. */}
-                <button
-                    type="button"
-                    onClick={() => setOpen(v => (v === null ? !isOpen : !v))}
-                    aria-expanded={isOpen}
-                    aria-controls={`prov-${cap}`}
-                    className="w-full flex items-start justify-between gap-4 flex-wrap text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
-                >
-                    <div className="flex items-center gap-4 min-w-0">
-                        <div className={`relative w-14 h-14 shrink-0 rounded-2xl flex items-center justify-center transition-all duration-300 ${configured
-                            ? 'bg-gradient-to-br from-green-400 to-emerald-500 shadow-lg shadow-green-500/30'
-                            : 'setup-tile'}`}>
-                            {configured ? <Check className="w-7 h-7 text-white" /> : <Icon className="w-7 h-7 text-white" />}
+                {/* Not one big button any more. "Test now" has to be its own
+                    control, and a button cannot live inside a button -- nesting
+                    them produces markup browsers silently restructure and
+                    screen readers announce wrongly. */}
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <button
+                        type="button"
+                        onClick={() => setOpen(v => (v === null ? !isOpen : !v))}
+                        aria-expanded={isOpen}
+                        aria-controls={`prov-${cap}`}
+                        className="flex items-center gap-3.5 min-w-0 flex-1 text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
+                    >
+                        <div className="setup-tile relative w-11 h-11 shrink-0 rounded-xl flex items-center justify-center">
+                            <Icon className="w-5 h-5 text-white" />
                             {guided && step && !configured && (
-                                <span className="absolute -top-1.5 -left-1.5 w-6 h-6 rounded-full bg-primary-500 border-2 border-slate-900 text-[11px] font-bold text-white flex items-center justify-center">
+                                <span className="absolute -top-1.5 -left-1.5 w-5 h-5 rounded-full bg-primary-500 border-2 border-slate-900 text-[10px] font-bold text-white flex items-center justify-center">
                                     {step.index + 1}
                                 </span>
                             )}
                         </div>
                         <div className="min-w-0">
-                            <h3 className="font-bold text-lg text-white leading-tight">{title}</h3>
-                            <p className="text-white/50 text-sm truncate">
-                                {currentName}
-                                {cap === 'ai' && catalog.current_model ? ` · ${catalog.current_model}` : ''}
+                            <h3 className="font-semibold text-white leading-tight truncate">{title}</h3>
+                            {/* The one line worth reading at a glance: which
+                                provider, whether it works, and when we last had
+                                evidence. "Configured" answered none of those --
+                                it only ever meant a row exists in our database. */}
+                            <p className="text-white/45 text-xs truncate mt-0.5">
+                                {configured
+                                    ? <>
+                                        {currentName}
+                                        {cap === 'ai' && catalog.current_model ? ` · ${catalog.current_model}` : ''}
+                                        {' · '}<LiveState health={health} />
+                                      </>
+                                    : 'Not set up yet'}
                             </p>
                         </div>
-                    </div>
-                    <div className="flex items-center gap-2.5 shrink-0">
-                        {/* Live state sits beside stored-credentials state, not
-                            instead of it. They answer different questions and a
-                            clerk needs both: "we have the key" and "the key
-                            works" diverge exactly when it matters. */}
-                        {configured && <HealthPill health={health} />}
-                        {configured ? (
-                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-2xl text-xs font-semibold bg-gradient-to-r from-green-500/20 to-emerald-500/20 text-green-300 border border-green-500/30 shadow-lg shadow-green-500/10">
-                                <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                                Configured
-                            </span>
-                        ) : statusUnknown ? (
-                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/60 border border-white/20">
-                                Status unknown
-                            </span>
-                        ) : (
-                            <span className="inline-flex items-center px-3 py-1.5 rounded-2xl text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30">
-                                Not configured
-                            </span>
+                    </button>
+                    <div className="flex items-center gap-2 shrink-0">
+                        {/* Only offered once there is something to test.
+                            Pressing it on an empty card would report a missing
+                            credential as a failure, which is true and useless. */}
+                        {configured && (
+                            <button
+                                type="button"
+                                onClick={handleTest}
+                                disabled={busy !== null}
+                                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-white/80 hover:text-white bg-white/[0.07] hover:bg-white/[0.13] border border-white/15 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
+                            >
+                                {busy === 'test'
+                                    ? <><Loader2 className="w-3 h-3 animate-spin" /> Testing…</>
+                                    : 'Test now'}
+                            </button>
                         )}
-                        <motion.span
-                            animate={{ rotate: isOpen ? 180 : 0 }}
-                            transition={{ duration: 0.25 }}
-                            className="text-white/40"
-                            aria-hidden="true"
+                        <button
+                            type="button"
+                            onClick={() => setOpen(v => (v === null ? !isOpen : !v))}
+                            aria-expanded={isOpen}
+                            aria-controls={`prov-${cap}`}
+                            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-white/70 hover:text-white hover:bg-white/[0.08] border border-transparent hover:border-white/15 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
                         >
-                            <ChevronDown className="w-4 h-4" />
-                        </motion.span>
+                            {isOpen ? 'Close' : configured ? 'Edit' : 'Set up'}
+                            <motion.span
+                                animate={{ rotate: isOpen ? 180 : 0 }}
+                                transition={{ duration: 0.25 }}
+                                aria-hidden="true"
+                            >
+                                <ChevronDown className="w-3.5 h-3.5" />
+                            </motion.span>
+                        </button>
                     </div>
-                </button>
+                </div>
 
                 <p className="text-white/60 text-sm mb-4">{blurb}</p>
 

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -2,12 +2,10 @@ import { useState, useEffect, useRef } from 'react';
 
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-    Key, Shield, Cloud, MessageSquare, Mail, CheckCircle,
+    Key, Shield, Cloud, CheckCircle,
     AlertCircle, ChevronDown, ChevronUp,
     ExternalLink, AlertTriangle, Database, BookOpen,
-    ListChecks, HardDrive, MapPin,
-    Sparkles, Languages, Lock, Image as ImageIcon, Landmark,
-    Clock, DollarSign, Bell,
+    ListChecks, HardDrive, Bell,
 } from 'lucide-react';
 
 import { Card, Button, Input, Badge, CollapsibleSection } from './ui';
@@ -16,8 +14,7 @@ import { api } from '../services/api';
 import type { Capability } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
-import InlineProviderSetup from './InlineProviderSetup';
-import SecretField from './SecretField';
+import SetupWizard from './SetupWizard';
 // Registers every provider's setup steps as a side effect, so the guide can
 // render them inline rather than pointing at the cards that do.
 import './setupStepsContent';
@@ -75,7 +72,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * up with the whole platform switched on, not the three we happened to
      * pre-tick -- so the list below is every feature, and a town removes what
      * it genuinely does not want. */
-    const ALL_FEATURES = ['ai', 'translation', 'moderation', 'redaction', 'email', 'sms', 'secrets', 'govtech', 'backups', 'errors'];
+    const ALL_FEATURES = ['ai', 'translation', 'safety', 'email', 'sms', 'secrets', 'govtech', 'backups', 'errors'];
     const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(new Set(ALL_FEATURES));
     const toggleFeature = (f: string) =>
         setWantedFeatures(prev => {
@@ -115,6 +112,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const smsProvider = smsOverride ?? SMS_BY_CLOUD[setupCloud];
     const redactionProvider = redactionOverride ?? setupCloud;
 
+    /** A picker inside the wizard writing back to the questionnaire's state. */
+    const chooseProvider = (key: 'email' | 'sms' | 'redaction' | 'maps' | 'idp', id: string) => {
+        if (key === 'email') setEmailOverride(id);
+        else if (key === 'sms') setSmsOverride(id);
+        else if (key === 'redaction') setRedactionOverride(id);
+        else if (key === 'maps') setSetupMaps(id as typeof setupMaps);
+        else if (key === 'idp') setSetupIdp(id as typeof setupIdp);
+    };
+
     /* The setup questions are asked in feature terms ("AI triage", "Secret
      * storage + PII encryption") and the provider cards are keyed by
      * capability. This is the one mapping between them. `secrets` covers the
@@ -128,7 +134,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * bystander who never wrote anything -- so they are now separate ticks. */
     const FEATURE_TO_CAPABILITY: Record<string, Capability> = {
         ai: 'ai', translation: 'translation', email: 'email',
-        sms: 'sms', secrets: 'kms', redaction: 'redaction',
+        sms: 'sms', secrets: 'kms', safety: 'redaction',
     };
     const wantedCapabilities = new Set<Capability>(
         Object.entries(FEATURE_TO_CAPABILITY)
@@ -140,10 +146,23 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     // Managed (state-hosted) mode: infrastructure cards are locked because the
     // state's orchestrator owns those keys (Google Cloud, Backups, domain).
     const [managedMode, setManagedMode] = useState(false);
+    /* The address residents actually use, for the callback URLs the setup steps
+     * tell an admin to paste into a vendor console.
+     *
+     * Not window.location.origin, which is wherever the admin happens to be
+     * -- an internal hostname, a port-forward, an IP. A redirect URI registered
+     * from one of those can never be redirected to, and the login then fails
+     * after the password is accepted, which looks like a wrong secret rather
+     * than a wrong URL. null means nothing has configured a domain yet, and the
+     * browser's origin is the best guess available. */
+    const [publicOrigin, setPublicOrigin] = useState<string | null>(null);
     useEffect(() => {
         fetch('/api/system/config')
             .then(r => (r.ok ? r.json() : null))
-            .then(cfg => setManagedMode(!!cfg?.managed_mode))
+            .then(cfg => {
+                setManagedMode(!!cfg?.managed_mode);
+                setPublicOrigin(cfg?.public_origin ?? null);
+            })
             .catch(() => setManagedMode(false));
     }, []);
 
@@ -211,6 +230,32 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     // so it counts as set up once a detector has been chosen.
     const redactionConfigured = isConfigured('REDACTION_PROVIDER');
 
+    /* Whether one wizard item is already set up.
+     *
+     * Reuses the flags computed above rather than fetching eight catalogs to
+     * fill in a list of ticks -- the answer is already in `secrets`, which the
+     * page has loaded anyway. Anything not listed is treated as unfinished,
+     * which is the safe direction: an item wrongly shown as done is one nobody
+     * ever opens.
+     */
+    const DONE_BY_ITEM: Record<string, boolean> = {
+        identity: !!signInConfigured,
+        maps: !!mapsConfigured,
+        ai: !!aiConfigured,
+        translation: !!translationConfigured,
+        kms: !!kmsConfigured,
+        safety: !!redactionConfigured,
+        email: !!smtpConfigured,
+        sms: smsConfigured,
+        backups: !!backupConfigured,
+        errors: !!sentryConfigured,
+        // The connector wizard lives in its own component and reports no single
+        // "configured" flag, so this never marks itself finished. Optional, and
+        // a town that has not connected anything has not got it wrong.
+        govtech: false,
+    };
+    const itemDone = (id: string) => DONE_BY_ITEM[id] ?? false;
+
     // Setup progress calculation. In managed mode the platform-managed steps
     // (Google Cloud, DB Backups) are excluded — the state handles them, so
     // counting them would leave progress permanently "incomplete".
@@ -269,56 +314,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         </div>
     );
 
-    /* Boxes for settings that belong to no provider card.
-     *
-     * Most of this page's credentials hang off a capability with a catalog, so
-     * InlineSetup covers them. A few do not -- Azure's Content Safety pair, the
-     * Sentry DSN -- and those were being printed as bare environment-variable
-     * names in the middle of a sentence, which is not an instruction a clerk
-     * can act on. It reads as something to hand to IT, and it is the only place
-     * on the page that asks somebody to go and edit a file.
-     *
-     * They are ordinary settings with ordinary boxes, so they get ordinary
-     * boxes, saved the same way as everything else here. */
-    const PlainSecrets = ({ fields }: {
-        fields: { key: string; label: string; secret?: boolean; help?: string }[];
-    }) => {
-        const pending = fields.filter(f => secretValues[f.key]);
-        return (
-            <div className="ml-9 rounded-xl border border-white/10 bg-white/[0.03] p-3.5">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
-                    {fields.map(f => (
-                        <SecretField
-                            key={f.key}
-                            label={f.label}
-                            secret={f.secret}
-                            help={f.help}
-                            savedHint={!!isConfigured(f.key)}
-                            value={secretValues[f.key] || ''}
-                            onChange={(v) => setSecretValues(prev => ({ ...prev, [f.key]: v }))}
-                        />
-                    ))}
-                </div>
-                <div className="flex flex-wrap items-center gap-2.5 mt-3 pt-3 border-t border-white/[0.07]">
-                    <button
-                        type="button"
-                        onClick={async () => { for (const f of pending) await handleSave(f.key); }}
-                        disabled={pending.length === 0 || savingKey !== null}
-                        className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
-                    >
-                        {savingKey ? 'Saving…' : 'Save'}
-                    </button>
-                    {fields.every(f => isConfigured(f.key)) && (
-                        <span className="text-[11px] text-emerald-300/80 inline-flex items-center gap-1.5">
-                            <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
-                            Already saved — leave a box blank to keep what is stored.
-                        </span>
-                    )}
-                </div>
-            </div>
-        );
-    };
-
     /* Sections that need a credential mount InlineProviderSetup directly --
      * not through a wrapper defined in here. A component declared during render
      * is a fresh type on every render, so React unmounts and remounts it, and
@@ -342,78 +337,59 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         </div>
     );
 
-    /* A term worth glossing inline. Hovering is not discoverable, so the plain
-     * meaning goes in parentheses right there in the sentence. */
-    const Term = ({ children, means }: { children: React.ReactNode; means: string }) => (
-        <span>
-            <strong className="text-white/90">{children}</strong>
-            <span className="text-white/45"> ({means})</span>
-        </span>
-    );
-
-    // Static tone classes (kept literal so Tailwind doesn't purge them).
-    const TONES: Record<string, { box: string; icon: string }> = {
-        orange: { box: 'border-orange-500/20 bg-orange-500/5', icon: 'text-orange-400' },
-        violet: { box: 'border-violet-500/20 bg-violet-500/5', icon: 'text-violet-400' },
-        blue: { box: 'border-blue-500/20 bg-blue-500/5', icon: 'text-blue-400' },
-        emerald: { box: 'border-emerald-500/20 bg-emerald-500/5', icon: 'text-emerald-400' },
-        amber: { box: 'border-amber-500/20 bg-amber-500/5', icon: 'text-amber-400' },
-        sky: { box: 'border-sky-500/20 bg-sky-500/5', icon: 'text-sky-400' },
-        rose: { box: 'border-rose-500/20 bg-rose-500/5', icon: 'text-rose-400' },
-        cyan: { box: 'border-cyan-500/20 bg-cyan-500/5', icon: 'text-cyan-400' },
-    };
-    /* A single guide block; renders nothing unless `show` is true.
+    /* The account itself, before anything is created inside it.
      *
-     * `what`, `time` and `cost` exist because the person doing this is usually a
-     * clerk who was handed the job, not an engineer. Before a numbered list is
-     * any use they need to know what they are about to sign the town up for:
-     * what it actually does, roughly how long it takes, and whether it costs
-     * money. Without that, "create a service account" is just alarming.
-     *
-     * `time` is honest-to-slow. Being told 10 minutes and taking 40 is worse
-     * than being told 30.
+     * This belongs to no single capability -- a project, a resource group, an
+     * IAM identity are the thing every other item in a cloud task sits inside.
+     * The wizard shows it once at the top of that task, which is the whole
+     * reason for grouping by login: it used to be repeated, in slightly
+     * different words, in each of the four sections that needed it.
      */
-    const Guide = ({ show = true, tone, icon: Icon, title, done, what, time, cost, children }: {
-        show?: boolean; tone: string; icon: React.ElementType; title: string;
-        done?: boolean; what?: React.ReactNode; time?: string; cost?: string;
-        children: React.ReactNode;
-    }) => {
-        if (!show) return null;
-        const t = TONES[tone] || TONES.blue;
-        return (
-            <div className={`rounded-xl border p-4 ${t.box}`}>
-                <div className="flex items-center gap-2 mb-2 flex-wrap">
-                    <Icon className={`w-4 h-4 ${t.icon}`} />
-                    <h4 className="font-semibold text-white text-sm">{title}</h4>
-                    {done && <Badge variant="success">Done</Badge>}
-                </div>
-                {what && <p className="text-xs text-white/55 leading-relaxed mb-2">{what}</p>}
-                {/* Stacked and top-aligned. The cost note is often a sentence
-                    rather than a figure -- the Google "you still need a card on
-                    file" caveat especially -- and a wrapped second line running
-                    back to the margin read as a separate item. */}
-                {(time || cost) && (
-                    <div className="flex flex-col gap-1 mb-3 text-[11px]">
-                        {time && (
-                            <span className="flex items-start gap-1.5 text-white/50">
-                                <Clock className="w-3 h-3 shrink-0 mt-0.5" aria-hidden="true" />
-                                <span>{time}</span>
-                            </span>
-                        )}
-                        {cost && (
-                            <span className="flex items-start gap-1.5 text-white/50">
-                                <DollarSign className="w-3 h-3 shrink-0 mt-0.5" aria-hidden="true" />
-                                <span>{cost}</span>
-                            </span>
-                        )}
-                    </div>
-                )}
-                <div className="space-y-2.5">{children}</div>
-            </div>
-        );
-    };
-
-    const cloudLabel = { google: 'Google Cloud', azure: 'Microsoft Azure', aws: 'AWS' }[setupCloud];
+    const renderFoundation = (cloud: 'google' | 'azure' | 'aws') => (
+        <div className="space-y-2.5">
+            <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold">First, the account</p>
+            {cloud === 'google' && <>
+                <InstructionStep num={1} check={<>a Project ID like <code className="bg-black/30 px-1 rounded">my-town-311-4821</code>.</>}>
+                    Go to <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">console.cloud.google.com</a> and make a new project. Copy its <strong className="text-white/90">Project ID</strong> — that is the short code, not the name you typed.
+                </InstructionStep>
+                <InstructionStep num={2}>
+                    Add a billing account under <strong className="text-white/90">Billing</strong>. Google asks for this even for the things it does not charge you for; without it the requests come back refused.
+                </InstructionStep>
+                <InstructionStep num={3} check={<>your service account listed under IAM &amp; Admin.</>}>
+                    Under <strong className="text-white/90">IAM &amp; Admin → Service Accounts</strong>, create one called <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311</code>. This is a login for the software, so nothing is tied to your own account.
+                </InstructionStep>
+                <InstructionStep num={4} check={<>a file ending in <code className="bg-black/30 px-1 rounded">.json</code> in your Downloads.</>}>
+                    Open it, then <strong className="text-white/90">Keys → Add Key → Create new key → JSON</strong>. A file downloads. That file is what you paste into the boxes below.
+                </InstructionStep>
+                <Trouble>Google will not let you download that file again. Put a copy somewhere the town controls — a shared drive rather than your own laptop — and do not send it by email.</Trouble>
+            </>}
+            {cloud === 'azure' && <>
+                <InstructionStep num={1}>
+                    In the <a href="https://portal.azure.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">Azure Portal</a>, search for <strong className="text-white/90">Resource groups</strong> and create one called <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311-rg</code>. Everything below goes in it, so it all sits together and bills together.
+                </InstructionStep>
+                <InstructionStep num={2} check={<>a region set. If your state has a rule about where data is held, pick one that satisfies it.</>}>
+                    Pick a region when it asks.
+                </InstructionStep>
+                <InstructionStep num={3}>
+                    Each thing below is a resource you create in that group. When you open one, its <strong className="text-white/90">Keys and Endpoint</strong> page has the two values the boxes here ask for.
+                </InstructionStep>
+            </>}
+            {cloud === 'aws' && <>
+                <InstructionStep num={1}>
+                    In the <a href="https://console.aws.amazon.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">AWS Console</a>, pick a <strong className="text-white/90">Region</strong> at the top right and use the same one throughout.
+                </InstructionStep>
+                <InstructionStep num={2}>
+                    Under <strong className="text-white/90">IAM → Users → Create user</strong>, make one called <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311</code>. If Pinpoint runs on EC2 or ECS, create a role instead — then there is no key to look after at all.
+                </InstructionStep>
+                <InstructionStep num={3} check={<>an Access key ID and a Secret access key. The secret is shown once.</>}>
+                    If you made a user, go to <strong className="text-white/90">Security credentials → Create access key</strong> and choose the option for an application running outside AWS.
+                </InstructionStep>
+            </>}
+            <p className="text-xs text-white/45 leading-relaxed pl-9">
+                Each box below has a <strong className="text-white/70">Save &amp; Test</strong> button. It makes a real call and tells you either that it worked or exactly what went wrong, so you find out now rather than when a resident does.
+            </p>
+        </div>
+    );
 
     return (
         <div className="space-y-6">
@@ -505,7 +481,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                         <BookOpen className="w-5 h-5 text-indigo-400" />
                         <div className="text-left">
                             <h3 className="font-semibold text-white">Setup Instructions</h3>
-                            <p className="text-white/50 text-xs">Step-by-step, in plain language — answer a few questions and see only your steps</p>
+                            <p className="text-white/50 text-xs">Answer a few questions, then work through one thing at a time</p>
                         </div>
                     </div>
                     {expandedGuide === 'master' ? <ChevronUp className="w-5 h-5 text-white/50" /> : <ChevronDown className="w-5 h-5 text-white/50" />}
@@ -529,16 +505,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     in one sitting. */}
                                 <div className="rounded-xl border border-indigo-400/20 bg-indigo-500/[0.07] p-4">
                                     <p className="text-sm text-white/75 leading-relaxed">
-                                        <strong className="text-white">You do not have to do all of this.</strong> Only two things are
-                                        required to take reports: <strong className="text-white/90">staff sign-in</strong> and a{' '}
-                                        <strong className="text-white/90">map</strong>. Everything else can be added later, in any order,
-                                        and nothing breaks while it is switched off. Your progress is saved as you go, so it is fine to
-                                        stop and come back.
+                                        <strong className="text-white">You do not have to do all of this.</strong> Two things are needed
+                                        before the town can take reports — <strong className="text-white/90">staff sign-in</strong> and a{' '}
+                                        <strong className="text-white/90">map</strong>. Everything else can be added whenever you like, and
+                                        nothing breaks while it is switched off. What you save is kept, so you can stop and come back.
                                     </p>
                                     <p className="text-xs text-white/50 leading-relaxed mt-2">
-                                        Each step tells you what to look for so you know it worked. If a step mentions something
-                                        unfamiliar, the plain meaning is in brackets right after it. Where a value has a copy button,
-                                        use it rather than retyping.
+                                        Each step says what you should be looking at, so you can tell it worked. Where there is a copy
+                                        button, use it instead of retyping. You will be asked to sign in to one or two outside services;
+                                        the steps say exactly where to click.
                                     </p>
                                 </div>
 
@@ -547,7 +522,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <p className="text-white/50 text-xs mb-3">Sign-in and maps are always shown — a town needs both before it can take a report.</p>
 
                                     <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">1. Which company hosts your town's services?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">Most towns pick Google. If your staff already use Microsoft 365, Microsoft Azure may be easier. If you genuinely do not know, choose Google — you can change this later.</p>
+                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If the town already uses Microsoft 365, pick Microsoft Azure. If you are not sure, pick Google — you can change it later.</p>
                                     <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
                                         {(['google', 'azure', 'aws'] as const).map(c => (
                                             <button key={c} type="button" onClick={() => setSetupCloud(c)}
@@ -558,7 +533,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     </div>
 
                                     <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">2. How will staff sign in?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If your staff already sign in to Microsoft 365, Entra is less work than standing up a new service. Auth0 is the fastest from nothing.</p>
+                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If your staff already sign in to Microsoft 365, you already have Entra and can use it. Auth0 is for when there is nothing in place yet.</p>
                                     <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
                                         {(['auth0', 'entra', 'okta', 'oidc'] as const).map(c => (
                                             <button key={c} type="button" onClick={() => setSetupIdp(c)}
@@ -569,7 +544,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     </div>
 
                                     <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">3. Which map provider?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">Google is the quickest to set up. Pick Esri if your county already publishes an ArcGIS basemap you are entitled to use.</p>
+                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If the town or county already has an ArcGIS agreement, Esri lets you use it. Otherwise any of these will do.</p>
                                     <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
                                         {(['google', 'esri', 'azure', 'apple'] as const).map(c => (
                                             <button key={c} type="button" onClick={() => setSetupMaps(c)}
@@ -580,14 +555,14 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     </div>
 
                                     <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">4. Which extras do you want? (all optional)</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">Tick anything that sounds useful — each one adds its own short guide below with what it does and what it costs. Untick it to hide the guide again.</p>
+                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">Tick anything you want. Each one is added to the list below, grouped with whatever else uses the same login. Untick to remove it again.</p>
                                     <div className="flex flex-wrap gap-2 mt-1.5">
                                         {([
                                             ['ai', 'AI triage'], ['translation', 'Translation'],
-                                            ['moderation', 'Content moderation'], ['redaction', 'Blur faces & plates'],
-                                            ['email', 'Email'], ['sms', 'Text / SMS'],
-                                            ['secrets', 'Secret storage + PII encryption'],
-                                            ['govtech', 'Town-system connector'], ['backups', 'Database backups'],
+                                            ['safety', 'Screening and blurring'],
+                                            ['email', 'Email'], ['sms', 'Text messages'],
+                                            ['secrets', 'Key management'],
+                                            ['govtech', 'Town-system connector'], ['backups', 'Backups'],
                                             ['errors', 'Crash reporting'],
                                         ] as const).map(([f, label]) => (
                                             <button key={f} type="button" onClick={() => toggleFeature(f)}
@@ -598,226 +573,26 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     </div>
                                 </div>
 
-                                {/* ── 1. Staff sign-in (always required) ── */}
-                                <Guide tone="orange" icon={Key} title="Staff sign-in" done={signInConfigured}
-                                    what={<>Residents never sign in — this is only for the clerks and staff who work the reports. Rather than Pinpoint storing staff passwords itself, an outside sign-in service handles that, which is what lets you require two-factor and switch off an ex-employee in one place.</>}
-                                    time={setupIdp === 'auth0' ? "About 20 minutes, and you only ever do it once" : "About 10 minutes if you already administer it"}
-                                    cost={setupIdp === 'auth0' ? "Auth0 is free up to 25,000 monthly logins — far more than a town's staff will use" : "Usually already covered by the licence your town has for it"}>
-                                    <InstructionStep num={1}>
-                                        <strong className="text-white/90">Check whether you already have this.</strong> If your staff sign in to Microsoft 365, you already run <strong className="text-white/90">Microsoft Entra ID</strong> and should pick that above — no new account, no new password for anyone, and your IT provider can do it in ten minutes. The same is true if the town uses Okta. Auth0 is the answer when there is nothing already in place.
-                                    </InstructionStep>
-                                    <InstructionStep num={2}>Register Pinpoint with {setupIdp === 'auth0' ? 'Auth0' : setupIdp === 'entra' ? 'Microsoft Entra ID' : setupIdp === 'okta' ? 'Okta' : 'your provider'} and collect its credentials. Do it here — the boxes are below each step.</InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="identity" provider={setupIdp} />
-                                    <InstructionStep num={3}
-                                        check={<>"Always" selected under the policy setting, and at least one factor switched on.</>}
-                                    >Require a second step at login. This is the single most valuable thing on this page: it means a stolen or guessed staff password is not enough on its own to reach resident records. Every provider here can do it — in Auth0 it is <strong className="text-white/90">Security → Multi-factor Auth</strong>, in Entra it is a Conditional Access policy, in Okta it is a sign-on policy. Turn on an authenticator app or passkeys, and set the policy to apply always. Warn staff first: the next time they sign in they will be asked to set it up.</InstructionStep>
-                                    <Trouble>This is not something Pinpoint can switch on for you — it lives entirely in the sign-in service. It is also the one setting a state auditor is most likely to ask about, so it is worth doing on the day rather than later.</Trouble>
-                                    <InstructionStep num={4}
-                                        check={<>their name in Pinpoint's User Management list after they have signed in once.</>}
-                                    >Add your first staff member, in the sign-in service rather than here. <strong className="text-white/90">They have to sign in to Pinpoint once before you can give them a role</strong> — signing in is what creates their record. After that, open <strong className="text-white/90">User Management</strong> in Pinpoint, set them to Admin or Staff, and choose their department.</InstructionStep>
-                                </Guide>
-
-                                {/* ── 2. Cloud foundation (only if a cloud-backed feature is wanted) ── */}
-                                <Guide show={wants('ai') || wants('translation') || wants('secrets') || wants('moderation')}
-                                    tone="blue" icon={Cloud} title={`Set up ${cloudLabel} (foundation)`}>
-                                    <p className="text-xs text-white/45 -mt-1 mb-1">Do this once. Every {cloudLabel} feature you picked reuses this same project + credentials, so you won't repeat it per feature.</p>
-                                    {setupCloud === 'google' && <>
-                                        <InstructionStep num={1}>Create the project. At <a href="https://console.cloud.google.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">console.cloud.google.com</a>, click the project dropdown (top bar) → <strong className="text-white/90">New Project</strong>, name it, and create. Copy the <strong className="text-white/90">Project ID</strong> (not the display name — it looks like <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">my-town-311-4821</code>).</InstructionStep>
-                                        <InstructionStep num={2}>Enable billing. <strong className="text-white/90">Billing → Link a billing account</strong>. Required even though most usage stays in the free tier — without it the APIs return 403.</InstructionStep>
-                                        <InstructionStep num={3}>Enable the APIs. Go to <strong className="text-white/90">APIs &amp; Services → Library</strong> and enable each of: {wants('ai') && <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Vertex AI API</code>}{wants('translation') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Cloud Translation API</code></>}{wants('secrets') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Cloud KMS API</code> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Secret Manager API</code></>}{wants('moderation') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Cloud Vision API</code> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">Cloud Natural Language API</code></>}. Search each by name and click <strong className="text-white/90">Enable</strong> (a minute each).</InstructionStep>
-                                        <InstructionStep num={4} check={<>pinpoint311 listed on the Service Accounts page.</>}>Create a <Term means="a login for the software rather than for a person, so nothing is tied to your personal account">service account</Term>. Go to <strong className="text-white/90">IAM &amp; Admin → Service Accounts → Create Service Account</strong>, name it <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311</code>, and click Create &amp; Continue.</InstructionStep>
-                                        <InstructionStep num={5}>Grant roles for what you picked, then Done:
-                                            <ul className="mt-1.5 space-y-1 list-disc list-inside text-white/55 text-xs">
-                                                {wants('ai') && <li><code className="bg-black/30 px-1 rounded text-blue-300">Vertex AI User</code></li>}
-                                                {wants('translation') && <li><code className="bg-black/30 px-1 rounded text-blue-300">Cloud Translation API User</code></li>}
-                                                {wants('secrets') && <li><code className="bg-black/30 px-1 rounded text-blue-300">Cloud KMS CryptoKey Encrypter/Decrypter</code> + <code className="bg-black/30 px-1 rounded text-blue-300">Secret Manager Admin</code></li>}
-                                                {wants('moderation') && <li><code className="bg-black/30 px-1 rounded text-blue-300">Cloud Vision API User</code> (Natural Language needs no extra role)</li>}
-                                            </ul>
-                                        </InstructionStep>
-                                        <InstructionStep num={6} check={<>a file ending in <code className="bg-black/30 px-1 rounded">.json</code> in your Downloads folder.</>}>Download its key file. Open the service account you just made, then <strong className="text-white/90">Keys → Add Key → Create new key → JSON</strong>. A file downloads automatically. This single file is what you paste or upload into the cards further down the page.<br /><strong className="text-white/90">Google will not let you download it again.</strong> Save a copy somewhere your town controls — a shared drive, not just your laptop — and do not email it.</InstructionStep>
-                                    </>}
-                                    {setupCloud === 'azure' && <>
-                                        <InstructionStep num={1}>Create a resource group. In the <a href="https://portal.azure.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">Azure Portal</a> search <strong className="text-white/90">Resource groups → Create</strong>, name it <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311-rg</code>, and pick a region (a US-Gov region if your jurisdiction requires it). Everything below goes in this group.</InstructionStep>
-                                        <InstructionStep num={2}>Note your <strong className="text-white/90">Subscription</strong> and <strong className="text-white/90">Tenant ID</strong> (Subscriptions / Microsoft Entra ID → Overview) — some resources ask for them.</InstructionStep>
-                                        <InstructionStep num={3}>You'll create one resource per feature you picked in the guides below ({wants('ai') && 'Azure OpenAI'}{wants('translation') && ', Translator'}{wants('secrets') && ', Key Vault'}{wants('moderation') && ', AI Content Safety'}). Each gives you an <strong className="text-white/90">Endpoint</strong> + <strong className="text-white/90">Key</strong> under its <strong className="text-white/90">Keys and Endpoint</strong> blade that you paste into the matching provider card. Create them in <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311-rg</code> so they're easy to find and bill together.</InstructionStep>
-                                    </>}
-                                    {setupCloud === 'aws' && <>
-                                        <InstructionStep num={1}>Pick a region. In the <a href="https://console.aws.amazon.com" target="_blank" rel="noopener noreferrer" className="text-blue-300 underline underline-offset-2">AWS Console</a> choose a <strong className="text-white/90">Region</strong> (top-right; e.g. <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">us-east-1</code>, or <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">us-gov-west-1</code> for GovCloud). Use the same region everywhere below.</InstructionStep>
-                                        <InstructionStep num={2}>Create an IAM identity. <strong className="text-white/90">IAM → Users → Create user</strong> (or a role if Pinpoint runs on EC2/ECS — a role avoids long-lived keys). Name it <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311</code>.</InstructionStep>
-                                        <InstructionStep num={3}>Attach permissions for what you picked: {wants('ai') && <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">bedrock:InvokeModel</code>}{wants('translation') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">translate:TranslateText</code></>}{wants('secrets') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">secretsmanager:*</code> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">kms:Encrypt/Decrypt</code></>}{wants('moderation') && <> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">rekognition:DetectModerationLabels</code> <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">comprehend:DetectToxicContent</code></>}. Scope to specific resources for production.</InstructionStep>
-                                        <InstructionStep num={4}>If you used a user, create an <strong className="text-white/90">access key</strong> (Security credentials → Create access key → Application running outside AWS). Save the <strong className="text-white/90">Access key ID</strong> + <strong className="text-white/90">Secret access key</strong> — you'll enter them plus the region in the provider cards.</InstructionStep>
-                                    </>}
-                                    <p className="text-xs text-white/50 leading-relaxed pl-9"><em>Tip:</em> after entering credentials in any provider card, press <strong className="text-white/80">Save &amp; Test</strong> — Pinpoint makes a live call and shows a green check on success or the exact error (wrong role, API not enabled, bad region) so you can fix it before going live.</p>
-                                </Guide>
-
-                                {/* ── AI ── */}
-                                <Guide show={wants('ai')} tone="sky" icon={Sparkles} title="AI triage"
-                                    what={<>Reads each new report and suggests a category, a priority and the department it belongs to. A clerk still decides — the suggestion is a starting point, never an action.</>}
-                                    time="About 15 minutes once your cloud account exists"
-                                    cost="Cents per hundred reports on any of the three providers.">
-                                    <InstructionStep num={1}>Enable the model service in the cloud account you set up above, and give Pinpoint permission to call it — nothing more than that. A leaked key scoped to "ask the model a question" can run up a bill; the same key with a broad role can delete the project.</InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="ai" provider={aiProvider}
-                                        note={<>Set up for <strong className="text-white/70">{{ vertex: 'Google Vertex AI', azure: 'Azure OpenAI', bedrock: 'AWS Bedrock' }[aiProvider]}</strong>, because that is the cloud you picked above. To use a different one, change the cloud at the top or use the AI Provider card further down.</>}
-                                    />
-                                    <Trouble>Model availability differs by region on every provider, and on AWS the models have to be requested before they can be used. If the picker is empty, that is usually why rather than a bad key.</Trouble>
-                                </Guide>
-
-                                {/* ── Translation ── */}
-                                <Guide show={wants('translation')} tone="cyan" icon={Languages} title="Translation"
-                                    what={<>Lets a resident file a report in their own language and read the replies in it, and lets staff work entirely in English. For many towns this is a Title VI obligation rather than a nicety.</>}
-                                    time="About 10 minutes"
-                                    cost="Free for a small town's volume on all three providers.">
-                                    <InstructionStep num={1}>Enable the translation service in the cloud account you set up above. {setupCloud === 'google' ? 'On Google it is an API to switch on.' : setupCloud === 'azure' ? 'On Azure it is a Translator resource to create.' : 'On AWS there is nothing to enable — it is on by default.'}</InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="translation" provider={setupCloud} />
-                                </Guide>
-
-                                {/* ── Secrets + PII encryption ── */}
-                                <Guide show={wants('secrets')} tone="violet" icon={Lock} title="Secure storage for keys and resident data (recommended)"
-                                    what={<>Two related things. Your integration credentials move out of the database into your cloud's secret store, and the key that encrypts resident names, emails and phone numbers is held by your cloud's key service rather than derived from a setting in a file. Both are what an auditor means by "key management".</>}
-                                    time="About 20 minutes"
-                                    cost="Under a dollar a month.">
-                                    <InstructionStep num={1}>Create the key and the vault in the cloud account you set up above, and grant Pinpoint permission to <strong className="text-white/90">wrap and unwrap</strong> with that key — not just to read it.</InstructionStep>
-                                    <Trouble>Wrap and unwrap are the two permissions people miss, and missing them fails quietly: the key exists, the settings save, and resident data is encrypted with the application key instead. The health dashboard is the only place that says so — it will tell you the key manager you selected is not the one being used.</Trouble>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="kms" provider={setupCloud} />
-                                    <InstructionStep num={2}>Once the vault is reachable, credentials already in the database move across on their own, within the hour. There is no button to press and nothing to remember.</InstructionStep>
-                                    <Trouble>Never delete or disable this key once resident data has been written under it. Every cloud enforces a waiting period and then destroys it permanently, and nobody — including the cloud provider — can recover what it protected.</Trouble>
-                                </Guide>
-
-                                {/* ── Email ── */}
-                                <Guide show={wants('email')} tone="violet" icon={Mail} title="Email notifications" done={smtpConfigured}
-                                    what={<>The confirmation a resident gets when they file, and the update when it is resolved. Without this, residents have no idea anything happened, and the phone calls come to you instead.</>}
-                                    time="About 15 minutes, longer if DNS records are involved"
-                                    cost="Free to a few dollars a month.">
-                                    <InstructionStep num={1}>Decide who sends. A dedicated town address like <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">311@yourtown.gov</code> rather than <code className="bg-black/30 px-1 rounded text-violet-300 text-xs">noreply@</code> — residents reply to these, and a reply that goes nowhere is a complaint you never hear.</InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="email" provider={emailProvider}
-                                        onChoose={setEmailOverride}
-                                        choices={[
-                                            { id: 'smtp', label: 'SMTP (your existing mail server)' },
-                                            { id: 'ses', label: 'Amazon SES' },
-                                            { id: 'acs', label: 'Azure Communication Services' },
-                                        ]}
-                                        note={<>How mail leaves the building is not a cloud decision — plenty of towns on Google send through SES. Starting on the one that suits {cloudLabel}; change it here if yours differs.</>}
-                                    />
-                                    <Trouble>Microsoft 365 and Google Workspace both block plain SMTP by default. If your IT provider says it is not allowed, they are right — Amazon SES or Azure Communication Services will be less work than getting an exception.</Trouble>
-                                </Guide>
-
-                                {/* ── SMS ── */}
-                                <Guide show={wants('sms')} tone="emerald" icon={MessageSquare} title="Text message notifications" done={smsConfigured}
-                                    what={<>The same updates by text, for residents who give a mobile number. Optional — email alone is a complete service.</>}
-                                    time="About 15 minutes, plus carrier registration"
-                                    cost="Around a cent per message.">
-                                    <InstructionStep num={1}>
-                                        <strong className="text-white/90">Start the carrier registration first, whichever provider you use.</strong> Texting US numbers from a business or government sender needs 10DLC registration, which identifies your town to the carriers. It is not a technical step and it is not quick — allow a couple of weeks. Unregistered messages are filtered heavily and often silently.
-                                    </InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="sms" provider={smsProvider}
-                                        onChoose={setSmsOverride}
-                                        choices={[
-                                            { id: 'twilio', label: 'Twilio' },
-                                            { id: 'sns', label: 'Amazon SNS' },
-                                            { id: 'acs', label: 'Azure Communication Services' },
-                                            { id: 'http', label: 'Other (HTTP gateway)' },
-                                        ]}
-                                    />
-                                    <Trouble>Every provider starts you in a trial or sandbox that can only text numbers you have verified. Everything looks like it works — the send succeeds — and residents receive nothing. Leave it before launch.</Trouble>
-                                </Guide>
-
-                                {/* ── Content moderation ── */}
-                                <Guide show={wants('moderation')} tone="rose" icon={ImageIcon} title="Blocking abusive reports and photos"
-                                    what={<>Anything a resident submits can end up on a public municipal website. Offensive language is always screened, with or without this; turning it on adds checking of photos too, and catches abuse a word list misses.</>}
-                                    time="About 10 minutes once your cloud account exists"
-                                    cost="Fractions of a cent per report.">
-                                    <InstructionStep num={1}><strong className="text-white/90">Built in, no setup:</strong> resident text is always screened — explicit/abusive descriptions and comments are blocked at submission; mild profanity posts but is flagged for staff. This works with nothing configured and is not something you can switch off by accident.</InstructionStep>
-                                    {setupCloud === 'google' && (
-                                        <InstructionStep num={2} check={<>both APIs showing as Enabled in the API library.</>}>
-                                            <strong className="text-white/90">Add photo screening.</strong> In the Google project you created above, enable the <strong className="text-white/90">Cloud Vision</strong> and <strong className="text-white/90">Cloud Natural Language</strong> APIs. There is nothing to enter here — screening reuses the service account you already downloaded.
-                                        </InstructionStep>
-                                    )}
-                                    {setupCloud === 'azure' && <>
-                                        <InstructionStep num={2} check={<>an <strong className="text-white/90">Endpoint</strong> and two keys on the resource's Keys and Endpoint page.</>}>
-                                            <strong className="text-white/90">Add photo screening.</strong> In the Azure Portal, create an <strong className="text-white/90">Azure AI Content Safety</strong> resource in <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">pinpoint311-rg</code>. Open it, go to <strong className="text-white/90">Keys and Endpoint</strong>, and copy the endpoint and either key into the boxes below.
-                                        </InstructionStep>
-                                        <PlainSecrets fields={[
-                                            { key: 'AZURE_CONTENT_SAFETY_ENDPOINT', label: 'Content Safety endpoint', help: 'Looks like https://your-resource.cognitiveservices.azure.com/' },
-                                            { key: 'AZURE_CONTENT_SAFETY_KEY', label: 'Content Safety key', secret: true, help: 'Either KEY 1 or KEY 2 — they are interchangeable.' },
-                                        ]} />
-                                    </>}
-                                    {setupCloud === 'aws' && (
-                                        <InstructionStep num={2}>
-                                            <strong className="text-white/90">Add photo screening.</strong> On the IAM identity you created above, allow <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">rekognition:DetectModerationLabels</code> for images and <code className="bg-black/30 px-1 rounded text-rose-300 text-xs">comprehend:DetectToxicContent</code> for text. Nothing to enter here — it reuses the AWS credentials you already have.
-                                        </InstructionStep>
-                                    )}
-                                    <InstructionStep num={3}>Leave the rest alone. Screening follows the cloud you picked at the top of this page automatically. If the cloud layer is not reachable, text still uses the built-in scan and photos fall back to the AI provider's own assessment, so nothing goes unchecked.</InstructionStep>
-                                </Guide>
-
-                                {/* ── Maps (always) ── */}
-                                <Guide tone="blue" icon={MapPin} title="Maps" done={mapsConfigured}
-                                    what={<>The map a resident drops a pin on, and the address lookup that turns what they type into a location your crews can find. Required — a 311 report without a location is not actionable.</>}
-                                    time="About 20 minutes"
-                                    cost="Google and Azure have free tiers a town will not exceed; Esri may already be covered by a county licence; Apple needs a paid developer membership.">
-                                    <InstructionStep num={1}>
-                                        <strong className="text-white/90">Ask your GIS department before you buy anything.</strong> If the town or county has an ArcGIS agreement — many New Jersey towns do — choose Esri above. You get the map free under that licence, and more importantly you can point address lookup at the county's own locator, which knows your street names, your address ranges and your recent subdivisions. A national geocoder does not.
-                                    </InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="maps" provider={setupMaps} />
-                                    <InstructionStep num={2}
-                                        check={<>the address box offering suggestions as you type, and a pin appearing when you click the map.</>}
-                                    >Test it as a resident would. Open the resident portal in another tab and file a test report — the map failing is the one thing on this page a resident notices immediately.</InstructionStep>
-                                </Guide>
-
-                                {/* ── GovTech connector ── */}
-                                <Guide show={wants('govtech')} tone="amber" icon={Landmark} title="Connecting to a system the town already uses"
-                                    what={<>If your town already runs permitting or work-order software, Pinpoint can push reports into it so staff are not working in two places. You will need someone with an administrator login to that system, and possibly a call to the vendor for an API key.</>}
-                                    time="An hour or more, and usually a vendor email"
-                                    cost="No cost from Pinpoint. Some vendors charge for API access.">
-                                    <InstructionStep num={1}>Scroll to <strong className="text-white/90">Connect Your Other Town Systems</strong> below. Purpose-built connectors exist for <strong className="text-white/90">Accela</strong>, <strong className="text-white/90">Tyler</strong>, <strong className="text-white/90">CivicPlus/SeeClickFix</strong>, and any <strong className="text-white/90">Open311</strong> endpoint.</InstructionStep>
-                                    <InstructionStep num={2}>For anything else (Cityworks, SDL, Edmunds, GovPilot, FastTrackGov, Polimorphic…) use <strong className="text-white/90">Other REST System</strong> and enter the base URL + key from your vendor's API docs.</InstructionStep>
-                                    <InstructionStep num={3}>Each connector has a guided wizard and a <strong className="text-white/90">Check connection</strong> button — always run it (and a test report) before going live.</InstructionStep>
-                                </Guide>
-
-                                {/* ── Database backups ── */}
-                                {/* ── Photo redaction ── */}
-                                <Guide show={wants('redaction')} tone="rose" icon={ImageIcon} title="Blurring faces and licence plates" done={redactionConfigured}
-                                    what={<>Residents photograph potholes with cars parked beside them and neighbours walking past. Those people did not ask to be in a public record, and a 311 photo is one. This blurs faces and plates before the photo is stored.</>}
-                                    time="About 10 minutes"
-                                    cost="A dollar or two per thousand photos, or free if you run it on this server.">
-                                    <InstructionStep num={1}>Choose where detection happens. All three clouds do it well; the option that runs on this server finds fewer faces — particularly small or partly turned ones — but no photo ever leaves the building, which for some towns settles it.</InstructionStep>
-                                    <InlineProviderSetup onSaved={onRefresh} cap="redaction" provider={redactionProvider}
-                                        onChoose={setRedactionOverride}
-                                        choices={[
-                                            { id: 'local', label: 'On this server (no account, no cost)' },
-                                            { id: 'google', label: 'Google Cloud Vision' },
-                                            { id: 'azure', label: 'Azure Face + Vision' },
-                                            { id: 'aws', label: 'AWS Rekognition' },
-                                        ]}
-                                        note={<>A fresh install already blurs on this server, so photos are never stored unblurred while you decide. Pointing it at a cloud finds more.</>}
-                                    />
-                                    <Trouble>This is the one setting whose failure is invisible from inside Pinpoint: "found nobody in this photo" and "could not ask" both produce an unblurred picture and a green tick. After saving, file a test report with a photo of a face in it and look at the stored image.</Trouble>
-                                </Guide>
-
-                                {/* ── Error reporting ── */}
-                                <Guide show={wants('errors')} tone="violet" icon={AlertTriangle} title="Knowing when something breaks" done={sentryConfigured}
-                                    what={<>Without this, a page that crashes for a resident is something you hear about only if they phone. Browser crashes are already collected and shown under Browser errors in the admin console; this sends them somewhere off the server as well, so they survive a container restart.</>}
-                                    time="About 5 minutes"
-                                    cost="Sentry's free tier covers a town's volume comfortably.">
-                                    <InstructionStep num={1} check={<>a DSN that looks like <code className="bg-black/30 px-1 rounded">https://…@…ingest.sentry.io/…</code></>}>Create a free account at <a href="https://sentry.io" target="_blank" rel="noopener noreferrer" className="text-violet-300 underline underline-offset-2">sentry.io</a>, make a project, and copy its <strong className="text-white/90">DSN</strong> into the box below.</InstructionStep>
-                                    <PlainSecrets fields={[
-                                        { key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true, help: 'Project Settings → Client Keys (DSN). Not a password — but it is still worth keeping to yourself.' },
-                                    ]} />
-                                    <InstructionStep num={2}><em className="text-white/50">Optional:</em> this is genuinely skippable. Crashes are still recorded in the admin console without it — Sentry adds alerting and keeps the history longer.</InstructionStep>
-                                </Guide>
-
-                                <Guide show={wants('backups')} tone="amber" icon={HardDrive} title="Automatic backups" done={backupConfigured}
-                                    what={<>Takes a nightly encrypted copy of everything and stores it off the server. Do this one. 311 reports are public records the town is legally required to keep, and a server can fail.</>}
-                                    time="About 20 minutes"
-                                    cost="A few dollars a month for storage.">
-                                    <InstructionStep num={1}>Provision an <strong className="text-white/90">S3-compatible</strong> bucket (AWS S3, Oracle Object Storage, MinIO, …) with put/get/list/delete permissions, and take an access key for it.</InstructionStep>
-                                    <InstructionStep num={2}
-                                        check={<>the passphrase shown once, with a box to tick confirming you have put a copy somewhere else.</>}
-                                    >Enter the bucket and keys in the <strong className="text-white/90">Database Backups</strong> card below, and press <strong className="text-white/90">Create backup passphrase</strong>. You are not asked to invent one — inventing a passphrase reliably produces either something guessable or something nobody can find again.</InstructionStep>
-                                    <Trouble>The one part nobody can automate is keeping a copy somewhere other than this server. A key held only inside the system it protects is worth nothing on the day that system is gone — which is the day a backup matters. A password manager, or a sealed envelope in the clerk's safe.</Trouble>
-                                    <div className="mt-3 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2">
-                                        <p className="text-amber-200/80 text-xs"><strong>⚠ Privacy note:</strong> Backups contain a full snapshot including resident PII. Retention deletes old backups, but PII anonymization only applies to the live database — not to existing backup files.</p>
-                                    </div>
-                                </Guide>
+                                <SetupWizard
+                                    cloud={setupCloud}
+                                    idp={setupIdp}
+                                    maps={setupMaps}
+                                    aiProvider={aiProvider}
+                                    emailProvider={emailProvider}
+                                    smsProvider={smsProvider}
+                                    redactionProvider={redactionProvider}
+                                    wanted={wantedFeatures}
+                                    isDone={itemDone}
+                                    secretValues={secretValues}
+                                    onSecretChange={(key, value) => setSecretValues(prev => ({ ...prev, [key]: value }))}
+                                    onSaveSecrets={async (keys) => { for (const k of keys) await handleSave(k); }}
+                                    savingSecret={savingKey}
+                                    isSecretConfigured={(key) => !!isConfigured(key)}
+                                    onRefresh={onRefresh}
+                                    publicOrigin={publicOrigin}
+                                    onChooseProvider={chooseProvider}
+                                    renderFoundation={renderFoundation}
+                                />
                             </div>
                         </motion.div>
                     )}

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Check, ChevronRight, Circle, AlertCircle } from 'lucide-react';
+
+import InlineProviderSetup from './InlineProviderSetup';
+import SecretField from './SecretField';
+import { buildPlan, type PlanInput, type PlanItem, type PlanTask } from './setupPlan';
+// Registers every provider's console walk as an import side effect.
+import './setupStepsContent';
+
+/**
+ * Setup, one login at a time.
+ *
+ * What this replaces was ten stacked panels, all open, each with a paragraph of
+ * prose above its boxes. Everything a town might ever configure was on screen
+ * at once, in capability order, so a town on Azure read Azure, Google, Azure,
+ * Azure, Azure. It was accurate and exhausting, and the person it is written
+ * for -- a township clerk who was handed this job, not an engineer -- has no
+ * way to tell from that page whether they are ten minutes from finished or two
+ * days.
+ *
+ * Two changes. The list on the left is grouped by the account you sign in to
+ * rather than by feature, so everything behind one login is one visit
+ * (setupPlan.ts does that arithmetic). And only one is open at a time, so the
+ * screen shows the thing you are doing and a list of what is left.
+ *
+ * Finishing advances you. Not on save -- on a save whose live test came back
+ * green, because being moved along past a credential that does not work is the
+ * exact failure this page exists to prevent.
+ */
+
+const STATUS_TONE = {
+    done: 'text-emerald-300',
+    todo: 'text-amber-300',
+    optional: 'text-white/35',
+} as const;
+
+export interface SetupWizardProps extends PlanInput {
+    /** Whether an item is already set up, from secrets the page has loaded. */
+    isDone: (itemId: string) => boolean;
+    /** Plain settings, saved through the page's own secret endpoint. */
+    secretValues: Record<string, string>;
+    onSecretChange: (key: string, value: string) => void;
+    onSaveSecrets: (keys: string[]) => Promise<void>;
+    savingSecret: string | null;
+    isSecretConfigured: (key: string) => boolean;
+    /** A save landed somewhere; refresh the page's own status. */
+    onRefresh: () => void;
+    /** The address residents use, for callback URLs. */
+    publicOrigin: string | null;
+    /** Switch a choice the questionnaire seeded but did not settle. */
+    onChooseProvider: (key: NonNullable<PlanItem['choiceKey']>, id: string) => void;
+    /** The cloud foundation walk, which belongs to no single capability. */
+    renderFoundation: (cloud: 'google' | 'azure' | 'aws') => React.ReactNode;
+    /** The town-systems connector, which has its own component further down. */
+    renderGovtech?: () => React.ReactNode;
+}
+
+export default function SetupWizard(props: SetupWizardProps) {
+    const { isDone, onRefresh, publicOrigin, onChooseProvider, renderFoundation } = props;
+
+    const tasks = useMemo(() => buildPlan(props), [
+        props.cloud, props.idp, props.maps, props.aiProvider,
+        props.emailProvider, props.smsProvider, props.redactionProvider, props.wanted,
+    ]);
+
+    const taskDone = (t: PlanTask) => t.items.every(i => isDone(i.id));
+
+    const [openId, setOpenId] = useState<string | null>(null);
+    /* Once a clerk clicks a row, their choice wins over the automatic one --
+     * being walked through setup should not mean losing the ability to go back
+     * and look at something already finished. */
+    const chosen = useRef(false);
+
+    // Land on the first unfinished task, once, when status first arrives.
+    useEffect(() => {
+        if (chosen.current || openId !== null || tasks.length === 0) return;
+        setOpenId((tasks.find(t => !taskDone(t)) ?? tasks[0]).id);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tasks.length]);
+
+    /** Move on, but only from a task that is genuinely finished. */
+    const advanceFrom = (taskId: string) => {
+        const index = tasks.findIndex(t => t.id === taskId);
+        if (index < 0) return;
+        const next = tasks.slice(index + 1).find(t => !taskDone(t));
+        setOpenId(next ? next.id : null);
+    };
+
+    const open = tasks.find(t => t.id === openId) ?? null;
+    const remaining = tasks.filter(t => !taskDone(t)).length;
+
+    return (
+        <div className="grid lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-5">
+            {/* ── The list ── */}
+            <nav aria-label="Setup tasks" className="lg:sticky lg:top-4 self-start">
+                <p className="text-[11px] uppercase tracking-wider text-white/40 font-semibold mb-2.5 px-1">
+                    {remaining === 0 ? 'All done' : `${remaining} left`}
+                </p>
+                <ul className="space-y-1">
+                    {tasks.map(task => {
+                        const done = taskDone(task);
+                        const active = task.id === openId;
+                        const tone = done ? 'done' : task.required ? 'todo' : 'optional';
+                        return (
+                            <li key={task.id}>
+                                <button
+                                    type="button"
+                                    onClick={() => { chosen.current = true; setOpenId(active ? null : task.id); }}
+                                    aria-current={active ? 'step' : undefined}
+                                    className={`w-full text-left rounded-xl px-3 py-2.5 flex items-center gap-2.5 border transition-colors ${active
+                                        ? 'bg-white/[0.09] border-white/20'
+                                        : 'bg-white/[0.03] border-transparent hover:bg-white/[0.06]'}`}
+                                >
+                                    <span className={`shrink-0 ${STATUS_TONE[tone]}`} aria-hidden="true">
+                                        {done
+                                            ? <Check className="w-4 h-4" />
+                                            : <Circle className="w-4 h-4" strokeWidth={task.required ? 2.5 : 1.5} />}
+                                    </span>
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block text-sm text-white/85 truncate">{task.title}</span>
+                                        <span className="block text-[11px] text-white/40 truncate">
+                                            {done ? 'Set up' : task.items.map(i => i.title).join(' · ')}
+                                        </span>
+                                    </span>
+                                    {active && <ChevronRight className="w-3.5 h-3.5 text-white/30 shrink-0" aria-hidden="true" />}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+
+            {/* ── The one you are on ── */}
+            <div className="min-w-0">
+                <AnimatePresence mode="wait">
+                    {open ? (
+                        <motion.section
+                            key={open.id}
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -6 }}
+                            transition={{ duration: 0.18 }}
+                            className="setup-panel p-5 sm:p-6"
+                        >
+                            <h3 className="font-semibold text-white text-base">{open.title}</h3>
+                            <p className="text-sm text-white/55 leading-relaxed mt-1">{open.blurb}</p>
+
+                            {open.foundation && (
+                                <div className="mt-4 pt-4 border-t border-white/[0.07]">
+                                    {renderFoundation(open.foundation)}
+                                </div>
+                            )}
+
+                            <div className="mt-4 space-y-5">
+                                {open.items.map(item => (
+                                    <TaskItem
+                                        key={item.id}
+                                        item={item}
+                                        {...props}
+                                        onDone={(verified) => {
+                                            onRefresh();
+                                            /* Only when the whole task is finished, and only on a
+                                             * green test. Advancing after one item of four would
+                                             * leave the other three behind. */
+                                            if (verified && open.items.every(i => i.id === item.id || isDone(i.id))) {
+                                                advanceFrom(open.id);
+                                            }
+                                        }}
+                                        publicOrigin={publicOrigin}
+                                        onChooseProvider={onChooseProvider}
+                                    />
+                                ))}
+                                {open.vendor === 'govtech' && props.renderGovtech?.()}
+                            </div>
+                        </motion.section>
+                    ) : (
+                        <motion.div
+                            key="done"
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            className="setup-panel p-6 text-center"
+                        >
+                            <div className="w-12 h-12 mx-auto rounded-2xl bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center shadow-lg shadow-emerald-500/25">
+                                <Check className="w-6 h-6 text-white" strokeWidth={2.5} />
+                            </div>
+                            <p className="text-white/80 mt-3.5">Everything you picked is set up.</p>
+                            <p className="text-white/45 text-sm mt-1.5">
+                                Pick anything from the list to look at it again, or change it later on the cards below.
+                            </p>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </div>
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+/** One thing inside a task: a provider with a catalog, plain settings, or both. */
+function TaskItem({
+    item, onDone, publicOrigin, onChooseProvider,
+    secretValues, onSecretChange, onSaveSecrets, savingSecret, isSecretConfigured,
+}: {
+    item: PlanItem;
+    onDone: (verified: boolean) => void;
+    publicOrigin: string | null;
+    onChooseProvider: (key: NonNullable<PlanItem['choiceKey']>, id: string) => void;
+} & Pick<SetupWizardProps,
+    'secretValues' | 'onSecretChange' | 'onSaveSecrets' | 'savingSecret' | 'isSecretConfigured'>) {
+    return (
+        <div>
+            <h4 className="text-sm font-semibold text-white/90">{item.title}</h4>
+            <p className="text-xs text-white/50 leading-relaxed mt-0.5 mb-2.5">{item.blurb}</p>
+
+            {item.cap && item.provider && (
+                <InlineProviderSetup
+                    cap={item.cap}
+                    provider={item.provider}
+                    choices={item.choices}
+                    onChoose={item.choiceKey ? (id) => onChooseProvider(item.choiceKey!, id) : undefined}
+                    onSaved={onDone}
+                    publicOrigin={publicOrigin}
+                />
+            )}
+
+            {item.secrets && (
+                <PlainSecrets
+                    fields={item.secrets}
+                    values={secretValues}
+                    onChange={onSecretChange}
+                    onSave={onSaveSecrets}
+                    saving={savingSecret}
+                    isConfigured={isSecretConfigured}
+                    onSaved={() => onDone(false)}
+                    /* Spacing only when it follows a provider block, so an item
+                     * that is only settings does not start with a gap. */
+                    className={item.cap ? 'mt-3' : ''}
+                />
+            )}
+        </div>
+    );
+}
+
+/**
+ * Boxes for settings that belong to no provider card.
+ *
+ * A few things here -- the backup bucket, Azure's Content Safety pair, the
+ * Sentry key -- have no capability catalog behind them, and were previously
+ * printed as bare environment-variable names in the middle of a sentence. That
+ * is not an instruction a clerk can act on: it reads as something to hand to
+ * IT, and it was the only place on this page asking anyone to edit a file.
+ */
+function PlainSecrets({
+    fields, values, onChange, onSave, saving, isConfigured, onSaved, className = '',
+}: {
+    fields: { key: string; label: string; secret?: boolean; help?: string }[];
+    values: Record<string, string>;
+    onChange: (key: string, value: string) => void;
+    onSave: (keys: string[]) => Promise<void>;
+    saving: string | null;
+    isConfigured: (key: string) => boolean;
+    onSaved: () => void;
+    className?: string;
+}) {
+    const pending = fields.filter(f => values[f.key]).map(f => f.key);
+    const allStored = fields.every(f => isConfigured(f.key));
+
+    return (
+        <div className={`rounded-xl border border-white/10 bg-white/[0.03] p-3.5 ${className}`}>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                {fields.map(f => (
+                    <SecretField
+                        key={f.key}
+                        label={f.label}
+                        secret={f.secret}
+                        help={f.help}
+                        savedHint={isConfigured(f.key)}
+                        value={values[f.key] || ''}
+                        onChange={(v) => onChange(f.key, v)}
+                    />
+                ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-2.5 mt-3 pt-3 border-t border-white/[0.07]">
+                <button
+                    type="button"
+                    onClick={async () => { await onSave(pending); onSaved(); }}
+                    disabled={pending.length === 0 || saving !== null}
+                    className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                >
+                    {saving ? 'Saving…' : 'Save'}
+                </button>
+                {allStored && (
+                    <span className="text-[11px] text-emerald-300/80 inline-flex items-center gap-1.5">
+                        <Check className="w-3.5 h-3.5" aria-hidden="true" />
+                        Saved. Leave a box blank to keep what is stored.
+                    </span>
+                )}
+                {/* These have no live test, and saying so is better than a green
+                    tick that only means the value reached the database. */}
+                {!allStored && pending.length === 0 && (
+                    <span className="text-[11px] text-white/35 inline-flex items-center gap-1.5">
+                        <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                        Not filled in yet.
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/setupPlan.test.ts
+++ b/frontend/src/components/setupPlan.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildPlan, type PlanInput } from './setupPlan';
+
+/**
+ * One trip per login, and the required things first.
+ *
+ * The grouping is the whole point of this rewrite, and it is the part most
+ * likely to quietly stop working: add a capability, forget to give it a vendor,
+ * and it lands in its own task. Nothing breaks, no test fails, and a town on
+ * Azure is back to bouncing between four portals.
+ */
+
+const base: PlanInput = {
+    cloud: 'azure',
+    idp: 'entra',
+    maps: 'azure',
+    aiProvider: 'azure',
+    emailProvider: 'acs',
+    smsProvider: 'acs',
+    redactionProvider: 'azure',
+    wanted: new Set(['ai', 'translation', 'safety', 'email', 'sms', 'secrets', 'backups', 'errors']),
+};
+
+const plan = (over: Partial<PlanInput> = {}) => buildPlan({ ...base, ...over });
+const ids = (over: Partial<PlanInput> = {}) => plan(over).map(t => t.id);
+const task = (id: string, over: Partial<PlanInput> = {}) => plan(over).find(t => t.id === id);
+
+describe('everything behind one login is one task', () => {
+    it('folds an all-Azure town into a single Azure task', () => {
+        const azure = task('azure')!;
+        const items = azure.items.map(i => i.id).sort();
+        // Sign-in via Entra, maps, AI, translation, Key Vault, screening, email
+        // and text are all the Azure portal. Eight sections became one visit.
+        expect(items).toEqual(['ai', 'email', 'identity', 'kms', 'maps', 'safety', 'sms', 'translation']);
+        expect(azure.foundation).toBe('azure');
+    });
+
+    it('does not fold things that are genuinely a different login', () => {
+        // Same town, but Google Maps and Auth0. Those are two more sign-ins and
+        // pretending otherwise would promise one trip and need three.
+        const list = ids({ idp: 'auth0', maps: 'google' });
+        expect(list).toContain('auth0');
+        expect(list).toContain('google');
+        expect(list).toContain('azure');
+        expect(task('google', { idp: 'auth0', maps: 'google' })!.items.map(i => i.id)).toEqual(['maps']);
+    });
+
+    it('treats Entra as Azure, because it is administered in the Azure portal', () => {
+        expect(task('azure')!.items.map(i => i.id)).toContain('identity');
+        // Okta is not, so it stays its own task.
+        expect(task('okta', { idp: 'okta' })!.items.map(i => i.id)).toEqual(['identity']);
+    });
+
+    it('only the clouds get the account-setup walk', () => {
+        for (const t of plan({ idp: 'auth0', maps: 'esri' })) {
+            const isCloud = ['google', 'azure', 'aws'].includes(t.id);
+            expect(Boolean(t.foundation)).toBe(isCloud);
+        }
+    });
+});
+
+describe('what the town asked for is what it gets', () => {
+    it('leaves out anything unticked', () => {
+        const list = ids({ wanted: new Set() });
+        // Sign-in and maps are not optional -- a town cannot take a report
+        // without them -- so they survive an empty tick list.
+        const items = plan({ wanted: new Set() }).flatMap(t => t.items.map(i => i.id));
+        expect(items.sort()).toEqual(['identity', 'maps']);
+        expect(list.length).toBeGreaterThan(0);
+    });
+
+    it('puts whatever carries a required item first', () => {
+        // Auth0 sign-in on an Azure town: the Auth0 task has to come before the
+        // big optional Azure one, or the first thing on the page is the wrong
+        // thing to do first.
+        const list = ids({ idp: 'auth0' });
+        expect(list.indexOf('auth0')).toBeLessThan(list.indexOf('azure'));
+        expect(plan({ idp: 'auth0' }).find(t => t.id === 'auth0')!.required).toBe(true);
+    });
+
+    it('screening and blurring are one item, not two', () => {
+        /* They were two sections and it made no sense: both answer "what is
+         * safe to publish", and a clerk had to work out that the rose panel
+         * three sections up was about words and this one is about faces. */
+        const all = plan().flatMap(t => t.items);
+        const safety = all.filter(i => i.id === 'safety');
+        expect(safety).toHaveLength(1);
+        expect(safety[0].title.toLowerCase()).toContain('blurring');
+        expect(safety[0].cap).toBe('redaction');
+    });
+
+    it('follows the cloud for things that are a cloud decision', () => {
+        const g = plan({ cloud: 'google', aiProvider: 'vertex', maps: 'google', idp: 'auth0' });
+        const google = g.find(t => t.id === 'google')!;
+        expect(google.items.map(i => i.id).sort()).toContain('translation');
+        expect(google.items.find(i => i.id === 'ai')!.provider).toBe('vertex');
+        expect(google.items.find(i => i.id === 'kms')!.provider).toBe('google');
+    });
+
+    it('lets email and text sit with whoever actually sends them', () => {
+        // An Azure town sending through SES: email belongs to the AWS trip, not
+        // the Azure one, because that is the console it is configured in.
+        const t = plan({ emailProvider: 'ses' });
+        expect(t.find(x => x.id === 'aws')!.items.map(i => i.id)).toContain('email');
+        expect(t.find(x => x.id === 'azure')!.items.map(i => i.id)).not.toContain('email');
+    });
+});
+
+describe('every item can actually be filled in', () => {
+    it('has somewhere to type, or is a pointer to its own component', () => {
+        /* The failure this catches is an item that renders a heading, a
+         * sentence, and nothing else -- which is what the guide used to do
+         * before the boxes moved inline, and which looks identical to a step
+         * that needs no input. */
+        const configurable = plan().flatMap(t => t.items).filter(i => i.id !== 'govtech');
+        for (const item of configurable) {
+            const hasProvider = Boolean(item.cap && item.provider);
+            const hasSecrets = Boolean(item.secrets?.length);
+            expect(hasProvider || hasSecrets).toBe(true);
+        }
+    });
+
+    it('gives backups real boxes rather than telling anyone to find a card', () => {
+        const backups = plan().flatMap(t => t.items).find(i => i.id === 'backups')!;
+        const keys = backups.secrets!.map(s => s.key);
+        expect(keys).toContain('BACKUP_S3_BUCKET');
+        expect(keys).toContain('BACKUP_S3_ACCESS_KEY');
+        expect(keys).toContain('BACKUP_S3_SECRET_KEY');
+    });
+
+    it('offers Azure Content Safety boxes only on Azure', () => {
+        const azureSafety = plan().flatMap(t => t.items).find(i => i.id === 'safety')!;
+        expect(azureSafety.secrets?.map(s => s.key)).toContain('AZURE_CONTENT_SAFETY_KEY');
+        // On Google and AWS the screening reuses credentials entered elsewhere,
+        // so offering an empty pair of boxes would invite someone to hunt for
+        // values that do not exist.
+        const awsSafety = plan({ cloud: 'aws', redactionProvider: 'aws' })
+            .flatMap(t => t.items).find(i => i.id === 'safety')!;
+        expect(awsSafety.secrets).toBeUndefined();
+    });
+
+    it('never puts one item in two tasks', () => {
+        const seen = plan().flatMap(t => t.items.map(i => i.id));
+        expect(new Set(seen).size).toBe(seen.length);
+    });
+});
+
+describe('the copy does not make promises', () => {
+    /* No claims about price, speed, or how easy something is. A town's
+     * procurement officer reads these too, a free tier can change, and telling
+     * a clerk something takes ten minutes is a way of making them feel slow
+     * when it takes forty. */
+    const FORBIDDEN = /\b(free|cheap|costs?|pricing|per month|a month|dollars?|cents?|\$\d|minutes?|hours?|quick(ly|est)?|fast(est)?|easy|easiest|simple|simplest|straightforward|just a)\b/i;
+
+    it('says nothing about cost, speed or difficulty', () => {
+        const offenders: string[] = [];
+        for (const t of [...plan(), ...plan({ cloud: 'google', idp: 'auth0', maps: 'esri' }),
+                         ...plan({ cloud: 'aws', idp: 'okta', maps: 'apple' })]) {
+            if (FORBIDDEN.test(t.blurb)) offenders.push(`task ${t.id}: ${t.blurb}`);
+            for (const i of t.items) {
+                if (FORBIDDEN.test(i.blurb)) offenders.push(`item ${i.id}: ${i.blurb}`);
+                if (FORBIDDEN.test(i.title)) offenders.push(`title ${i.id}: ${i.title}`);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+});

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -1,0 +1,300 @@
+import type { Capability } from '../services/api';
+
+/**
+ * The setup guide, organised by the console you have to open.
+ *
+ * The guide used to have one section per capability, in a fixed order: staff
+ * sign-in, then maps, then AI, then translation, then key management. For a
+ * town on Azure that reads as Azure, Google, Azure, Azure, Azure -- five
+ * sections, four of which are the same portal, each repeating "create a
+ * resource in pinpoint311-rg" as though you had not just done it. A clerk
+ * following it top to bottom opens the Azure portal, leaves for Google, and
+ * comes back three times.
+ *
+ * So the unit is not a capability, it is a trip. Everything that lives behind
+ * one login gets folded into one task: the foundation steps once, then each
+ * thing to create while you are already in there. A town on Azure using Entra
+ * for sign-in and Azure Maps has a single Azure task covering sign-in, maps,
+ * AI, translation, Key Vault and Content Safety. A town on Azure using Google
+ * Maps has two tasks, because that genuinely is two logins.
+ *
+ * This file is the arithmetic and nothing else -- no JSX, no fetching -- so the
+ * grouping can be tested directly rather than through a rendered page.
+ */
+
+export type Cloud = 'google' | 'azure' | 'aws';
+export type Idp = 'auth0' | 'entra' | 'okta' | 'oidc';
+export type MapProvider = 'google' | 'esri' | 'azure' | 'apple';
+
+/** Who you sign in to. Two capabilities share a vendor iff they share a login. */
+export type Vendor =
+    | 'google' | 'azure' | 'aws'
+    | 'auth0' | 'okta' | 'oidc'
+    | 'esri' | 'apple'
+    | 'twilio' | 'smtp' | 'http'
+    | 'sentry' | 'storage' | 'local' | 'govtech';
+
+export const VENDOR_LABEL: Record<Vendor, string> = {
+    google: 'Google Cloud',
+    azure: 'Microsoft Azure',
+    aws: 'AWS',
+    auth0: 'Auth0',
+    okta: 'Okta',
+    oidc: 'Your OIDC provider',
+    esri: 'Esri / ArcGIS',
+    apple: 'Apple',
+    twilio: 'Twilio',
+    smtp: 'Your mail server',
+    http: 'Your SMS gateway',
+    sentry: 'Sentry',
+    storage: 'Your backup storage',
+    local: 'This server',
+    govtech: "Your town's other systems",
+};
+
+/* Entra is administered in the Azure portal, so a town on Azure that uses it
+ * for staff sign-in is not making a second trip. Getting this wrong in the
+ * other direction would be worse than not grouping at all: it would promise one
+ * login and then need two. */
+const IDP_VENDOR: Record<Idp, Vendor> = {
+    auth0: 'auth0', entra: 'azure', okta: 'okta', oidc: 'oidc',
+};
+const AI_VENDOR: Record<string, Vendor> = { vertex: 'google', azure: 'azure', bedrock: 'aws' };
+const EMAIL_VENDOR: Record<string, Vendor> = { smtp: 'smtp', ses: 'aws', acs: 'azure' };
+const SMS_VENDOR: Record<string, Vendor> = { twilio: 'twilio', sns: 'aws', acs: 'azure', http: 'http' };
+
+/** One thing to set up, inside one task. */
+export interface PlanItem {
+    /** Stable id, used for the "done" lookup and as a React key. */
+    id: string;
+    title: string;
+    /** What it does, in a sentence, for someone who did not pick it themselves. */
+    blurb: string;
+    /** The capability whose catalog holds its credentials, if it has one. */
+    cap?: Capability;
+    /** Which provider of that capability. */
+    provider?: string;
+    /** Settings with no capability card, entered as plain boxes. */
+    secrets?: { key: string; label: string; secret?: boolean; help?: string }[];
+    /** Alternatives offered inline, where the cloud answer does not decide it. */
+    choices?: { id: string; label: string }[];
+    /** Which questionnaire answer this item's provider comes from, so a picker
+     *  can write back to the right piece of state. */
+    choiceKey?: 'email' | 'sms' | 'redaction' | 'maps' | 'idp';
+    /** Required to take a report at all. */
+    required?: boolean;
+}
+
+export interface PlanTask {
+    id: string;
+    vendor: Vendor;
+    title: string;
+    /** Why this task exists, shown under the title. */
+    blurb: string;
+    /** Whether this task needs the cloud foundation walk (project, resource
+     *  group, IAM) before its items. Only the three clouds do. */
+    foundation: Cloud | null;
+    items: PlanItem[];
+    required: boolean;
+}
+
+export interface PlanInput {
+    cloud: Cloud;
+    idp: Idp;
+    maps: MapProvider;
+    aiProvider: string;
+    emailProvider: string;
+    smsProvider: string;
+    redactionProvider: string;
+    /** Feature ids ticked in the questionnaire. */
+    wanted: ReadonlySet<string>;
+}
+
+/* Order is the order a town should work in, not the order the code was
+ * written. Sign-in and maps are required, so whichever task carries them comes
+ * first; the cloud task is next because most optional features hang off it. */
+const VENDOR_ORDER: Vendor[] = [
+    'auth0', 'okta', 'oidc',            // sign-in, when it is its own vendor
+    'azure', 'google', 'aws',           // the clouds
+    'esri', 'apple',                    // maps, when it is its own vendor
+    'smtp', 'twilio', 'http',           // delivery, when it is its own vendor
+    'local', 'storage', 'govtech', 'sentry',
+];
+
+export function buildPlan(input: PlanInput): PlanTask[] {
+    const { cloud, idp, maps, wanted } = input;
+    const want = (f: string) => wanted.has(f);
+    const byVendor = new Map<Vendor, PlanItem[]>();
+    const add = (vendor: Vendor, item: PlanItem) => {
+        const list = byVendor.get(vendor) ?? [];
+        list.push(item);
+        byVendor.set(vendor, list);
+    };
+
+    // --- Required ---------------------------------------------------------
+
+    add(IDP_VENDOR[idp], {
+        id: 'identity',
+        title: 'Staff sign-in',
+        blurb: 'How your staff log in. Residents never sign in — only the people who work the reports.',
+        cap: 'identity', provider: idp, required: true,
+    });
+
+    add(maps as Vendor, {
+        id: 'maps',
+        title: 'Maps and address lookup',
+        blurb: 'The map residents drop a pin on, and the address box that finds their street.',
+        cap: 'maps', provider: maps, required: true,
+    });
+
+    // --- Optional, folded into whichever console owns them ----------------
+
+    if (want('ai')) {
+        add(AI_VENDOR[input.aiProvider] ?? cloud, {
+            id: 'ai',
+            title: 'AI triage',
+            blurb: 'Suggests a category and a department for each new report. A clerk still decides.',
+            cap: 'ai', provider: input.aiProvider,
+        });
+    }
+
+    if (want('translation')) {
+        add(cloud, {
+            id: 'translation',
+            title: 'Translation',
+            blurb: 'Lets residents file in their own language. Your staff carry on in English.',
+            cap: 'translation', provider: cloud,
+        });
+    }
+
+    if (want('secrets')) {
+        add(cloud, {
+            id: 'kms',
+            title: 'Key management and secret storage',
+            blurb: 'Keeps resident names, emails and phone numbers encrypted, using a key your cloud looks after.',
+            cap: 'kms', provider: cloud,
+        });
+    }
+
+    /* Screening and blurring, together.
+     *
+     * They were two sections and they should not have been. Both answer "what
+     * is safe to publish", both are configured in the same place, and a clerk
+     * reading two rose-coloured panels about photos three sections apart has to
+     * work out that one is about words and the other about faces. */
+    if (want('safety')) {
+        add((input.redactionProvider as Vendor) || cloud, {
+            id: 'safety',
+            title: 'Screening and blurring',
+            blurb: 'Screens what residents write, and blurs faces and number plates in the photos they send. Abusive text is always screened, with or without this.',
+            cap: 'redaction', provider: input.redactionProvider,
+            choiceKey: 'redaction',
+            choices: [
+                { id: 'local', label: 'On this server' },
+                { id: 'google', label: 'Google Cloud Vision' },
+                { id: 'azure', label: 'Azure Face + Vision' },
+                { id: 'aws', label: 'AWS Rekognition' },
+            ],
+            secrets: cloud === 'azure' ? [
+                { key: 'AZURE_CONTENT_SAFETY_ENDPOINT', label: 'Content Safety endpoint', help: 'Keys and Endpoint blade of an Azure AI Content Safety resource.' },
+                { key: 'AZURE_CONTENT_SAFETY_KEY', label: 'Content Safety key', secret: true, help: 'Either KEY 1 or KEY 2 — they are interchangeable.' },
+            ] : undefined,
+        });
+    }
+
+    if (want('email')) {
+        add(EMAIL_VENDOR[input.emailProvider] ?? 'smtp', {
+            id: 'email',
+            title: 'Email notifications',
+            blurb: 'Sends residents a confirmation when they file, and an update when the job is done.',
+            cap: 'email', provider: input.emailProvider,
+            choiceKey: 'email',
+            choices: [
+                { id: 'smtp', label: 'SMTP (your existing mail server)' },
+                { id: 'ses', label: 'Amazon SES' },
+                { id: 'acs', label: 'Azure Communication Services' },
+            ],
+        });
+    }
+
+    if (want('sms')) {
+        add(SMS_VENDOR[input.smsProvider] ?? 'twilio', {
+            id: 'sms',
+            title: 'Text message notifications',
+            blurb: 'The same updates by text, for residents who give a mobile number. Email on its own is fine too.',
+            cap: 'sms', provider: input.smsProvider,
+            choiceKey: 'sms',
+            choices: [
+                { id: 'twilio', label: 'Twilio' },
+                { id: 'sns', label: 'Amazon SNS' },
+                { id: 'acs', label: 'Azure Communication Services' },
+                { id: 'http', label: 'Other (HTTP gateway)' },
+            ],
+        });
+    }
+
+    if (want('backups')) {
+        add('storage', {
+            id: 'backups',
+            title: 'Automatic backups',
+            blurb: 'A nightly copy of everything, kept somewhere other than this server.',
+            secrets: [
+                { key: 'BACKUP_S3_BUCKET', label: 'Bucket name' },
+                { key: 'BACKUP_S3_ENDPOINT', label: 'Endpoint URL', help: 'Leave blank for AWS S3. Set it for Oracle, MinIO, Backblaze and the rest.' },
+                { key: 'BACKUP_S3_REGION', label: 'Region' },
+                { key: 'BACKUP_S3_ACCESS_KEY', label: 'Access key ID', secret: true },
+                { key: 'BACKUP_S3_SECRET_KEY', label: 'Secret access key', secret: true },
+            ],
+        });
+    }
+
+    if (want('govtech')) {
+        add('govtech', {
+            id: 'govtech',
+            title: 'Connecting a system the town already uses',
+            blurb: 'Sends reports into permitting or work-order software the town already runs, so staff are not typing things twice.',
+        });
+    }
+
+    if (want('errors')) {
+        add('sentry', {
+            id: 'errors',
+            title: 'Crash reporting',
+            blurb: 'Sends crash reports somewhere off this server, so they survive a restart.',
+            secrets: [{ key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true, help: 'Project Settings → Client Keys (DSN).' }],
+        });
+    }
+
+    // --- Assemble ---------------------------------------------------------
+
+    const tasks: PlanTask[] = [];
+    for (const vendor of VENDOR_ORDER) {
+        const items = byVendor.get(vendor);
+        if (!items?.length) continue;
+        const isCloud = vendor === 'google' || vendor === 'azure' || vendor === 'aws';
+        tasks.push({
+            id: vendor,
+            vendor,
+            title: VENDOR_LABEL[vendor],
+            blurb: isCloud
+                ? `Everything here is in one place. Set the account up once, then add each piece while you are already signed in.`
+                : items.length > 1
+                    ? 'Both of these use the same login.'
+                    : items[0].blurb,
+            foundation: isCloud ? (vendor as Cloud) : null,
+            items,
+            required: items.some(i => i.required),
+        });
+    }
+
+    /* Whatever carries a required item goes first, whichever vendor it is. A
+     * town cannot take a report without sign-in and a map, and burying those
+     * under an optional cloud task would make the first thing on the page the
+     * wrong thing. */
+    return tasks.sort((a, b) => Number(b.required) - Number(a.required));
+}
+
+/** The first task not yet finished, which is where the wizard should be. */
+export function nextIncomplete(tasks: PlanTask[], done: (t: PlanTask) => boolean): PlanTask | undefined {
+    return tasks.find(t => !done(t));
+}

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -420,7 +420,7 @@ defineSteps('maps', 'apple', () => [
         body: (
             <>
                 This needs a paid <L href="https://developer.apple.com/programs/">Apple Developer
-                Program</L> membership (about $99/year) held by the town, not by a person. If you do not
+                Program</L> membership held by the town, not by a person. If you do not
                 have one, one of the other map providers will be much less work.
             </>
         ),
@@ -599,7 +599,7 @@ defineSteps('translation', 'azure', () => [
         body: (
             <>
                 In the <L href="https://portal.azure.com">Azure portal</L>, press <B>Create a
-                resource</B> and create a <B>Translator</B> resource. The free tier handles a
+                resource</B> and create a <B>Translator</B> resource. Pick the tier that suits a
                 small town's volume; note the <B>region</B> you pick, because it is part of the
                 credentials.
             </>
@@ -788,7 +788,7 @@ defineSteps('sms', 'sns', () => [
                 unregistered traffic heavily.
             </>
         ),
-        trouble: <>Start the 10DLC registration early. It is a carrier process, not an AWS one, and it can take a couple of weeks.</>,
+        trouble: <>Start the 10DLC registration early. It is a carrier process rather than an AWS one, and it is not immediate.</>,
     },
     {
         body: (
@@ -1199,7 +1199,7 @@ defineSteps('redaction', 'local', () => [
         body: (
             <>
                 <B>This is what you get if you choose nothing.</B> Detection runs on this server using
-                OpenCV, with no account, no key and no cost — and no resident photo ever leaves the
+                OpenCV, with no account and no key — and no resident photo ever leaves the
                 building, which is the real reason to keep it.
             </>
         ),


### PR DESCRIPTION
## One trip per login

The guide was ten stacked panels, all open, ordered by feature. For a town on Azure that reads Azure, Google, Azure, Azure, Azure — five sections, four of them the same portal, each repeating "create a resource in pinpoint311-rg" as though you had not just done it.

The unit is now a trip rather than a feature. Everything behind one login is one task: the account setup once, then each piece to create while already signed in. A town on Azure using Entra and Azure Maps gets a single Azure task covering sign-in, maps, AI, translation, Key Vault and screening — Entra is administered in the Azure portal, so it is not a second visit. Using Google Maps instead makes that two tasks, because it genuinely is two logins.

A side rail lists the tasks and one is open at a time. Finishing advances you — not on save, but on a save whose live test came back green, because being moved past a credential that does not work is the failure this page exists to prevent.

`setupPlan.ts` is the grouping arithmetic, with no JSX and no fetching, so it is tested directly rather than through a rendered page.

## Also asked for

- **Screening and blurring are one section.** They were two panels about what is safe to publish, three sections apart, and the second was hidden by the first one&#39;s tick.
- **Esri is offered rather than pushed.** One of four options, not the answer.
- **No claims about price, speed or difficulty, anywhere.** Every `time=` and `cost=` label is gone, along with "free tier", "about $99/year", "quickest" and "simplest". A free tier can change without notice and a procurement officer reads this page too.
- **Backups are configured inline** like everything else.
- **Prose rewritten shorter and plainer**, for the clerk who was handed this job rather than an engineer.
- **Callback URLs use the town&#39;s configured domain**, not whatever address the admin&#39;s browser is on. A redirect URI registered from an internal hostname produces a login that accepts the password and then fails on the redirect — which reads as a wrong secret rather than a wrong URL.

## Cards become the standing view

The handcrafted `premium-card` template, one status line saying which provider, whether it works and when that was last checked, plus **Test now** and **Edit**.

"Configured" was a fact about our own database: it went green the moment a credential was saved and stayed green through the key being revoked. A nightly task now runs the same live checks the Test button runs, so an expired key shows amber the next morning rather than in a complaint. It skips what is not configured, does not record "cannot be checked from here" as a failure, and does not stop at the first check that raises.

## Roads follow the boundary, however it arrived

Three endpoints accept a boundary — an uploaded file, a Census lookup, the built-in search — and only the search persisted it and fetched roads. The other two loaded the shape into an in-memory helper and returned success, so the boundary was gone on restart and no road was ever fetched. The map still drew, because the browser had the file it had just uploaded.

Underneath that, the state was read out of the boundary&#39;s *name*. That works for a search result ("Montclair, Essex County, New Jersey") and never for `montclair.geojson`, so uploaded boundaries quietly got the national layer instead of the state&#39;s NG911 centrelines — the ones that know the street names and last year&#39;s subdivisions.

The state now comes from the coordinates, via a point-in-polygon query against the Census state layer, with the name and a saved setting as offline fallbacks. All three paths land on the same source: an OSM search result, a county GIS export carrying only a FIPS code, and a bare shape with no properties at all each resolve to New Jersey&#39;s NG911 file.

It returns nothing rather than a guess when it cannot tell. The national layer covers every state, so "could not tell" costs better data; a confident wrong answer hands a town its neighbour&#39;s streets.

I tried a state bounding-box table first. It was wrong for eleven of twenty-six real towns, Montclair included — state boxes overlap most exactly where being wrong matters. That table is gone.

The lookup is verified against the live service: layer 0 of `State_County` is states, the point-intersects query works, and a point in Montclair returns `STUSAB: "NJ"`. That response is pinned as a fixture. It also justified the field validation retroactively — the same feature carries `STATE: "34"`, a FIPS code, two characters, under a key the parser checks first. Accepting any two-character value returns `"34"` and every town silently gets the national layer.

## Smaller things found on the way

- `"DEFAULT"` was being truncated into a two-character column as `"DE"`, so the roads page told New Jersey towns their source was Delaware.
- Eight inline setup blocks each probed the attached-identity endpoint; now memoised on the in-flight promise.
- The guide&#39;s inline wrapper was declared during render, making it a fresh component type every time — React would remount it and discard a half-typed client secret whenever any chip was ticked.

## Verification

529 backend tests under CI&#39;s four-package install, 850 with the full one, 103 frontend, clean build, typecheck steady at 11 pre-existing errors.

Checked by mutation rather than by passing. Reverting to name-first fails 1; removing the coordinate lookup fails 5; guessing `DEFAULT` fails 1; dropping the inline seed fallback fails 1; un-persisting the upload fails 2; depending on a single field name fails 1; accepting any two-character string as a state fails 4. On the connector sweep: testing unconfigured connectors fails 1, treating unverifiable as failure fails 1, aborting on the first raise fails 2.

**Not verified in a browser.** The tests drive the components and assert on the DOM, but nobody has looked at the side-rail layout, the folded Azure task or the rebuilt cards on a real screen. That is where I would expect any remaining problems.

**One known asymmetry.** With the Census lookup unreachable, a search result still resolves (its name carries the state) while an uploaded file falls back to the national layer. Roads still arrive, they are just the less-good ones. Closing it would mean reverse-geocoding through the town&#39;s own map provider, which is always configured since maps is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_