### PR TITLE
Setup guide: one thing at a time, honest status, and a departments page that matches

### DIFF
--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -981,6 +981,43 @@ class CloudProfileRequest(BaseModel):
     apply_identity: bool = False
 
 
+@router.get("/providers/status")
+async def get_provider_status(_: User = Depends(get_current_admin)):
+    """Which provider each capability is on, and which providers are set up.
+
+    One request instead of eight. The setup guide's task list needs to know
+    whether each item is finished before anything is opened, and the only
+    honest answer is per *provider* rather than per capability.
+
+    That distinction is the bug this exists to fix. The page was deciding from
+    the stored secrets, where "maps is configured" meant any map provider's key
+    was present -- so a town that had set up Google Maps and then switched to
+    Esri saw a green tick against a provider with no credentials at all, and the
+    guide skipped straight past the thing it most needed to ask for.
+    """
+    from app.core.sanitize import sanitize_for_log
+    from app.services.secret_manager import get_secret
+
+    out: Dict[str, Any] = {}
+    for capability, select_key in _PROVIDER_SELECT_KEY.items():
+        try:
+
+            providers = await providers_for(capability)
+            current = ((await get_secret(select_key)) or "").strip().lower()
+            out[capability] = {
+                "current_provider": current or None,
+                "configured": await _configured_map(providers),
+            }
+        except Exception as exc:
+            # One capability failing to report must not blank the other seven.
+            # An absent entry reads as "unknown", which the page shows as
+            # unfinished -- the safe direction, since the cost is asking about
+            # something already done rather than skipping something that isn't.
+            logger.warning("provider status failed for %s: %s",
+                           sanitize_for_log(capability), sanitize_for_log(str(exc)))
+    return out
+
+
 @router.get("/providers/cloud-identity")
 async def cloud_identity(_: User = Depends(get_current_admin)):
     """Whether this server already has an identity on its cloud.

--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -103,7 +103,7 @@ def test_the_wizard_only_advances_on_a_passing_test():
     advancing at all: it reads as confirmation."""
     wizard = _read(WIZARD)
     assert "onSaved={onRefresh}" not in wizard, "advancing on save rather than on a passing test"
-    assert "verified &&" in wizard, "nothing gates the advance on the test result"
+    assert "if (verified) advanceItem" in wizard, "nothing gates the advance on the test result"
     assert "advanceFrom" in wizard
 
 
@@ -291,3 +291,44 @@ def test_esri_is_offered_rather_than_pushed():
     guide_text = _read(GUIDE)
     assert "before you buy anything" not in guide_text
     assert "choose Esri above" not in guide_text
+
+
+# ---------------------------------------------------------------------------
+# The wall
+# ---------------------------------------------------------------------------
+
+def test_only_one_item_is_open_inside_a_task():
+    """Grouping by login turned four visits into one and then put all four on
+    the screen at once. The Azure task rendered about six thousand pixels tall
+    while the rail said "1 left" -- the same wall, moved.
+
+    Items collapse for the same reason tasks do, and advance on the same rule:
+    a save whose live test came back green.
+    """
+    wizard = _read(WIZARD)
+    assert "openItemId" in wizard, "every item in a task is expanded at once"
+    assert "expanded={item.id === openItemId}" in wizard
+    assert "advanceItem" in wizard, "finishing an item does not open the next"
+    assert "if (verified) advanceItem" in wizard, (
+        "items advance on save rather than on a passing test"
+    )
+
+
+def test_no_console_walk_runs_away_with_itself():
+    """A cap on how long any one provider's instructions can get.
+
+    Not arbitrary: the three key-management walks were 456, 465 and 559 words,
+    and two of the Azure steps restated what step one had already said. Prose at
+    that length stops being instructions and becomes something to skim, which is
+    how the warnings inside it get missed.
+    """
+    import re
+
+    source = _read(CONTENT)
+    offenders = []
+    for m in re.finditer(r"defineSteps\(\s*'([a-z]+)'\s*,\s*'([a-z0-9]+)'", source):
+        end = source.index("\n]);", m.start())
+        words = len(re.sub(r"<[^>]+>", " ", source[m.start():end]).split())
+        if words > 400:
+            offenders.append(f"{m.group(1)}:{m.group(2)} is {words} words")
+    assert not offenders, "console walks have grown back:\n" + "\n".join(offenders)

--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -80,7 +80,7 @@ def test_the_page_mounts_the_wizard(guide):
     assert "<SetupWizard" in guide
     # And hands it everything it needs to do the work in place rather than
     # describing it. Any of these missing is a silently half-wired panel.
-    for prop in ("isDone=", "onRefresh=", "publicOrigin=", "renderFoundation=", "onChooseProvider="):
+    for prop in ("status=", "isDone=", "onRefresh=", "publicOrigin=", "renderFoundation="):
         assert prop in guide, f"the wizard is mounted without {prop}"
 
 
@@ -145,18 +145,80 @@ def test_changing_the_cloud_moves_the_email_and_sms_defaults(guide):
     assert "redactionOverride ?? setupCloud" in guide
 
 
-def test_every_extra_has_a_chip_and_every_chip_reaches_the_plan(guide):
-    """A feature with no chip cannot be turned off; a chip the plan ignores is a
-    control that does nothing when clicked."""
-    features = set(re.findall(r"'([a-z]+)'", re.search(r"const ALL_FEATURES = \[(.*?)\]", guide, re.S).group(1)))
-    chips = set(re.findall(r"\['([a-z]+)', '[^']+'\]", guide))
-    assert features == chips, (
-        f"features without a chip: {sorted(features - chips)}; "
-        f"chips that are not features: {sorted(chips - features)}"
+def test_every_feature_gates_something_in_the_plan(guide):
+    """A chip that changes nothing when clicked.
+
+    The feature ids and their chip labels used to be two separate lists, and
+    both failure directions had already happened: `errors` was in one and not
+    the other, so crash reporting could not be switched off. They are one list
+    now, so the only thing left to check is that ticking each one actually
+    reaches the plan.
+    """
+    features = set(re.findall(r"\['([a-z]+)', '[^']+'\]",
+                              re.search(r"const FEATURES = \[(.*?)\] as const;", guide, re.S).group(1)))
+    assert features, "could not find the feature list"
+    assert "ALL_FEATURES: readonly string[] = FEATURES.map" in guide, (
+        "the feature set is hand-written again rather than derived from the chips"
     )
     plan = _read(PLAN)
     unused = [f for f in features if f"want('{f}')" not in plan]
     assert not unused, f"ticking these changes nothing in the plan: {sorted(unused)}"
+
+
+def test_provider_choices_are_all_made_in_the_questionnaire(guide):
+    """Every provider decision happens once, at the top.
+
+    Email, text and screening used to be decided on pickers nested inside their
+    own sections further down, so the questionnaire could say one thing and a
+    section another, and there was nowhere to see what the town had chosen.
+    """
+    plan = _read(PLAN)
+    assert "choices?" not in plan, "a task is offering its own provider picker again"
+    assert "choiceKey" not in plan
+    for question in ("Who sends your email?", "Who sends your text messages?",
+                     "Where should photos be checked and blurred?"):
+        assert question in guide, f"the questionnaire never asks: {question}"
+
+
+def test_the_town_systems_connector_is_not_repeated_in_the_guide(guide):
+    """It has its own section, with its own wizard, further down the page. A
+    stub in the guide duplicated the heading and explained nothing."""
+    plan = _read(PLAN)
+    assert "govtech" not in plan, "the guide has grown a town-systems task again"
+    assert "'govtech'" not in guide
+
+
+def test_the_completion_message_means_completion(guide):
+    """It rendered whenever nothing was open -- which includes collapsing a row,
+    so clicking the open task shut congratulated a town that had configured
+    nothing at all."""
+    wizard = _read(WIZARD)
+    assert "allDone" in wizard, "nothing distinguishes 'finished' from 'nothing selected'"
+    assert "{!open && (allDone ? (" in wizard, "the done panel is not gated on being done"
+    # And it sits outside the AnimatePresence, so the fallback appears at once
+    # rather than after an exit animation -- which is also what makes the bug
+    # visible to a test rather than hidden behind frames jsdom never produces.
+    assert wizard.index("{!open && (allDone") > wizard.index("</AnimatePresence>")
+
+
+def test_done_means_done_for_the_provider_actually_chosen(guide):
+    """Read per capability, "maps is set up" was true if any map provider had a
+    key -- so switching from Google to Esri kept a green tick against a provider
+    with no credentials, and the guide skipped it."""
+    wizard = _read(WIZARD)
+    assert "status?.[item.cap]?.configured?.[item.provider]" in wizard, (
+        "done-ness is not being read per provider"
+    )
+    system = (ROOT / "backend/app/api/system.py").read_text()
+    assert "async def get_provider_status" in system
+    assert '"/providers/status"' in system
+
+
+def test_switching_provider_reopens_the_task(guide):
+    """Leaving it collapsed with a tick is how a town goes live on a provider it
+    never configured."""
+    wizard = _read(WIZARD)
+    assert "props.redactionProvider]" in wizard, "nothing watches for a provider change"
 
 
 def test_screening_and_blurring_are_one_thing(guide):

--- a/frontend/preview.html
+++ b/frontend/preview.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>preview</title></head>
+<body><div id="root"></div><script type="module" src="/src/__preview__/main.tsx"></script></body></html>

--- a/frontend/src/__preview__/main.tsx
+++ b/frontend/src/__preview__/main.tsx
@@ -1,0 +1,121 @@
+import { createRoot } from 'react-dom/client';
+
+/**
+ * A local harness for looking at admin pages.
+ *
+ * Not part of the app and not built into it -- Vite's build entry is
+ * index.html, so preview.html and this file never reach dist. Run
+ * `npx vite` and open /preview.html.
+ *
+ * It exists because two rounds of this work were verified only by tests
+ * asserting on the DOM, which cannot see that a page looks wrong. The
+ * departments cards matched the service-category page in every respect a test
+ * could check and still read as a different product until they were put side
+ * by side here.
+ */
+import '../index.css';
+
+import SetupWizard from '../components/SetupWizard';
+import { DepartmentsTab, ServiceCategoriesTab } from '../pages/AdminConsole';
+
+// Canned API so the components render exactly as they would with a real one.
+const CATALOGS: Record<string, any> = {
+    identity: { current_provider: 'entra', configured: { entra: false }, providers: [
+        { provider: 'entra', name: 'Microsoft Entra ID', credential_fields: [
+            { key: 'ENTRA_TENANT_ID', label: 'Directory (tenant) ID', secret: false },
+            { key: 'ENTRA_CLIENT_ID', label: 'Application (client) ID', secret: false },
+            { key: 'ENTRA_CLIENT_SECRET', label: 'Client secret value', secret: true }]}]},
+    maps: { current_provider: 'google', configured: { google: true }, providers: [
+        { provider: 'google', name: 'Google Maps', credential_fields: [
+            { key: 'GOOGLE_MAPS_API_KEY', label: 'Google Maps API key', secret: true }]}]},
+    ai: { current_provider: 'azure', configured: { azure: false }, providers: [
+        { provider: 'azure', name: 'Azure OpenAI', credential_fields: [
+            { key: 'AZURE_OPENAI_ENDPOINT', label: 'Endpoint', secret: false },
+            { key: 'AZURE_OPENAI_API_KEY', label: 'API key', secret: true }]}]},
+    translation: { current_provider: 'azure', configured: { azure: false }, providers: [
+        { provider: 'azure', name: 'Azure Translator', credential_fields: [
+            { key: 'AZURE_TRANSLATOR_KEY', label: 'Translator key', secret: true },
+            { key: 'AZURE_TRANSLATOR_REGION', label: 'Region', secret: false }]}]},
+    kms: { current_provider: 'azure', configured: { azure: false }, providers: [
+        { provider: 'azure', name: 'Azure Key Vault', credential_fields: [
+            { key: 'AZURE_KEYVAULT_URL', label: 'Vault URL', secret: false }]}]},
+};
+const origFetch = window.fetch.bind(window);
+window.fetch = async (input: any, init?: any) => {
+    const url = String(typeof input === 'string' ? input : input.url);
+    const json = (o: any) => new Response(JSON.stringify(o), { headers: { 'Content-Type': 'application/json' } });
+    const m = url.match(/\/system\/([a-z]+)\/catalog/);
+    if (m && CATALOGS[m[1]]) return json(CATALOGS[m[1]]);
+    if (url.includes('cloud-identity')) return json({ attached: false, provider: null, identity: null, skippable_keys: [] });
+    if (url.includes('/system/')) return json({});
+    return origFetch(input, init);
+};
+
+const DEPARTMENTS = [
+    { id: 1, name: 'Public Works', description: 'Roads, potholes, street lighting and drainage', routing_email: 'publicworks@example.gov', is_active: true },
+    { id: 2, name: 'Sanitation', description: 'Refuse collection, recycling and missed pickups', routing_email: 'sanitation@example.gov', is_active: true },
+    { id: 3, name: 'Parks & Recreation', description: 'Parks, playgrounds, trees and public grounds', routing_email: null, is_active: true },
+    { id: 4, name: 'Code Enforcement', description: 'Property maintenance and zoning complaints', routing_email: 'code@example.gov', is_active: true },
+];
+
+const SERVICES = [
+    { id: 1, service_code: 'POTHOLE', service_name: 'Pothole', description: 'Damaged road surface', routing_mode: 'road_based', is_active: true, department_id: 1, display_order: 1 },
+    { id: 2, service_code: 'STREETLIGHT', service_name: 'Street Light Out', description: 'Lighting fault on a public way', routing_mode: 'township', is_active: true, department_id: 1, display_order: 2 },
+    { id: 3, service_code: 'MISSEDPICKUP', service_name: 'Missed Refuse Collection', description: 'Bins not emptied on the scheduled day', routing_mode: 'township', is_active: true, department_id: 2, display_order: 3 },
+    { id: 4, service_code: 'TREE', service_name: 'Fallen or Damaged Tree', description: 'Trees on public land', routing_mode: 'third_party', is_active: true, department_id: 3, display_order: 4 },
+];
+
+const STATUS = {
+    identity: { current_provider: 'entra', configured: { entra: false } },
+    maps: { current_provider: 'google', configured: { google: true } },
+    ai: { current_provider: 'azure', configured: { azure: false } },
+    translation: { current_provider: 'azure', configured: { azure: false } },
+    kms: { current_provider: 'azure', configured: { azure: false } },
+};
+
+function Section({ id, title, children }: any) {
+    return (
+        <section id={id} className="p-8 max-w-6xl mx-auto">
+            <p className="text-[10px] uppercase tracking-widest text-white/25 mb-4">{title}</p>
+            {children}
+        </section>
+    );
+}
+
+function App() {
+    return (
+        <div style={{ background: 'linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #1e1b4b 100%)', minHeight: '100vh' }}>
+            <Section id="wizard" title="Setup guide">
+                <SetupWizard
+                    cloud="azure" idp="entra" maps="google"
+                    aiProvider="azure" emailProvider="acs" smsProvider="acs" redactionProvider="azure"
+                    wanted={new Set(['ai', 'translation', 'secrets'])}
+                    status={STATUS as any}
+                    isDone={() => false}
+                    secretValues={{}} onSecretChange={() => {}} onSaveSecrets={async () => {}}
+                    savingSecret={null} isSecretConfigured={() => false}
+                    onRefresh={() => {}} publicOrigin="https://311.example.gov"
+                    renderFoundation={(cloud) => (
+                        <div className="space-y-2.5">
+                            <p className="text-[11px] uppercase tracking-wider text-white/45 font-semibold">First, the account</p>
+                            <p className="text-sm text-white/70 pl-9">Create a resource group called <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311-rg</code> in the {cloud} portal. Everything below goes in it.</p>
+                        </div>
+                    )}
+                />
+            </Section>
+
+            <Section id="departments" title="Departments">
+                <DepartmentsTab departments={DEPARTMENTS as any} onAdd={() => {}} onEdit={() => {}} onDelete={() => {}} />
+            </Section>
+
+            <Section id="categories" title="Service categories (for comparison)">
+                <ServiceCategoriesTab
+                    services={SERVICES as any} setServices={() => {}} loadTabData={() => {}}
+                    setShowServiceModal={() => {}} handleEditService={() => {}} handleDeleteService={() => {}}
+                />
+            </Section>
+        </div>
+    );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -11,7 +11,7 @@ import {
 import { Card, Button, Input, Badge, CollapsibleSection } from './ui';
 import { SystemSecret } from '../types';
 import { api } from '../services/api';
-import type { Capability } from '../services/api';
+import type { Capability, ProviderStatusMap } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 import SetupWizard from './SetupWizard';
@@ -21,6 +21,71 @@ import './setupStepsContent';
 import StorageStatusLine from './StorageStatusLine';
 import { openStayInformed } from './StayInformed';
 
+
+/* One question in the questionnaire.
+ *
+ * Declared at module scope, not inside the page's render. A component defined
+ * during render is a fresh type every render, so React unmounts and remounts it
+ * -- which, for anything holding state, silently discards what was typed.
+ */
+/* The optional features, as id-and-label pairs.
+ *
+ * One list rather than two. An id in the feature set with no chip is a feature
+ * that cannot be switched off; a chip whose id is not in the set is a control
+ * that does nothing when clicked. Both existed, so the set is now derived from
+ * the chips and the pair cannot drift.
+ */
+const FEATURES = [
+    ['ai', 'AI triage'],
+    ['translation', 'Translation'],
+    ['safety', 'Screening and blurring'],
+    ['email', 'Email'],
+    ['sms', 'Text messages'],
+    ['secrets', 'Key management'],
+    ['backups', 'Backups'],
+    ['errors', 'Crash reporting'],
+] as const;
+
+const ALL_FEATURES: readonly string[] = FEATURES.map(([id]) => id);
+
+function Ask({ n, label, hint, children }: {
+    n: number; label: string; hint?: string; children: React.ReactNode;
+}) {
+    return (
+        <div className="mb-4 last:mb-0">
+            <p className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">
+                {n}. {label}
+            </p>
+            {hint && <p className="text-white/40 text-[11px] mt-0.5 mb-1.5">{hint}</p>}
+            <div className="mt-1.5">{children}</div>
+        </div>
+    );
+}
+
+/** A row of mutually exclusive choices. */
+function Options({ value, onChange, options }: {
+    value: string;
+    onChange: (v: string) => void;
+    options: readonly (readonly [string, string])[];
+}) {
+    return (
+        <div className="flex flex-wrap gap-2">
+            {options.map(([id, label]) => (
+                <button
+                    key={id}
+                    type="button"
+                    onClick={() => onChange(id)}
+                    aria-pressed={value === id}
+                    className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${value === id
+                        ? 'bg-primary-500/20 border-primary-400/50 text-white'
+                        : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}
+                >
+                    {label}
+                </button>
+            ))}
+        </div>
+    );
+}
 
 interface ModulesState {
     ai_analysis: boolean;
@@ -72,7 +137,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * up with the whole platform switched on, not the three we happened to
      * pre-tick -- so the list below is every feature, and a town removes what
      * it genuinely does not want. */
-    const ALL_FEATURES = ['ai', 'translation', 'safety', 'email', 'sms', 'secrets', 'govtech', 'backups', 'errors'];
     const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(new Set(ALL_FEATURES));
     const toggleFeature = (f: string) =>
         setWantedFeatures(prev => {
@@ -112,14 +176,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const smsProvider = smsOverride ?? SMS_BY_CLOUD[setupCloud];
     const redactionProvider = redactionOverride ?? setupCloud;
 
-    /** A picker inside the wizard writing back to the questionnaire's state. */
-    const chooseProvider = (key: 'email' | 'sms' | 'redaction' | 'maps' | 'idp', id: string) => {
-        if (key === 'email') setEmailOverride(id);
-        else if (key === 'sms') setSmsOverride(id);
-        else if (key === 'redaction') setRedactionOverride(id);
-        else if (key === 'maps') setSetupMaps(id as typeof setupMaps);
-        else if (key === 'idp') setSetupIdp(id as typeof setupIdp);
-    };
 
     /* The setup questions are asked in feature terms ("AI triage", "Secret
      * storage + PII encryption") and the provider cards are keyed by
@@ -156,6 +212,18 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * than a wrong URL. null means nothing has configured a domain yet, and the
      * browser's origin is the best guess available. */
     const [publicOrigin, setPublicOrigin] = useState<string | null>(null);
+    /* Which provider each capability is on, and which are set up.
+     *
+     * Per provider, not per capability: "maps is configured" was true if any
+     * map provider's key existed, so switching to one with no credentials still
+     * showed a tick. Refetched whenever something saves. */
+    const [providerStatus, setProviderStatus] = useState<ProviderStatusMap | null>(null);
+    const loadProviderStatus = useCallback(() => {
+        api.getProviderStatus()
+            .then(setProviderStatus)
+            .catch(() => { /* leaves everything unfinished, which is the safe way to be wrong */ });
+    }, []);
+    useEffect(() => { loadProviderStatus(); }, [loadProviderStatus, secrets.length]);
     useEffect(() => {
         fetch('/api/system/config')
             .then(r => (r.ok ? r.json() : null))
@@ -249,10 +317,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         sms: smsConfigured,
         backups: !!backupConfigured,
         errors: !!sentryConfigured,
-        // The connector wizard lives in its own component and reports no single
-        // "configured" flag, so this never marks itself finished. Optional, and
-        // a town that has not connected anything has not got it wrong.
-        govtech: false,
     };
     const itemDone = (id: string) => DONE_BY_ITEM[id] ?? false;
 
@@ -521,56 +585,108 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     <p className="text-sm font-semibold text-white mb-0.5">Answer a few questions and we will hide the rest</p>
                                     <p className="text-white/50 text-xs mb-3">Sign-in and maps are always shown — a town needs both before it can take a report.</p>
 
-                                    <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">1. Which company hosts your town's services?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If the town already uses Microsoft 365, pick Microsoft Azure. If you are not sure, pick Google — you can change it later.</p>
-                                    <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
-                                        {(['google', 'azure', 'aws'] as const).map(c => (
-                                            <button key={c} type="button" onClick={() => setSetupCloud(c)}
-                                                className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${setupCloud === c ? 'bg-primary-500/20 border-primary-400/50 text-white' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
-                                                {{ google: 'Google Cloud', azure: 'Microsoft Azure', aws: 'AWS' }[c]}
-                                            </button>
-                                        ))}
-                                    </div>
+                                    {/* Every provider decision, in one place.
+                                      *
+                                      * They used to be split: the cloud, sign-in
+                                      * and maps here, and email, text and
+                                      * screening on pickers nested inside their
+                                      * own sections further down. That meant the
+                                      * questionnaire could say one thing and a
+                                      * section another, and a clerk had no single
+                                      * place to see what the town had chosen.
+                                      *
+                                      * Extras come first because there is no
+                                      * point asking who sends your email before
+                                      * asking whether you want email at all. */}
+                                    <Ask
+                                        n={1}
+                                        label="What do you want to switch on? (all optional)"
+                                        hint="Sign-in and maps are always needed. Tick anything else you want; untick to remove it."
+                                    >
+                                        <div className="flex flex-wrap gap-2">
+                                            {FEATURES.map(([f, label]) => (
+                                                <button key={f} type="button" onClick={() => toggleFeature(f)}
+                                                    aria-pressed={wants(f)}
+                                                    className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${wants(f) ? 'bg-emerald-500/15 border-emerald-400/40 text-emerald-100' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
+                                                    {wants(f) ? '\u2713 ' : ''}{label}
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </Ask>
 
-                                    <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">2. How will staff sign in?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If your staff already sign in to Microsoft 365, you already have Entra and can use it. Auth0 is for when there is nothing in place yet.</p>
-                                    <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
-                                        {(['auth0', 'entra', 'okta', 'oidc'] as const).map(c => (
-                                            <button key={c} type="button" onClick={() => setSetupIdp(c)}
-                                                className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${setupIdp === c ? 'bg-primary-500/20 border-primary-400/50 text-white' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
-                                                {{ auth0: 'Auth0', entra: 'Microsoft Entra ID', okta: 'Okta', oidc: 'Other (OIDC)' }[c]}
-                                            </button>
-                                        ))}
-                                    </div>
+                                    <Ask
+                                        n={2}
+                                        label="Which company hosts your town's services?"
+                                        hint="If the town already uses Microsoft 365, pick Microsoft Azure. If you are not sure, pick Google — you can change it later."
+                                    >
+                                        <Options
+                                            value={setupCloud}
+                                            onChange={(v) => setSetupCloud(v as typeof setupCloud)}
+                                            options={[['google', 'Google Cloud'], ['azure', 'Microsoft Azure'], ['aws', 'AWS']]}
+                                        />
+                                    </Ask>
 
-                                    <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">3. Which map provider?</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">If the town or county already has an ArcGIS agreement, Esri lets you use it. Otherwise any of these will do.</p>
-                                    <div className="flex flex-wrap gap-2 mt-1.5 mb-4">
-                                        {(['google', 'esri', 'azure', 'apple'] as const).map(c => (
-                                            <button key={c} type="button" onClick={() => setSetupMaps(c)}
-                                                className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${setupMaps === c ? 'bg-primary-500/20 border-primary-400/50 text-white' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
-                                                {{ google: 'Google Maps', esri: 'Esri / ArcGIS', azure: 'Azure Maps', apple: 'Apple Maps' }[c]}
-                                            </button>
-                                        ))}
-                                    </div>
+                                    <Ask
+                                        n={3}
+                                        label="How will staff sign in?"
+                                        hint="If your staff already sign in to Microsoft 365, you already have Entra and can use it. Auth0 is for when there is nothing in place yet."
+                                    >
+                                        <Options
+                                            value={setupIdp}
+                                            onChange={(v) => setSetupIdp(v as typeof setupIdp)}
+                                            options={[['auth0', 'Auth0'], ['entra', 'Microsoft Entra ID'], ['okta', 'Okta'], ['oidc', 'Other (OIDC)']]}
+                                        />
+                                    </Ask>
 
-                                    <label className="text-[11px] uppercase tracking-wider text-white/50 font-semibold">4. Which extras do you want? (all optional)</label>
-                                    <p className="text-white/40 text-[11px] mt-0.5 mb-1">Tick anything you want. Each one is added to the list below, grouped with whatever else uses the same login. Untick to remove it again.</p>
-                                    <div className="flex flex-wrap gap-2 mt-1.5">
-                                        {([
-                                            ['ai', 'AI triage'], ['translation', 'Translation'],
-                                            ['safety', 'Screening and blurring'],
-                                            ['email', 'Email'], ['sms', 'Text messages'],
-                                            ['secrets', 'Key management'],
-                                            ['govtech', 'Town-system connector'], ['backups', 'Backups'],
-                                            ['errors', 'Crash reporting'],
-                                        ] as const).map(([f, label]) => (
-                                            <button key={f} type="button" onClick={() => toggleFeature(f)}
-                                                className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${wants(f) ? 'bg-emerald-500/15 border-emerald-400/40 text-emerald-100' : 'bg-white/5 border-white/10 text-white/60 hover:text-white'}`}>
-                                                {wants(f) ? '✓ ' : ''}{label}
-                                            </button>
-                                        ))}
-                                    </div>
+                                    <Ask
+                                        n={4}
+                                        label="Which map provider?"
+                                        hint="If the town or county already has an ArcGIS agreement, Esri lets you use it. Otherwise any of these will do."
+                                    >
+                                        <Options
+                                            value={setupMaps}
+                                            onChange={(v) => setSetupMaps(v as typeof setupMaps)}
+                                            options={[['google', 'Google Maps'], ['esri', 'Esri / ArcGIS'], ['azure', 'Azure Maps'], ['apple', 'Apple Maps']]}
+                                        />
+                                    </Ask>
+
+                                    {/* Only asked about what the town ticked.
+                                      * These three are not a cloud decision -- a
+                                      * town on Google may well send through SES --
+                                      * so each starts on whatever suits the cloud
+                                      * above and can be changed here. */}
+                                    {wants('email') && (
+                                        <Ask n={5} label="Who sends your email?"
+                                            hint="SMTP uses the mail server the town already has. Microsoft 365 and Google Workspace block plain SMTP by default, so SES or Azure Communication Services may be less work than getting an exception.">
+                                            <Options
+                                                value={emailProvider}
+                                                onChange={setEmailOverride}
+                                                options={[['smtp', 'Our mail server (SMTP)'], ['ses', 'Amazon SES'], ['acs', 'Azure Communication Services']]}
+                                            />
+                                        </Ask>
+                                    )}
+
+                                    {wants('sms') && (
+                                        <Ask n={6} label="Who sends your text messages?"
+                                            hint="Whichever you pick, start the 10DLC carrier registration early — it is not a technical step and it is not immediate.">
+                                            <Options
+                                                value={smsProvider}
+                                                onChange={setSmsOverride}
+                                                options={[['twilio', 'Twilio'], ['sns', 'Amazon SNS'], ['acs', 'Azure Communication Services'], ['http', 'Other (HTTP gateway)']]}
+                                            />
+                                        </Ask>
+                                    )}
+
+                                    {wants('safety') && (
+                                        <Ask n={7} label="Where should photos be checked and blurred?"
+                                            hint="On this server needs no account and no photo ever leaves the building; it finds fewer faces than the clouds do.">
+                                            <Options
+                                                value={redactionProvider}
+                                                onChange={setRedactionOverride}
+                                                options={[['local', 'On this server'], ['google', 'Google Cloud Vision'], ['azure', 'Azure Face + Vision'], ['aws', 'AWS Rekognition']]}
+                                            />
+                                        </Ask>
+                                    )}
                                 </div>
 
                                 <SetupWizard
@@ -582,15 +698,15 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     smsProvider={smsProvider}
                                     redactionProvider={redactionProvider}
                                     wanted={wantedFeatures}
+                                    status={providerStatus}
                                     isDone={itemDone}
                                     secretValues={secretValues}
                                     onSecretChange={(key, value) => setSecretValues(prev => ({ ...prev, [key]: value }))}
                                     onSaveSecrets={async (keys) => { for (const k of keys) await handleSave(k); }}
                                     savingSecret={savingKey}
                                     isSecretConfigured={(key) => !!isConfigured(key)}
-                                    onRefresh={onRefresh}
+                                    onRefresh={() => { onRefresh(); loadProviderStatus(); }}
                                     publicOrigin={publicOrigin}
-                                    onChooseProvider={chooseProvider}
                                     renderFoundation={renderFoundation}
                                 />
                             </div>

--- a/frontend/src/components/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Two things the task list has to get right, both reported as bugs.
+ *
+ * "Everything you picked is set up" appeared when it was not true. It rendered
+ * whenever nothing was open, and nothing is open after collapsing a row -- so
+ * clicking the current task shut congratulated a town that had configured
+ * nothing.
+ *
+ * And switching a provider left the task ticked. Done-ness was read per
+ * capability, where "maps is set up" meant any map provider had a key, so a
+ * town that configured Google Maps and switched to Esri kept a green tick
+ * against a provider with no credentials.
+ *
+ * Both are about the list, not about credentials, so this renders the wizard
+ * with its provider setup stubbed out.
+ */
+
+vi.mock('./InlineProviderSetup', () => ({
+    default: ({ cap, provider }: { cap: string; provider: string }) =>
+        React.createElement('div', { 'data-setup': `${cap}:${provider}` }),
+}));
+
+let SetupWizard: typeof import('./SetupWizard').default;
+let container: HTMLDivElement;
+let root: Root;
+
+const BASE = {
+    cloud: 'azure' as const,
+    idp: 'entra' as const,
+    maps: 'google' as string,
+    aiProvider: 'azure',
+    emailProvider: 'acs',
+    smsProvider: 'acs',
+    redactionProvider: 'azure',
+    wanted: new Set<string>(),
+    isDone: () => false,
+    secretValues: {},
+    onSecretChange: () => {},
+    onSaveSecrets: async () => {},
+    savingSecret: null,
+    isSecretConfigured: () => false,
+    onRefresh: () => {},
+    publicOrigin: 'https://311.example.gov',
+    renderFoundation: () => null,
+};
+
+/** Everything configured, for whichever providers are named. */
+const statusFor = (pairs: Record<string, string[]>) =>
+    Object.fromEntries(Object.entries(pairs).map(([cap, provs]) => [
+        cap, { current_provider: provs[0] ?? null, configured: Object.fromEntries(provs.map(p => [p, true])) },
+    ]));
+
+async function render(props: Partial<typeof BASE> & { status: any }) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(React.createElement(SetupWizard as any, { ...BASE, ...props })); });
+    await act(async () => { await Promise.resolve(); });
+}
+
+const text = () => container.textContent || '';
+const rows = () => Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'));
+
+beforeEach(async () => {
+    vi.resetModules();
+    await import('./setupStepsContent');
+    SetupWizard = (await import('./SetupWizard')).default;
+});
+
+afterEach(async () => {
+    await act(async () => { root?.unmount(); });
+    container?.remove();
+});
+
+describe('the completion message means completion', () => {
+    it('does not claim everything is set up when nothing is', async () => {
+        await render({ status: {} });
+        expect(text()).not.toContain('Everything you picked is set up');
+    });
+
+    it('still does not claim it after the open task is collapsed', async () => {
+        /* The reported bug. Collapsing a row leaves nothing open, and the done
+         * panel was shown for "nothing open" rather than for "nothing left". */
+        await render({ status: {} });
+        // The first unfinished task opens itself.
+        expect(rows()[0].getAttribute('aria-current')).toBe('step');
+
+        await act(async () => { rows()[0].click(); });
+
+        // Collapsed: nothing is the current step any more.
+        expect(rows().every(r => r.getAttribute('aria-current') === null)).toBe(true);
+        // ...and that state is not congratulation. This is the reported bug.
+        expect(text()).not.toContain('Everything you picked is set up');
+        expect(text()).toContain('2 left');
+
+        /* Not asserting that the idle panel has appeared. AnimatePresence runs
+         * `mode="wait"`, so the outgoing panel is held in the DOM until its exit
+         * animation finishes -- which it does in a browser and never does under
+         * jsdom, where no frames are produced. What matters here is what the
+         * page claims, and it no longer claims to be finished. */
+    });
+
+    it('says it only when every task really is done', async () => {
+        await render({
+            status: statusFor({ identity: ['entra'], maps: ['google'] }),
+        });
+        expect(text()).toContain('Everything you picked is set up');
+    });
+});
+
+describe('switching a provider', () => {
+    it('marks the task unfinished when the new provider has no credentials', async () => {
+        // Google Maps is set up; Esri is not. Same capability.
+        const status = statusFor({ identity: ['entra'], maps: ['google'] });
+        await render({ status });
+        expect(text()).toContain('Everything you picked is set up');
+
+        await act(async () => {
+            root.render(React.createElement(SetupWizard as any, { ...BASE, status, maps: 'esri' }));
+        });
+        await act(async () => { await Promise.resolve(); });
+
+        // No longer finished, and no longer claiming to be.
+        expect(text()).not.toContain('Everything you picked is set up');
+        expect(text()).toContain('1 left');
+    });
+
+    it('opens the task whose provider changed', async () => {
+        const status = statusFor({ identity: ['entra'], maps: ['google'] });
+        await render({ status });
+
+        await act(async () => {
+            root.render(React.createElement(SetupWizard as any, { ...BASE, status, maps: 'esri' }));
+        });
+        await act(async () => { await Promise.resolve(); });
+
+        // Esri is its own login, so it becomes its own task -- and it is the
+        // one now open, showing the boxes for the provider just chosen.
+        expect(container.querySelector('[data-setup="maps:esri"]')).toBeTruthy();
+    });
+});
+
+describe('the task list', () => {
+    it('counts what is left rather than what exists', async () => {
+        await render({ status: statusFor({ identity: ['entra'] }) });
+        expect(text()).toContain('1 left');   // maps still outstanding
+    });
+
+    it('does not tick a capability just because some other provider is set up', async () => {
+        /* The heart of the bug: `configured` keyed by provider, not capability.
+         * Google Maps configured while the town is on Esri must not read as
+         * done. */
+        const status = {
+            identity: { current_provider: 'entra', configured: { entra: true } },
+            maps: { current_provider: 'google', configured: { google: true, esri: false } },
+        };
+        await render({ status, maps: 'esri' });
+        expect(text()).not.toContain('Everything you picked is set up');
+    });
+});

--- a/frontend/src/components/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard.test.tsx
@@ -23,8 +23,14 @@ import { createRoot, type Root } from 'react-dom/client';
  */
 
 vi.mock('./InlineProviderSetup', () => ({
-    default: ({ cap, provider }: { cap: string; provider: string }) =>
-        React.createElement('div', { 'data-setup': `${cap}:${provider}` }),
+    default: ({ cap, provider, onSaved }: { cap: string; provider: string; onSaved?: (v: boolean) => void }) =>
+        React.createElement('div', { 'data-setup': `${cap}:${provider}` },
+            React.createElement('button', {
+                'data-pass': `${cap}`, onClick: () => onSaved?.(true),
+            }, 'pass'),
+            React.createElement('button', {
+                'data-fail': `${cap}`, onClick: () => onSaved?.(false),
+            }, 'fail')),
 }));
 
 let SetupWizard: typeof import('./SetupWizard').default;
@@ -163,5 +169,96 @@ describe('the task list', () => {
         };
         await render({ status, maps: 'esri' });
         expect(text()).not.toContain('Everything you picked is set up');
+    });
+});
+
+
+describe('one item open at a time', () => {
+    /* Grouping by login turned four visits into one and then put all four on
+     * the screen at once: the Azure task rendered about six thousand pixels
+     * tall while the rail said "1 left". Items collapse for the same reason
+     * tasks do. */
+    const AZURE_WORK = { wanted: new Set(['ai', 'translation', 'secrets']) };
+
+    const itemHeaders = () =>
+        Array.from(container.querySelectorAll<HTMLButtonElement>('section button[aria-expanded]'));
+    const expandedItems = () => itemHeaders().filter(b => b.getAttribute('aria-expanded') === 'true');
+    const openSetup = () => container.querySelector('[data-setup]')?.getAttribute('data-setup');
+
+    it('shows every item but expands only one', async () => {
+        await render({ ...AZURE_WORK, status: {} });
+        // Sign-in, AI, translation and key management are all one Azure trip.
+        expect(itemHeaders().length).toBe(4);
+        expect(expandedItems().length).toBe(1);
+    });
+
+    it('opens the first unfinished item', async () => {
+        await render({ ...AZURE_WORK, status: {} });
+        expect(openSetup()).toBe('identity:entra');
+    });
+
+    it('skips past items already set up', async () => {
+        await render({
+            ...AZURE_WORK,
+            status: statusFor({ identity: ['entra'], ai: ['azure'], maps: ['google'] }),
+        });
+        expect(openSetup()).toBe('translation:azure');
+    });
+
+    it('opens the next item when one is finished and verified', async () => {
+        await render({ ...AZURE_WORK, status: {} });
+        expect(openSetup()).toBe('identity:entra');
+
+        await act(async () => {
+            container.querySelector<HTMLButtonElement>('[data-pass="identity"]')!.click();
+        });
+        expect(openSetup()).toBe('ai:azure');
+    });
+
+    it('does not move on when the test failed', async () => {
+        /* The whole point of advancing on the test rather than the save.
+         * Moving somebody past a credential that does not work reads as
+         * confirmation that it does. */
+        await render({ ...AZURE_WORK, status: {} });
+        await act(async () => {
+            container.querySelector<HTMLButtonElement>('[data-fail="identity"]')!.click();
+        });
+        expect(openSetup()).toBe('identity:entra');
+    });
+
+    it('collapses and expands on click', async () => {
+        await render({ ...AZURE_WORK, status: {} });
+        const [first, second] = itemHeaders();
+
+        await act(async () => { second.click(); });
+        expect(openSetup()).toBe('ai:azure');
+
+        await act(async () => { itemHeaders()[1].click(); });   // same one again
+        expect(expandedItems().length).toBe(0);
+
+        await act(async () => { itemHeaders()[0].click(); });
+        expect(openSetup()).toBe('identity:entra');
+        expect(first).toBeTruthy();
+    });
+
+    it('leaves the task once its last item passes', async () => {
+        // Only sign-in is outstanding in the Azure task; maps is a separate one.
+        await render({
+            ...AZURE_WORK,
+            status: statusFor({ ai: ['azure'], translation: ['azure'], kms: ['azure'] }),
+        });
+        expect(openSetup()).toBe('identity:entra');
+
+        await act(async () => {
+            container.querySelector<HTMLButtonElement>('[data-pass="identity"]')!.click();
+        });
+
+        /* Asserted on the rail, not the panel. Crossing to another task swaps
+         * the panel through AnimatePresence `mode="wait"`, which holds the
+         * outgoing one until its exit animation finishes -- and jsdom produces
+         * no frames, so it never does. The rail is outside that animation and
+         * says which task is current. */
+        const current = rows().find(r => r.getAttribute('aria-current') === 'step');
+        expect(current?.textContent).toContain('Google Cloud');
     });
 });

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Check, ChevronRight, Circle, AlertCircle } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, Circle, AlertCircle } from 'lucide-react';
 
 import InlineProviderSetup from './InlineProviderSetup';
 import SecretField from './SecretField';
@@ -133,6 +133,36 @@ export default function SetupWizard(props: SetupWizardProps) {
 
     const open = openTask;
 
+    /* One item open inside the task, for the same reason one task is open in
+     * the rail. Grouping by login turned four visits into one, and then put
+     * everything from all four on the screen together: the Azure task rendered
+     * about six thousand pixels tall while the rail said "1 left". That is the
+     * same wall in a new place.
+     *
+     * Reset when the task changes, then filled in by the effect below. */
+    const [openItemId, setOpenItemId] = useState<string | null>(null);
+    const itemChosen = useRef(false);
+    useEffect(() => { setOpenItemId(null); itemChosen.current = false; }, [openId]);
+    useEffect(() => {
+        if (!open || itemChosen.current || openItemId !== null) return;
+        const next = open.items.find(i => !itemDone(i));
+        setOpenItemId((next ?? open.items[0])?.id ?? null);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [openId, status, open?.items.length]);
+
+    /** Finishing an item opens the next one, or moves on to the next task. */
+    const advanceItem = (fromId: string) => {
+        if (!open) return;
+        const index = open.items.findIndex(i => i.id === fromId);
+        const next = open.items.slice(index + 1).find(i => !itemDone(i))
+            ?? open.items.find(i => i.id !== fromId && !itemDone(i));
+        if (next) {
+            setOpenItemId(next.id);
+        } else {
+            advanceFrom(open.id);
+        }
+    };
+
     return (
         <div className="grid lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-5">
             {/* ── The list ── */}
@@ -197,19 +227,24 @@ export default function SetupWizard(props: SetupWizardProps) {
                             )}
 
                             <div className="mt-4 space-y-5">
-                                {open.items.map(item => (
+                                {open.items.map((item, i) => (
                                     <TaskItem
                                         key={item.id}
                                         item={item}
+                                        index={i + 1}
+                                        total={open.items.length}
+                                        done={itemDone(item)}
+                                        expanded={item.id === openItemId}
+                                        onToggle={() => {
+                                            itemChosen.current = true;
+                                            setOpenItemId(item.id === openItemId ? null : item.id);
+                                        }}
                                         {...props}
                                         onDone={(verified) => {
                                             onRefresh();
-                                            /* Only when the whole task is finished, and only on a
-                                             * green test. Advancing after one item of four would
-                                             * leave the other three behind. */
-                                            if (verified && open.items.every(i => i.id === item.id || itemDone(i))) {
-                                                advanceFrom(open.id);
-                                            }
+                                            // Only on a green test: moving somebody past a
+                                            // credential that does not work reads as confirmation.
+                                            if (verified) advanceItem(item.id);
                                         }}
                                         publicOrigin={publicOrigin}
                                     />
@@ -261,41 +296,80 @@ export default function SetupWizard(props: SetupWizardProps) {
 
 /** One thing inside a task: a provider with a catalog, plain settings, or both. */
 function TaskItem({
-    item, onDone, publicOrigin,
+    item, index, total, done, expanded, onToggle, onDone, publicOrigin,
     secretValues, onSecretChange, onSaveSecrets, savingSecret, isSecretConfigured,
 }: {
     item: PlanItem;
+    index: number;
+    total: number;
+    done: boolean;
+    expanded: boolean;
+    onToggle: () => void;
     onDone: (verified: boolean) => void;
     publicOrigin: string | null;
 } & Pick<SetupWizardProps,
     'secretValues' | 'onSecretChange' | 'onSaveSecrets' | 'savingSecret' | 'isSecretConfigured'>) {
     return (
-        <div>
-            <h4 className="text-sm font-semibold text-white/90">{item.title}</h4>
-            <p className="text-xs text-white/50 leading-relaxed mt-0.5 mb-2.5">{item.blurb}</p>
-
-            {item.cap && item.provider && (
-                <InlineProviderSetup
-                    cap={item.cap}
-                    provider={item.provider}
-                    onSaved={onDone}
-                    publicOrigin={publicOrigin}
+        <div className={`rounded-2xl border transition-colors ${expanded
+            ? 'border-white/15 bg-white/[0.04]'
+            : 'border-white/[0.07] bg-white/[0.02] hover:bg-white/[0.04]'}`}>
+            <button
+                type="button"
+                onClick={onToggle}
+                aria-expanded={expanded}
+                className="w-full text-left px-4 py-3 flex items-center gap-3 rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
+            >
+                <span
+                    className={`shrink-0 w-6 h-6 rounded-full border text-[11px] font-semibold flex items-center justify-center ${done
+                        ? 'bg-emerald-500/20 border-emerald-400/40 text-emerald-300'
+                        : 'bg-white/10 border-white/15 text-white/60'}`}
+                    aria-hidden="true"
+                >
+                    {done ? <Check className="w-3.5 h-3.5" /> : index}
+                </span>
+                <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-semibold text-white/90 truncate">{item.title}</span>
+                    {/* The one-line summary stays visible when collapsed, so the
+                        list reads as a plan rather than as a row of headings. */}
+                    <span className="block text-[11px] text-white/45 truncate">
+                        {done ? 'Set up' : item.blurb}
+                    </span>
+                </span>
+                <span className="text-[10px] uppercase tracking-wider text-white/30 shrink-0 hidden sm:block">
+                    {index} of {total}
+                </span>
+                <ChevronDown
+                    className={`w-4 h-4 text-white/35 shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`}
+                    aria-hidden="true"
                 />
-            )}
+            </button>
 
-            {item.secrets && (
-                <PlainSecrets
-                    fields={item.secrets}
-                    values={secretValues}
-                    onChange={onSecretChange}
-                    onSave={onSaveSecrets}
-                    saving={savingSecret}
-                    isConfigured={isSecretConfigured}
-                    onSaved={() => onDone(false)}
-                    /* Spacing only when it follows a provider block, so an item
-                     * that is only settings does not start with a gap. */
-                    className={item.cap ? 'mt-3' : ''}
-                />
+            {/* No blurb repeated inside: it is already in the header above,
+                which stays visible while expanded. */}
+            {expanded && (
+                <div className="px-4 pb-4 pt-1">
+                    {item.cap && item.provider && (
+                        <InlineProviderSetup
+                            cap={item.cap}
+                            provider={item.provider}
+                            onSaved={onDone}
+                            publicOrigin={publicOrigin}
+                        />
+                    )}
+
+                    {item.secrets && (
+                        <PlainSecrets
+                            fields={item.secrets}
+                            values={secretValues}
+                            onChange={onSecretChange}
+                            onSave={onSaveSecrets}
+                            saving={savingSecret}
+                            isConfigured={isSecretConfigured}
+                            onSaved={() => onDone(false)}
+                            className={item.cap ? 'mt-3' : ''}
+                        />
+                    )}
+                </div>
             )}
         </div>
     );

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight, Circle, AlertCircle } from 'lucide-react';
 import InlineProviderSetup from './InlineProviderSetup';
 import SecretField from './SecretField';
 import { buildPlan, type PlanInput, type PlanItem, type PlanTask } from './setupPlan';
+import type { ProviderStatusMap } from '../services/api';
 // Registers every provider's console walk as an import side effect.
 import './setupStepsContent';
 
@@ -36,7 +37,10 @@ const STATUS_TONE = {
 } as const;
 
 export interface SetupWizardProps extends PlanInput {
-    /** Whether an item is already set up, from secrets the page has loaded. */
+    /** Which provider each capability is on and which are set up, from the
+     *  server. Null while it loads. */
+    status: ProviderStatusMap | null;
+    /** For items with no capability catalog -- backups, the Sentry key. */
     isDone: (itemId: string) => boolean;
     /** Plain settings, saved through the page's own secret endpoint. */
     secretValues: Record<string, string>;
@@ -48,23 +52,40 @@ export interface SetupWizardProps extends PlanInput {
     onRefresh: () => void;
     /** The address residents use, for callback URLs. */
     publicOrigin: string | null;
-    /** Switch a choice the questionnaire seeded but did not settle. */
-    onChooseProvider: (key: NonNullable<PlanItem['choiceKey']>, id: string) => void;
     /** The cloud foundation walk, which belongs to no single capability. */
     renderFoundation: (cloud: 'google' | 'azure' | 'aws') => React.ReactNode;
-    /** The town-systems connector, which has its own component further down. */
-    renderGovtech?: () => React.ReactNode;
 }
 
 export default function SetupWizard(props: SetupWizardProps) {
-    const { isDone, onRefresh, publicOrigin, onChooseProvider, renderFoundation } = props;
+    const { onRefresh, publicOrigin, renderFoundation, status } = props;
 
     const tasks = useMemo(() => buildPlan(props), [
         props.cloud, props.idp, props.maps, props.aiProvider,
         props.emailProvider, props.smsProvider, props.redactionProvider, props.wanted,
     ]);
 
-    const taskDone = (t: PlanTask) => t.items.every(i => isDone(i.id));
+    /* Finished means finished *for the provider currently chosen*.
+     *
+     * This was the bug behind two complaints at once. Done-ness was read from
+     * the stored secrets per capability, so "maps is set up" was true if any
+     * map provider's key existed. A town that configured Google Maps and then
+     * switched to Esri saw a green tick against a provider with no credentials,
+     * and the guide skipped the one thing it most needed to ask for.
+     *
+     * Asking the server per provider fixes both: the tick is honest, and
+     * switching to something unconfigured makes the task unfinished again,
+     * which is what reopens it.
+     */
+    const itemDone = (item: PlanItem): boolean => {
+        if (item.cap && item.provider) {
+            // Unknown until the status arrives. Treated as unfinished, which is
+            // the safe direction: the cost is asking about something already
+            // done rather than skipping something that is not.
+            return status?.[item.cap]?.configured?.[item.provider] === true;
+        }
+        return props.isDone(item.id);
+    };
+    const taskDone = (t: PlanTask) => t.items.every(itemDone);
 
     const [openId, setOpenId] = useState<string | null>(null);
     /* Once a clerk clicks a row, their choice wins over the automatic one --
@@ -72,23 +93,45 @@ export default function SetupWizard(props: SetupWizardProps) {
      * and look at something already finished. */
     const chosen = useRef(false);
 
-    // Land on the first unfinished task, once, when status first arrives.
+    const remaining = tasks.filter(t => !taskDone(t)).length;
+    const allDone = tasks.length > 0 && remaining === 0;
+
+    // Land on the first unfinished task once the server has said which those
+    // are. Guarded on `status` as well as on the ref: before it arrives every
+    // task looks unfinished, so landing then would always pick the first one.
     useEffect(() => {
-        if (chosen.current || openId !== null || tasks.length === 0) return;
-        setOpenId((tasks.find(t => !taskDone(t)) ?? tasks[0]).id);
+        if (chosen.current || openId !== null || tasks.length === 0 || !status) return;
+        const next = tasks.find(t => !taskDone(t));
+        if (next) setOpenId(next.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tasks.length]);
+    }, [tasks.length, status]);
+
+    /* Switching a provider reopens the task it belongs to.
+     *
+     * Changing the map provider from Google to Esri makes that task unfinished
+     * again -- there are no Esri credentials -- and leaving it collapsed with a
+     * tick beside it is how a town ends up live on a provider it never
+     * configured. Only reopens what the clerk has not deliberately navigated
+     * away from since. */
+    const openTask = tasks.find(t => t.id === openId) ?? null;
+    useEffect(() => {
+        if (openTask && !taskDone(openTask)) return;
+        const next = tasks.find(t => !taskDone(t));
+        if (next && next.id !== openId) setOpenId(next.id);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.cloud, props.idp, props.maps, props.aiProvider,
+        props.emailProvider, props.smsProvider, props.redactionProvider]);
 
     /** Move on, but only from a task that is genuinely finished. */
     const advanceFrom = (taskId: string) => {
         const index = tasks.findIndex(t => t.id === taskId);
         if (index < 0) return;
-        const next = tasks.slice(index + 1).find(t => !taskDone(t));
+        const next = tasks.slice(index + 1).find(t => !taskDone(t))
+            ?? tasks.find(t => !taskDone(t));
         setOpenId(next ? next.id : null);
     };
 
-    const open = tasks.find(t => t.id === openId) ?? null;
-    const remaining = tasks.filter(t => !taskDone(t)).length;
+    const open = openTask;
 
     return (
         <div className="grid lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-5">
@@ -134,7 +177,8 @@ export default function SetupWizard(props: SetupWizardProps) {
             {/* ── The one you are on ── */}
             <div className="min-w-0">
                 <AnimatePresence mode="wait">
-                    {open ? (
+                    {open && (
+
                         <motion.section
                             key={open.id}
                             initial={{ opacity: 0, y: 8 }}
@@ -163,34 +207,51 @@ export default function SetupWizard(props: SetupWizardProps) {
                                             /* Only when the whole task is finished, and only on a
                                              * green test. Advancing after one item of four would
                                              * leave the other three behind. */
-                                            if (verified && open.items.every(i => i.id === item.id || isDone(i.id))) {
+                                            if (verified && open.items.every(i => i.id === item.id || itemDone(i))) {
                                                 advanceFrom(open.id);
                                             }
                                         }}
                                         publicOrigin={publicOrigin}
-                                        onChooseProvider={onChooseProvider}
                                     />
                                 ))}
-                                {open.vendor === 'govtech' && props.renderGovtech?.()}
                             </div>
                         </motion.section>
-                    ) : (
-                        <motion.div
-                            key="done"
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            className="setup-panel p-6 text-center"
-                        >
-                            <div className="w-12 h-12 mx-auto rounded-2xl bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center shadow-lg shadow-emerald-500/25">
-                                <Check className="w-6 h-6 text-white" strokeWidth={2.5} />
-                            </div>
-                            <p className="text-white/80 mt-3.5">Everything you picked is set up.</p>
-                            <p className="text-white/45 text-sm mt-1.5">
-                                Pick anything from the list to look at it again, or change it later on the cards below.
-                            </p>
-                        </motion.div>
                     )}
                 </AnimatePresence>
+
+                {/* Outside the AnimatePresence above, deliberately.
+                    Inside it, `mode="wait"` holds the outgoing task panel until
+                    its exit animation finishes, so collapsing a row left the
+                    old panel on screen and this one unmounted. It is also what
+                    made the bug invisible to a test: jsdom produces no frames,
+                    so the exit never completes and the wrong panel never
+                    appears. */}
+                {!open && (allDone ? (
+                    <div className="setup-panel p-6 text-center">
+                        <div className="w-12 h-12 mx-auto rounded-2xl bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center shadow-lg shadow-emerald-500/25">
+                            <Check className="w-6 h-6 text-white" strokeWidth={2.5} />
+                        </div>
+                        <p className="text-white/80 mt-3.5">Everything you picked is set up.</p>
+                        <p className="text-white/45 text-sm mt-1.5">
+                            Pick anything from the list to look at it again, or change it later on the cards below.
+                        </p>
+                    </div>
+                ) : (
+                    /* Nothing open, but not finished either.
+                     *
+                     * This state used to render the "everything is set up"
+                     * panel, because that panel was shown whenever nothing was
+                     * open -- and nothing is open after collapsing a row, not
+                     * only after finishing the last task. So clicking the open
+                     * task shut congratulated a town that had configured
+                     * nothing at all. */
+                    <div className="setup-panel p-6 text-center">
+                        <p className="text-white/70">
+                            {remaining} {remaining === 1 ? 'thing' : 'things'} left to set up.
+                        </p>
+                        <p className="text-white/45 text-sm mt-1.5">Pick one from the list to carry on.</p>
+                    </div>
+                ))}
             </div>
         </div>
     );
@@ -200,13 +261,12 @@ export default function SetupWizard(props: SetupWizardProps) {
 
 /** One thing inside a task: a provider with a catalog, plain settings, or both. */
 function TaskItem({
-    item, onDone, publicOrigin, onChooseProvider,
+    item, onDone, publicOrigin,
     secretValues, onSecretChange, onSaveSecrets, savingSecret, isSecretConfigured,
 }: {
     item: PlanItem;
     onDone: (verified: boolean) => void;
     publicOrigin: string | null;
-    onChooseProvider: (key: NonNullable<PlanItem['choiceKey']>, id: string) => void;
 } & Pick<SetupWizardProps,
     'secretValues' | 'onSecretChange' | 'onSaveSecrets' | 'savingSecret' | 'isSecretConfigured'>) {
     return (
@@ -218,8 +278,6 @@ function TaskItem({
                 <InlineProviderSetup
                     cap={item.cap}
                     provider={item.provider}
-                    choices={item.choices}
-                    onChoose={item.choiceKey ? (id) => onChooseProvider(item.choiceKey!, id) : undefined}
                     onSaved={onDone}
                     publicOrigin={publicOrigin}
                 />

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -32,7 +32,7 @@ export type Vendor =
     | 'auth0' | 'okta' | 'oidc'
     | 'esri' | 'apple'
     | 'twilio' | 'smtp' | 'http'
-    | 'sentry' | 'storage' | 'local' | 'govtech';
+    | 'sentry' | 'storage' | 'local';
 
 export const VENDOR_LABEL: Record<Vendor, string> = {
     google: 'Google Cloud',
@@ -49,7 +49,6 @@ export const VENDOR_LABEL: Record<Vendor, string> = {
     sentry: 'Sentry',
     storage: 'Your backup storage',
     local: 'This server',
-    govtech: "Your town's other systems",
 };
 
 /* Entra is administered in the Azure portal, so a town on Azure that uses it
@@ -76,11 +75,10 @@ export interface PlanItem {
     provider?: string;
     /** Settings with no capability card, entered as plain boxes. */
     secrets?: { key: string; label: string; secret?: boolean; help?: string }[];
-    /** Alternatives offered inline, where the cloud answer does not decide it. */
-    choices?: { id: string; label: string }[];
-    /** Which questionnaire answer this item's provider comes from, so a picker
-     *  can write back to the right piece of state. */
-    choiceKey?: 'email' | 'sms' | 'redaction' | 'maps' | 'idp';
+    /* No `choices` here on purpose. Every provider decision is made once, in
+     * the questionnaire at the top, so a task never asks again -- asking twice
+     * is how a clerk ends up with a section configured for one provider and a
+     * questionnaire that says another. */
     /** Required to take a report at all. */
     required?: boolean;
 }
@@ -118,7 +116,7 @@ const VENDOR_ORDER: Vendor[] = [
     'azure', 'google', 'aws',           // the clouds
     'esri', 'apple',                    // maps, when it is its own vendor
     'smtp', 'twilio', 'http',           // delivery, when it is its own vendor
-    'local', 'storage', 'govtech', 'sentry',
+    'local', 'storage', 'sentry',
 ];
 
 export function buildPlan(input: PlanInput): PlanTask[] {
@@ -188,13 +186,6 @@ export function buildPlan(input: PlanInput): PlanTask[] {
             title: 'Screening and blurring',
             blurb: 'Screens what residents write, and blurs faces and number plates in the photos they send. Abusive text is always screened, with or without this.',
             cap: 'redaction', provider: input.redactionProvider,
-            choiceKey: 'redaction',
-            choices: [
-                { id: 'local', label: 'On this server' },
-                { id: 'google', label: 'Google Cloud Vision' },
-                { id: 'azure', label: 'Azure Face + Vision' },
-                { id: 'aws', label: 'AWS Rekognition' },
-            ],
             secrets: cloud === 'azure' ? [
                 { key: 'AZURE_CONTENT_SAFETY_ENDPOINT', label: 'Content Safety endpoint', help: 'Keys and Endpoint blade of an Azure AI Content Safety resource.' },
                 { key: 'AZURE_CONTENT_SAFETY_KEY', label: 'Content Safety key', secret: true, help: 'Either KEY 1 or KEY 2 — they are interchangeable.' },
@@ -208,12 +199,6 @@ export function buildPlan(input: PlanInput): PlanTask[] {
             title: 'Email notifications',
             blurb: 'Sends residents a confirmation when they file, and an update when the job is done.',
             cap: 'email', provider: input.emailProvider,
-            choiceKey: 'email',
-            choices: [
-                { id: 'smtp', label: 'SMTP (your existing mail server)' },
-                { id: 'ses', label: 'Amazon SES' },
-                { id: 'acs', label: 'Azure Communication Services' },
-            ],
         });
     }
 
@@ -223,13 +208,6 @@ export function buildPlan(input: PlanInput): PlanTask[] {
             title: 'Text message notifications',
             blurb: 'The same updates by text, for residents who give a mobile number. Email on its own is fine too.',
             cap: 'sms', provider: input.smsProvider,
-            choiceKey: 'sms',
-            choices: [
-                { id: 'twilio', label: 'Twilio' },
-                { id: 'sns', label: 'Amazon SNS' },
-                { id: 'acs', label: 'Azure Communication Services' },
-                { id: 'http', label: 'Other (HTTP gateway)' },
-            ],
         });
     }
 
@@ -248,13 +226,6 @@ export function buildPlan(input: PlanInput): PlanTask[] {
         });
     }
 
-    if (want('govtech')) {
-        add('govtech', {
-            id: 'govtech',
-            title: 'Connecting a system the town already uses',
-            blurb: 'Sends reports into permitting or work-order software the town already runs, so staff are not typing things twice.',
-        });
-    }
 
     if (want('errors')) {
         add('sentry', {

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -840,9 +840,9 @@ defineSteps('sms', 'http', () => [
     {
         body: (
             <>
-                For a gateway that is not listed — a regional carrier, a state contract, or an existing
-                notification system. Pinpoint sends a POST with a JSON body containing the destination
-                number and the message text, and treats any 2xx response as delivered.
+                For a gateway not listed here — a regional carrier, a state contract, an existing
+                notification system. Pinpoint POSTs JSON with the number and the message, and treats
+                any 2xx as delivered.
             </>
         ),
     },
@@ -876,13 +876,11 @@ defineSteps('sms', 'http', () => [
  */
 const ACCOUNT_SURVIVES = (
     <>
-        <B>Finally, the boring one that matters most.</B> Every protection above guards the key. None
-        of them guards the <em>account</em> — and an account closed for non-payment takes the key with
-        it after about 90 days, whatever is set on the key itself. So: the cloud account must be in the
-        town's name on a town payment method, not an individual's; more than one person must be an
-        administrator; and billing alerts must go to a shared address that is still monitored after
-        somebody leaves. For most towns that is the realistic way this data gets lost — not a
-        mis-click, a lapsed card between budget cycles.
+        <B>The boring one that matters most.</B> Everything above protects the key. Nothing protects
+        the <em>account</em>, and a closed account takes the key with it. So put the cloud account in
+        the town's name on a town payment method, make more than one person an administrator, and send
+        billing alerts to a shared address. This, not a mis-click, is how towns actually lose the
+        data — a lapsed card between budget cycles.
     </>
 );
 
@@ -928,36 +926,24 @@ defineSteps('kms', 'google', () => [
     {
         body: (
             <>
-                <B>Then make it hard to destroy.</B> Google will not let you delete a key or a key ring
-                at all — only <em>destroy a key version</em>, which is enough to lose the data. Two
-                things to do now, while you are already here:
-                <span className="mt-2 grid gap-1.5">
-                    <span className="text-white/50 text-xs">
-                        Set the key's <B>destroy scheduled duration</B> to the longest you can — the
-                        default is 24 hours, and it can go to 120 days. That is the length of the window
-                        in which somebody can undo the mistake.
-                    </span>
-                    <span className="text-white/50 text-xs">
-                        Make sure day-to-day accounts do not hold{' '}
-                        <C>cloudkms.cryptoKeyVersions.destroy</C>. Encrypter/Decrypter does not include
-                        it — so if you followed the previous step exactly, Pinpoint already cannot
-                        destroy its own key. Check that a human administrator's role does not either.
-                    </span>
-                </span>
+                <B>Make it hard to destroy.</B> Keys and key rings cannot be deleted, but a key{' '}
+                <em>version</em> can be destroyed, which loses the data just as well. Set the key's{' '}
+                <B>destroy scheduled duration</B> to the longest available — it defaults to 24 hours
+                and goes to 120 days. That is how long somebody has to undo a mistake. Then check no
+                everyday account holds <C>cloudkms.cryptoKeyVersions.destroy</C>.
             </>
         ),
-        trouble: <>Rotating this key is safe and good practice — old versions stay and keep decrypting old rows. <B>Destroying</B> a version is the fatal one, and the two sit next to each other in the console. Once a version is destroyed, Google cannot recover it for you, for law enforcement, or for anyone.</>,
+        trouble: <>Rotating is safe — old versions stay and keep decrypting old rows. <B>Destroying</B> a version is the fatal one, and the two sit next to each other in the console. Google cannot recover a destroyed version for anyone.</>,
     },
     {
         body: (
             <>
-                <B>Protect the project, not just the key.</B> None of the above survives the project
-                being deleted — that takes the key ring with it. Place a <B>lien</B> on the project,
-                which blocks deletion outright until somebody removes the lien:
+                <B>Protect the project too.</B> Deleting the project takes the key ring with it, whatever
+                is set on the key. A <B>lien</B> blocks that until somebody removes the lien:
                 <span className="mt-2 block"><C>gcloud alpha resource-manager liens create --project=YOUR_PROJECT --restrictions=resourcemanager.projects.delete --reason="Holds the Pinpoint 311 PII encryption key"</C></span>
             </>
         ),
-        trouble: <>Ask whoever manages your Google Cloud billing to run it if you do not have the command line. It is one command, it is free, and it is the difference between a mis-click being an inconvenience and being permanent.</>,
+        trouble: <>No command line? Ask whoever manages your Google Cloud billing to run it. It is free, and it is the difference between a mis-click being an inconvenience and being permanent.</>,
     },
     {
         body: <>{ACCOUNT_SURVIVES}</>,
@@ -968,68 +954,42 @@ defineSteps('kms', 'azure', () => [
     {
         body: (
             <>
-                In the <L href="https://portal.azure.com">Azure portal</L> create a <B>Key Vault</B>.
-                Turn on <B>soft delete</B> and <B>purge protection</B> — both are offered during
-                creation, and they are what stops an accidental deletion becoming permanent.
+                In the <L href="https://portal.azure.com">Azure portal</L>, create a <B>Key Vault</B>.
+                Turn on <B>soft delete</B> and <B>purge protection</B> while creating it.
             </>
         ),
-        trouble: <>Purge protection cannot be turned on later on some configurations, and it is exactly the setting a town regrets not having. Take it now.</>,
+        trouble: <>Take purge protection now. On some configurations it cannot be turned on later, and it is the only setting that makes an accidental deletion survivable.</>,
+    },
+    {
+        body: <>Open <B>Objects → Keys → Generate/Import</B> and create an <B>RSA</B> key. 2048 or 4096, either is fine. Note its name.</>,
+        check: <>the key listed, status Enabled.</>,
     },
     {
         body: (
             <>
-                Open <B>Objects → Keys → Generate/Import</B> and create an <B>RSA</B> key. 2048 is fine;
-                4096 is fine too. Note the key's name.
+                Give Pinpoint access. Under <B>Microsoft Entra ID → App registrations → New
+                registration</B>, register an app and create a client secret for it. Then grant that app{' '}
+                <B>Get</B>, <B>Wrap Key</B> and <B>Unwrap Key</B> on the vault — in <B>Access
+                policies</B>, or the <B>Key Vault Crypto User</B> role if the vault uses Azure RBAC.
             </>
         ),
-        check: <>the key listed with status Enabled.</>,
+        trouble: <>Wrap and Unwrap are the two people miss. Get on its own is not enough, and the failure is silent.</>,
     },
     {
-        body: (
-            <>
-                Register an application for Pinpoint (<B>Microsoft Entra ID → App registrations → New
-                registration</B>), create a client secret for it under{' '}
-                <B>Certificates &amp; secrets</B>, and grant that application <B>Get</B>, <B>Wrap Key</B>{' '}
-                and <B>Unwrap Key</B> on the vault — under <B>Access policies</B>, or as the{' '}
-                <B>Key Vault Crypto User</B> role if your vault uses Azure RBAC.
-            </>
-        ),
-        trouble: <>Wrap and Unwrap are the two that matter and they are easy to miss in a long checklist of permissions. Get alone is not enough.</>,
-    },
-    {
-        body: (
-            <>
-                Then fill these in. The vault URL is the full{' '}
-                <C>https://yourvault.vault.azure.net/</C> address from the vault's overview page.
-            </>
-        ),
+        body: <>Fill these in. The vault URL is the <C>https://yourvault.vault.azure.net/</C> address on the vault's overview page.</>,
         fields: ['AZURE_KEYVAULT_URL', 'AZURE_KEYVAULT_KEY', 'AZURE_TENANT_ID', 'AZURE_KEYVAULT_CLIENT_ID', 'AZURE_KEYVAULT_CLIENT_SECRET'],
-        trouble: <>The client secret has an expiry date. Put it in the town's calendar with a month's notice: when it lapses, resident data stops decrypting, and nothing about that failure points at a calendar. Azure will not warn you.</>,
+        trouble: <>The client secret expires. Put the date in the town's calendar with a month's notice — when it lapses, resident data stops decrypting and nothing about that failure points at a calendar.</>,
     },
     {
         body: (
             <>
-                <B>Last, lock the vault down.</B> Confirm <B>soft delete</B> and <B>purge protection</B>{' '}
-                are both showing as enabled on the vault's Properties page — with them on, a deleted key
-                is recoverable for the retention period and cannot be permanently purged early, even by
-                an administrator, even deliberately. Then check that the everyday accounts your staff use
-                do not hold <B>Delete</B> or <B>Purge</B> on keys; a service principal certainly should
-                not.
+                Lock it down. On <B>Properties</B>, confirm soft delete and purge protection are both
+                enabled. Then under <B>Settings → Locks</B> add a lock of type <B>Delete</B>, which
+                stops anyone deleting the vault even with permission to.
             </>
         ),
-        check: <>Soft delete: Enabled, and Purge protection: Enabled, on Properties.</>,
-        trouble: <>This is the step to insist on. Purge protection cannot be switched on later in some configurations, and it is the only setting that makes an accidental deletion survivable rather than final.</>,
-    },
-    {
-        body: (
-            <>
-                <B>Then lock the vault itself.</B> On the vault, open <B>Settings → Locks</B> and add a
-                lock of type <B>Delete</B>. An Azure lock overrides user permissions — with it in place
-                nobody can delete the vault, and an attempt to delete the whole resource group fails
-                rather than half-completing.
-            </>
-        ),
-        check: <>a lock listed on the vault, type Delete.</>,
+        check: <>Soft delete: Enabled, Purge protection: Enabled, and a Delete lock on the vault.</>,
+        trouble: <>Also check that everyday staff accounts do not hold Delete or Purge on keys.</>,
     },
     {
         body: <>{ACCOUNT_SURVIVES}</>,
@@ -1061,16 +1021,15 @@ defineSteps('kms', 'aws', () => [
     {
         body: (
             <>
-                <B>Then make deletion impossible rather than merely inadvisable.</B> AWS has no
-                "protect from deletion" switch, so you do it in the key policy: add a statement that{' '}
-                <B>denies</B> <C>kms:ScheduleKeyDeletion</C> and <C>kms:DisableKey</C> to everyone. An
-                explicit deny in AWS cannot be overridden by any allow, including the account root — so
-                the deletion simply cannot be started, by anyone, by accident or otherwise. If you ever
-                genuinely need to retire the key, an administrator edits the policy first, which is one
-                deliberate step where there was none.
+                <B>Make deletion impossible, not just inadvisable.</B> AWS has no switch for this, so
+                do it in the key policy: add a statement that <B>denies</B>{' '}
+                <C>kms:ScheduleKeyDeletion</C> and <C>kms:DisableKey</C> to everyone. An explicit deny
+                beats every allow, including the account root, so nobody can start a deletion. To
+                retire the key later, an administrator edits the policy first — one deliberate step
+                where there was none.
             </>
         ),
-        trouble: <>Do this rather than relying on care. The console offers deletion from the same page as everything else, the default waiting period is 30 days, and the key stops working the moment deletion is <em>scheduled</em> — so resident data breaks at the start of the window, not the end. It can be cancelled inside those 30 days; after that, the data is unrecoverable by you and by AWS.</>,
+        trouble: <>The key stops working the moment deletion is <em>scheduled</em>, not when the 30 days end — so resident data breaks at the start of the window. It can be cancelled inside those 30 days. After that the data is <B>unrecoverable</B>, by you and by AWS.</>,
     },
     {
         body: <>{ACCOUNT_SURVIVES}</>,
@@ -1096,27 +1055,25 @@ defineSteps('kms', 'aws', () => [
  */
 const UNCONFIGURED_DETECTOR = (
     <>
-        If the credentials are missing or wrong, this fails <em>quietly</em>. The detector returns no
-        faces, Pinpoint blurs nothing, the photo is stored, and the card still shows redaction as on —
-        because "found nobody" and "could not ask" look identical from here. Check the Photo Redaction
-        line on the health dashboard after saving, and do the test below.
+        Wrong credentials fail <em>quietly</em>: the detector finds nothing, nothing is blurred, the
+        photo is stored, and the card still reads as on — "found nobody" and "could not ask" look
+        identical from here. Check the Photo Redaction line on the health dashboard, then do the test
+        below.
     </>
 );
 
 const VERIFY_WITH_A_PHOTO = (
     <>
-        <B>Test it once, with a real photo.</B> Open the resident portal, file a test report with a
-        picture that has a recognisable face in it, then look at the stored image in the staff
-        dashboard. Thirty seconds, and it is the only thing that actually proves this is working.
-        Delete the test report afterwards.
+        <B>Test it once, with a real photo.</B> File a test report from the resident portal with a
+        recognisable face in the picture, then look at the stored image in the staff dashboard. It is
+        the only thing that proves this works. Delete the test report afterwards.
     </>
 );
 
 const REDACTION_CHOICE = (
     <>
-        Faces and licence plates are both on by default. Residents photograph potholes with cars parked
-        beside them and neighbours walking past, and neither of those people asked to be in a public
-        record.
+        Faces and licence plates are both on by default — residents photograph potholes with cars and
+        neighbours in shot, and none of those people asked to be in a public record.
     </>
 );
 

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -2147,62 +2147,120 @@ export default function AdminConsole() {
                         )}
                         {/* Departments Tab */}
                         {currentTab === 'departments' && (
+                            /* Same shape as Service Categories: title with a
+                             * subtitle, a gradient action button, a row of stat
+                             * cards, then the grid. The two pages list the same
+                             * kind of thing and sat next to each other in the
+                             * sidebar looking unrelated. */
                             <div className="space-y-6">
                                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                                    <h1 className="text-xl sm:text-2xl font-bold text-white">Departments</h1>
+                                    <div>
+                                        <h1 className="text-xl sm:text-2xl font-bold text-white tracking-tight">Departments</h1>
+                                        <p className="text-sm text-white/50 mt-1">The teams reports are assigned to, and where their notifications go</p>
+                                    </div>
                                     <Button
-                                        className="w-full sm:w-auto"
                                         leftIcon={<Plus className="w-4 h-4" />}
                                         onClick={() => {
                                             setEditingDepartment(null);
                                             setNewDepartment({ name: '', description: '', routing_email: '' });
                                             setShowDepartmentModal(true);
                                         }}
+                                        className="w-full sm:w-auto bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-400 hover:to-primary-500 shadow-lg shadow-primary-500/25"
                                     >
                                         Add Department
                                     </Button>
                                 </div>
 
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-blue-500/10 to-blue-600/5 border border-blue-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-blue-500/20 flex items-center justify-center shrink-0">
+                                                <Building2 className="w-5 h-5 text-blue-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.length}</p>
+                                                <p className="text-xs text-blue-300/70">Departments</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-emerald-500/10 to-emerald-600/5 border border-emerald-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-emerald-500/20 flex items-center justify-center shrink-0">
+                                                <Mail className="w-5 h-5 text-emerald-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.filter(d => d.routing_email).length}</p>
+                                                <p className="text-xs text-emerald-300/70">With routing email</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {/* A department with no email is not broken --
+                                        reports still route to it in the console --
+                                        but nobody is told, so it is worth counting. */}
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-amber-500/10 to-amber-600/5 border border-amber-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-amber-500/20 flex items-center justify-center shrink-0">
+                                                <AlertCircle className="w-5 h-5 text-amber-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.filter(d => !d.routing_email).length}</p>
+                                                <p className="text-xs text-amber-300/70">No email set</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                                     {departments.map((dept) => (
-                                        <Card key={dept.id} className="relative group">
+                                        <div key={dept.id} className="premium-card group relative p-5">
                                             <div className="flex items-start gap-4">
-                                                <div className="w-12 h-12 rounded-xl bg-blue-500/20 flex items-center justify-center text-blue-300">
-                                                    <Building2 className="w-6 h-6" />
+                                                <div className="setup-tile w-12 h-12 rounded-2xl flex items-center justify-center shrink-0">
+                                                    <Building2 className="w-6 h-6 text-white" />
                                                 </div>
-                                                <div className="flex-1">
-                                                    <h3 className="font-semibold text-white">{dept.name}</h3>
+                                                <div className="min-w-0 flex-1">
+                                                    <h3 className="font-semibold text-white truncate">{dept.name}</h3>
                                                     <p className="text-sm text-white/50 mt-1">{dept.description || 'No description'}</p>
-                                                    {dept.routing_email && (
-                                                        <p className="text-xs text-white/30 mt-2 font-mono">{dept.routing_email}</p>
+                                                    {dept.routing_email ? (
+                                                        <p className="text-xs text-white/40 mt-2 font-mono truncate">{dept.routing_email}</p>
+                                                    ) : (
+                                                        <p className="text-xs text-amber-300/70 mt-2 inline-flex items-center gap-1.5">
+                                                            <AlertCircle className="w-3 h-3 shrink-0" aria-hidden="true" />
+                                                            No routing email — nobody is notified
+                                                        </p>
                                                     )}
                                                 </div>
-                                                <div className="flex gap-1">
+                                                {/* Visible on focus as well as hover: keyboard
+                                                    users never trigger hover, and these were the
+                                                    only way to edit a department. */}
+                                                <div className="flex gap-1 shrink-0">
                                                     <button
                                                         onClick={() => handleEditDepartment(dept)}
-                                                        className="opacity-0 group-hover:opacity-100 p-2 hover:bg-white/10 rounded-lg transition-all"
+                                                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-2 hover:bg-white/10 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
                                                         aria-label={`Edit ${dept.name} department`}
                                                     >
                                                         <Edit className="w-4 h-4 text-white/60" aria-hidden="true" />
                                                     </button>
                                                     <button
                                                         onClick={() => handleDeleteDepartment(dept.id)}
-                                                        className="opacity-0 group-hover:opacity-100 p-2 hover:bg-red-500/20 rounded-lg transition-all"
+                                                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-2 hover:bg-red-500/20 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60"
                                                         aria-label={`Delete ${dept.name} department`}
                                                     >
                                                         <Trash2 className="w-4 h-4 text-red-400" aria-hidden="true" />
                                                     </button>
                                                 </div>
                                             </div>
-                                        </Card>
+                                        </div>
                                     ))}
                                 </div>
 
                                 {departments.length === 0 && (
-                                    <Card className="text-center py-8">
+                                    <div className="premium-card text-center py-10 px-6">
                                         <Building2 className="w-12 h-12 mx-auto text-white/20 mb-3" />
-                                        <p className="text-white/50">No departments yet. Add your first department to organize staff.</p>
-                                    </Card>
+                                        <p className="text-white/60">No departments yet.</p>
+                                        <p className="text-white/40 text-sm mt-1">
+                                            Add one to organise staff and route reports to the right team.
+                                        </p>
+                                    </div>
                                 )}
                             </div>
                         )}

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -333,7 +333,7 @@ function BubblyServiceCard({ service, onEdit, onDelete }: {
     );
 }
 
-function ServiceCategoriesTab({ services, setServices, loadTabData, setShowServiceModal, handleEditService, handleDeleteService }: {
+export function ServiceCategoriesTab({ services, setServices, loadTabData, setShowServiceModal, handleEditService, handleDeleteService }: {
     services: ServiceDefinition[];
     setServices: (s: ServiceDefinition[]) => void;
     loadTabData: () => void;
@@ -458,6 +458,157 @@ function ServiceCategoriesTab({ services, setServices, loadTabData, setShowServi
                 </SortableContext>
             </DndContext>
         </div>
+    );
+}
+
+
+
+/**
+ * The departments tab.
+ *
+ * Lifted out of AdminConsole's render so it can be mounted on its own -- which
+ * is what makes it possible to look at, rather than only to reason about. It is
+ * the same markup, with the values it used to close over passed in.
+ */
+export function DepartmentsTab({
+    departments, onAdd, onEdit, onDelete,
+}: {
+    departments: Department[];
+    onAdd: () => void;
+    onEdit: (dept: Department) => void;
+    onDelete: (id: number) => void;
+}) {
+    return (
+                            <div className="space-y-6">
+                                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                    <div>
+                                        <h1 className="text-xl sm:text-2xl font-bold text-white tracking-tight">Departments</h1>
+                                        <p className="text-sm text-white/50 mt-1">The teams reports are assigned to, and where their notifications go</p>
+                                    </div>
+                                    <Button
+                                        leftIcon={<Plus className="w-4 h-4" />}
+                                        onClick={onAdd}
+                                        className="w-full sm:w-auto bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-400 hover:to-primary-500 shadow-lg shadow-primary-500/25"
+                                    >
+                                        Add Department
+                                    </Button>
+                                </div>
+
+                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-blue-500/10 to-blue-600/5 border border-blue-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-blue-500/20 flex items-center justify-center shrink-0">
+                                                <Building2 className="w-5 h-5 text-blue-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.length}</p>
+                                                <p className="text-xs text-blue-300/70">Departments</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-emerald-500/10 to-emerald-600/5 border border-emerald-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-emerald-500/20 flex items-center justify-center shrink-0">
+                                                <Mail className="w-5 h-5 text-emerald-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.filter(d => d.routing_email).length}</p>
+                                                <p className="text-xs text-emerald-300/70">With routing email</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    {/* A department with no email is not broken --
+                                        reports still route to it in the console --
+                                        but nobody is told, so it is worth counting. */}
+                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-amber-500/10 to-amber-600/5 border border-amber-500/20 backdrop-blur-sm shadow-xl">
+                                        <div className="flex items-center gap-3.5">
+                                            <div className="w-10 h-10 rounded-xl bg-amber-500/20 flex items-center justify-center shrink-0">
+                                                <AlertCircle className="w-5 h-5 text-amber-400" />
+                                            </div>
+                                            <div>
+                                                <p className="text-2xl font-bold text-white">{departments.filter(d => !d.routing_email).length}</p>
+                                                <p className="text-xs text-amber-300/70">No email set</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                                    {departments.map((dept) => (
+                                        /* Same card as a service category: the
+                                         * 3xl radius, the glow bar, the lift on
+                                         * hover, badges, and an action footer
+                                         * that is always visible. The previous
+                                         * version hid Edit and Delete behind
+                                         * hover, which put them out of reach of
+                                         * anyone using a keyboard and made the
+                                         * two pages read as unrelated. */
+                                        <div key={dept.id} className="group">
+                                            <div className="relative p-6 rounded-3xl bg-gradient-to-br from-white/[0.08] via-white/[0.03] to-indigo-950/30 border border-white/15 backdrop-blur-2xl shadow-[0_10px_30px_rgba(0,0,0,0.3)] hover:shadow-[0_20px_50px_rgba(99,102,241,0.2)] hover:border-primary-400/50 hover:-translate-y-1 transition-all duration-300">
+                                                <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-transparent via-primary-400/40 to-transparent rounded-t-3xl" />
+
+                                                <div className="flex items-center gap-3 mb-4">
+                                                    <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary-500/25 via-indigo-500/20 to-purple-500/15 border border-white/20 shadow-inner flex items-center justify-center text-primary-300 shrink-0">
+                                                        <Building2 className="w-6 h-6" />
+                                                    </div>
+                                                    <h3 className="font-bold text-white text-lg tracking-tight group-hover:text-primary-200 transition-colors truncate">
+                                                        {dept.name}
+                                                    </h3>
+                                                </div>
+
+                                                <p className="text-xs text-white/65 leading-relaxed min-h-[32px] line-clamp-2">
+                                                    {dept.description || 'No description provided.'}
+                                                </p>
+
+                                                <div className="flex items-center gap-2 mt-4 flex-wrap">
+                                                    {dept.routing_email ? (
+                                                        <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-2xl text-xs font-medium bg-white/10 border border-white/15 text-white/90 max-w-full">
+                                                            <Mail className="w-3.5 h-3.5 text-white/40 shrink-0" aria-hidden="true" />
+                                                            <span className="font-mono truncate">{dept.routing_email}</span>
+                                                        </span>
+                                                    ) : (
+                                                        /* Not a failure -- reports still route to the
+                                                         * department in the console -- but nobody is
+                                                         * emailed, and that is worth saying on the card
+                                                         * rather than leaving to be discovered. */
+                                                        <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-2xl text-xs font-semibold bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 border border-amber-500/30 shadow-md shadow-amber-950/40">
+                                                            <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                                            No routing email
+                                                        </span>
+                                                    )}
+                                                </div>
+
+                                                <div className="flex items-center justify-end gap-2.5 mt-5 pt-4 border-t border-white/10">
+                                                    <Button
+                                                        leftIcon={<Edit className="w-4 h-4" />}
+                                                        onClick={() => onEdit(dept)}
+                                                        className="rounded-2xl px-5"
+                                                    >
+                                                        Edit Department
+                                                    </Button>
+                                                    <button
+                                                        onClick={() => onDelete(dept.id)}
+                                                        className="p-2.5 rounded-2xl bg-white/5 hover:bg-red-500/20 border border-white/10 hover:border-red-500/30 text-white/40 hover:text-red-300 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60"
+                                                        aria-label={`Delete ${dept.name} department`}
+                                                    >
+                                                        <Trash2 className="w-4 h-4" aria-hidden="true" />
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+
+                                {departments.length === 0 && (
+                                    <div className="premium-card text-center py-10 px-6">
+                                        <Building2 className="w-12 h-12 mx-auto text-white/20 mb-3" />
+                                        <p className="text-white/60">No departments yet.</p>
+                                        <p className="text-white/40 text-sm mt-1">
+                                            Add one to organise staff and route reports to the right team.
+                                        </p>
+                                    </div>
+                                )}
+                            </div>
     );
 }
 
@@ -2147,122 +2298,16 @@ export default function AdminConsole() {
                         )}
                         {/* Departments Tab */}
                         {currentTab === 'departments' && (
-                            /* Same shape as Service Categories: title with a
-                             * subtitle, a gradient action button, a row of stat
-                             * cards, then the grid. The two pages list the same
-                             * kind of thing and sat next to each other in the
-                             * sidebar looking unrelated. */
-                            <div className="space-y-6">
-                                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                                    <div>
-                                        <h1 className="text-xl sm:text-2xl font-bold text-white tracking-tight">Departments</h1>
-                                        <p className="text-sm text-white/50 mt-1">The teams reports are assigned to, and where their notifications go</p>
-                                    </div>
-                                    <Button
-                                        leftIcon={<Plus className="w-4 h-4" />}
-                                        onClick={() => {
-                                            setEditingDepartment(null);
-                                            setNewDepartment({ name: '', description: '', routing_email: '' });
-                                            setShowDepartmentModal(true);
-                                        }}
-                                        className="w-full sm:w-auto bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-400 hover:to-primary-500 shadow-lg shadow-primary-500/25"
-                                    >
-                                        Add Department
-                                    </Button>
-                                </div>
-
-                                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-blue-500/10 to-blue-600/5 border border-blue-500/20 backdrop-blur-sm shadow-xl">
-                                        <div className="flex items-center gap-3.5">
-                                            <div className="w-10 h-10 rounded-xl bg-blue-500/20 flex items-center justify-center shrink-0">
-                                                <Building2 className="w-5 h-5 text-blue-400" />
-                                            </div>
-                                            <div>
-                                                <p className="text-2xl font-bold text-white">{departments.length}</p>
-                                                <p className="text-xs text-blue-300/70">Departments</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-emerald-500/10 to-emerald-600/5 border border-emerald-500/20 backdrop-blur-sm shadow-xl">
-                                        <div className="flex items-center gap-3.5">
-                                            <div className="w-10 h-10 rounded-xl bg-emerald-500/20 flex items-center justify-center shrink-0">
-                                                <Mail className="w-5 h-5 text-emerald-400" />
-                                            </div>
-                                            <div>
-                                                <p className="text-2xl font-bold text-white">{departments.filter(d => d.routing_email).length}</p>
-                                                <p className="text-xs text-emerald-300/70">With routing email</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    {/* A department with no email is not broken --
-                                        reports still route to it in the console --
-                                        but nobody is told, so it is worth counting. */}
-                                    <div className="p-4 rounded-2xl bg-gradient-to-br from-amber-500/10 to-amber-600/5 border border-amber-500/20 backdrop-blur-sm shadow-xl">
-                                        <div className="flex items-center gap-3.5">
-                                            <div className="w-10 h-10 rounded-xl bg-amber-500/20 flex items-center justify-center shrink-0">
-                                                <AlertCircle className="w-5 h-5 text-amber-400" />
-                                            </div>
-                                            <div>
-                                                <p className="text-2xl font-bold text-white">{departments.filter(d => !d.routing_email).length}</p>
-                                                <p className="text-xs text-amber-300/70">No email set</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                                    {departments.map((dept) => (
-                                        <div key={dept.id} className="premium-card group relative p-5">
-                                            <div className="flex items-start gap-4">
-                                                <div className="setup-tile w-12 h-12 rounded-2xl flex items-center justify-center shrink-0">
-                                                    <Building2 className="w-6 h-6 text-white" />
-                                                </div>
-                                                <div className="min-w-0 flex-1">
-                                                    <h3 className="font-semibold text-white truncate">{dept.name}</h3>
-                                                    <p className="text-sm text-white/50 mt-1">{dept.description || 'No description'}</p>
-                                                    {dept.routing_email ? (
-                                                        <p className="text-xs text-white/40 mt-2 font-mono truncate">{dept.routing_email}</p>
-                                                    ) : (
-                                                        <p className="text-xs text-amber-300/70 mt-2 inline-flex items-center gap-1.5">
-                                                            <AlertCircle className="w-3 h-3 shrink-0" aria-hidden="true" />
-                                                            No routing email — nobody is notified
-                                                        </p>
-                                                    )}
-                                                </div>
-                                                {/* Visible on focus as well as hover: keyboard
-                                                    users never trigger hover, and these were the
-                                                    only way to edit a department. */}
-                                                <div className="flex gap-1 shrink-0">
-                                                    <button
-                                                        onClick={() => handleEditDepartment(dept)}
-                                                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-2 hover:bg-white/10 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
-                                                        aria-label={`Edit ${dept.name} department`}
-                                                    >
-                                                        <Edit className="w-4 h-4 text-white/60" aria-hidden="true" />
-                                                    </button>
-                                                    <button
-                                                        onClick={() => handleDeleteDepartment(dept.id)}
-                                                        className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-2 hover:bg-red-500/20 rounded-lg transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/60"
-                                                        aria-label={`Delete ${dept.name} department`}
-                                                    >
-                                                        <Trash2 className="w-4 h-4 text-red-400" aria-hidden="true" />
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-
-                                {departments.length === 0 && (
-                                    <div className="premium-card text-center py-10 px-6">
-                                        <Building2 className="w-12 h-12 mx-auto text-white/20 mb-3" />
-                                        <p className="text-white/60">No departments yet.</p>
-                                        <p className="text-white/40 text-sm mt-1">
-                                            Add one to organise staff and route reports to the right team.
-                                        </p>
-                                    </div>
-                                )}
-                            </div>
+                            <DepartmentsTab
+                                departments={departments}
+                                onAdd={() => {
+                                    setEditingDepartment(null);
+                                    setNewDepartment({ name: '', description: '', routing_email: '' });
+                                    setShowDepartmentModal(true);
+                                }}
+                                onEdit={handleEditDepartment}
+                                onDelete={handleDeleteDepartment}
+                            />
                         )}
 
                         {/* Services Tab */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -619,6 +619,15 @@ class ApiClient {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 
+    /** Which provider each capability is on, and which of its providers have
+     *  their credentials stored. One request rather than eight, and answered
+     *  per provider — "maps is configured" is not the same question as "Esri is
+     *  configured", and conflating them made the setup guide skip a provider
+     *  that had no credentials at all. */
+    async getProviderStatus(): Promise<ProviderStatusMap> {
+        return this.request<ProviderStatusMap>('/system/providers/status');
+    }
+
     /** Whether this server already has an identity on its cloud, in which case
      *  the credential boxes for that cloud should be left empty rather than
      *  filled — the platform issues a short-lived token instead. */
@@ -1550,6 +1559,12 @@ export interface HealthSummary {
 /** An identity attached to the compute by the cloud itself. When present, the
  *  listed keys need no value — and leaving them empty is the better answer, not
  *  merely an allowed one. */
+/** Per capability: the provider in use, and which providers are set up. */
+export type ProviderStatusMap = Record<string, {
+    current_provider: string | null;
+    configured: Record<string, boolean>;
+}>;
+
 export interface CloudIdentity {
     attached: boolean;
     provider: string | null;


### PR DESCRIPTION
Three commits, all from things found by looking at the rendered pages rather than by reading the code.

## The completion message lied

"Everything you picked is set up" was shown whenever *nothing was open* — and nothing is open after collapsing a row. So clicking the current task shut congratulated a town that had configured nothing. There is now a distinct "nothing selected, N to go" state, and the completion panel is gated on actually being complete.

Both fallback panels moved outside the `AnimatePresence`. Inside it, `mode="wait"` holds the outgoing panel until its exit animation finishes, so the replacement appeared late — and never at all under jsdom, which produces no frames. That is why the first version of this test could not see the bug: reintroducing it left all seven tests passing.

## Switching a provider left the task ticked

Done-ness was read from stored secrets per *capability*, where "maps is set up" meant any map provider had a key. A town that configured Google Maps and switched to Esri kept a green tick against a provider with no credentials, and the guide skipped the one thing it most needed to ask for.

A new `GET /system/providers/status` answers per provider, in one request rather than eight. Switching to something unconfigured now marks the task unfinished and reopens it.

## Every provider decision is made once

Email, text and screening were decided on pickers nested inside their own sections, so the questionnaire could say one thing and a section another with nowhere to see what the town had chosen. Those pickers are gone; the questions moved to the top, asked only for what the town ticked. The town-systems connector is out of the guide entirely — it has its own section with its own wizard further down.

## The wall, moved and then removed

Grouping by login turned four visits into one and then put everything from all four on screen together. Rendered, the Azure task was **6,158 pixels tall** while the rail said "1 left".

Items inside a task now collapse the way tasks collapse in the rail. One is open; the rest show a title and one line. Finishing an item opens the next, on the same rule as tasks — a save whose live test came back green, never merely a save. Finishing the last one moves to the next task.

**6,158px → 1,314px**, measured in Chromium.

The prose was the other half. The three key-management walks ran 456, 465 and 559 words, and the Azure one explained purge protection three times across seven steps. It is six steps and 313 words now with nothing dropped. A test caught me weakening the AWS deletion warning while trimming — it lost the word "unrecoverable", which is the point of the sentence. Restored, and there is now a cap of 400 words per provider walk, because the length is what made those warnings skimmable.

## Departments

Now the same card as service categories, not just the same header: the 3xl radius, glow bar, lift on hover, badge row and a visible action footer. The previous version hid Edit and Delete behind `opacity-0` with a hover trigger, which made them unreachable by keyboard.

It also gained something the old layout hid — a department with no routing email is counted in the stat row and called out on its card. Reports still route to it in the console while nobody is emailed.

## A harness for looking at pages

`preview.html` and `src/__preview__/` mount admin pages against canned data. Not part of the app — Vite's build entry is `index.html`, so neither reaches `dist` (checked).

It exists because two rounds of this work were verified only by tests asserting on the DOM, and a test cannot see that a page looks wrong. The departments cards matched in every respect a test could check and still read as a different product. Making it possible meant lifting the departments markup out of `AdminConsole`'s render into a `DepartmentsTab` component.

## Verification

536 backend tests under CI's four-package install, 117 frontend, clean build, typecheck steady at 11 pre-existing errors.

Checked by mutation rather than by passing: showing the done panel whenever nothing is open fails 1, reading done-ness per capability fails 3, not reopening on a provider change fails 1, expanding every item fails 4, advancing on save rather than on a passing test fails 1, never advancing between items fails 1, opening the first item rather than the first unfinished one fails 1.

**Rendered and looked at** — the setup wizard and both admin pages, in Chromium at 1440px. That is new for this branch and it is what found the departments gap and the duplicated item blurb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_