### PR TITLE
Fix a settings bug that looked like a retention bug, and stop the console overstating what it knows

### DIFF
--- a/backend/alembic/versions/20260731_1400_d0e1f2a3b4c5_system_settings_singleton.py
+++ b/backend/alembic/versions/20260731_1400_d0e1f2a3b4c5_system_settings_singleton.py
@@ -1,0 +1,74 @@
+"""Collapse duplicate system_settings rows and keep it to one.
+
+The table is a singleton by convention only. Seven code paths create it with a
+non-atomic read-then-insert, so two concurrent requests on a fresh deployment
+produce two rows -- and from then on an unordered `LIMIT 1` can read a
+different row than the one just written. The visible symptom is a saved setting
+that reverts on reload.
+
+Ordering every read (done in the same change) makes the behaviour deterministic
+even with duplicates present. This closes the other half: existing duplicates
+are folded into the oldest row, and a constraint stops new ones appearing.
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "system_settings"
+INDEX = "uq_system_settings_singleton"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in set(inspector.get_table_names()):
+        return
+
+    columns = [c["name"] for c in inspector.get_columns(TABLE)]
+    if "id" not in columns:
+        return
+    value_columns = [c for c in columns if c != "id"]
+
+    ids = [r[0] for r in bind.execute(
+        sa.text(f"SELECT id FROM {TABLE} ORDER BY id")  # nosec B608 - fixed identifier
+    )]
+    if len(ids) > 1:
+        keep, drop = ids[0], ids[1:]
+        # Carry over anything the duplicates hold that the canonical row does
+        # not. A value on a duplicate is still a value somebody typed into this
+        # product; deleting the row without this would discard configuration.
+        #
+        # Oldest duplicate first, so an earlier answer beats a later one -- the
+        # same tie-break as choosing the row to keep.
+        for column in value_columns:
+            bind.execute(
+                sa.text(
+                    f"UPDATE {TABLE} AS target SET {column} = source.{column} "  # nosec B608
+                    f"FROM (SELECT {column} FROM {TABLE} WHERE id = ANY(:drop) "  # nosec B608
+                    f"AND {column} IS NOT NULL ORDER BY id LIMIT 1) AS source "
+                    f"WHERE target.id = :keep AND target.{column} IS NULL"
+                ),
+                {"drop": drop, "keep": keep},
+            )
+        bind.execute(sa.text(f"DELETE FROM {TABLE} WHERE id = ANY(:drop)"), {"drop": drop})  # nosec B608
+
+    # At most one row, enforced by the database rather than by every caller
+    # remembering to check. A unique index on a constant expression is the
+    # standard way to say "one row" in PostgreSQL.
+    if bind.dialect.name == "postgresql":
+        op.execute(f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX} ON {TABLE} ((true))")
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(f"DROP INDEX IF EXISTS {INDEX}")

--- a/backend/alembic/versions/20260731_1400_d0e1f2a3b4c5_system_settings_singleton.py
+++ b/backend/alembic/versions/20260731_1400_d0e1f2a3b4c5_system_settings_singleton.py
@@ -37,36 +37,44 @@ def upgrade() -> None:
     columns = [c["name"] for c in inspector.get_columns(TABLE)]
     if "id" not in columns:
         return
-    value_columns = [c for c in columns if c != "id"]
 
-    ids = [r[0] for r in bind.execute(
-        sa.text(f"SELECT id FROM {TABLE} ORDER BY id")  # nosec B608 - fixed identifier
-    )]
+    # Reflected, so the statements below are built from SQLAlchemy objects
+    # rather than from formatted strings. The identifiers here come from the
+    # database rather than from a request, but SQL assembled by string
+    # formatting is worth avoiding on sight -- it is indistinguishable, to a
+    # reader and to a scanner, from the version of this that is a vulnerability.
+    table = sa.Table(TABLE, sa.MetaData(), autoload_with=bind)
+    value_columns = [c for c in table.columns if c.name != "id"]
+
+    ids = [row[0] for row in bind.execute(sa.select(table.c.id).order_by(table.c.id))]
     if len(ids) > 1:
         keep, drop = ids[0], ids[1:]
         # Carry over anything the duplicates hold that the canonical row does
         # not. A value on a duplicate is still a value somebody typed into this
         # product; deleting the row without this would discard configuration.
         #
-        # Oldest duplicate first, so an earlier answer beats a later one -- the
-        # same tie-break as choosing the row to keep.
+        # Oldest duplicate first, so an earlier answer beats a later one --
+        # the same tie-break as choosing the row to keep.
         for column in value_columns:
-            bind.execute(
-                sa.text(
-                    f"UPDATE {TABLE} AS target SET {column} = source.{column} "  # nosec B608
-                    f"FROM (SELECT {column} FROM {TABLE} WHERE id = ANY(:drop) "  # nosec B608
-                    f"AND {column} IS NOT NULL ORDER BY id LIMIT 1) AS source "
-                    f"WHERE target.id = :keep AND target.{column} IS NULL"
-                ),
-                {"drop": drop, "keep": keep},
-            )
-        bind.execute(sa.text(f"DELETE FROM {TABLE} WHERE id = ANY(:drop)"), {"drop": drop})  # nosec B608
+            source = bind.execute(
+                sa.select(column)
+                .where(sa.and_(table.c.id.in_(drop), column.isnot(None)))
+                .order_by(table.c.id)
+                .limit(1)
+            ).scalar()
+            if source is not None:
+                bind.execute(
+                    sa.update(table)
+                    .where(sa.and_(table.c.id == keep, column.is_(None)))
+                    .values({column.name: source})
+                )
+        bind.execute(sa.delete(table).where(table.c.id.in_(drop)))
 
     # At most one row, enforced by the database rather than by every caller
     # remembering to check. A unique index on a constant expression is the
     # standard way to say "one row" in PostgreSQL.
     if bind.dialect.name == "postgresql":
-        op.execute(f"CREATE UNIQUE INDEX IF NOT EXISTS {INDEX} ON {TABLE} ((true))")
+        op.execute(sa.text(f'CREATE UNIQUE INDEX IF NOT EXISTS "{INDEX}" ON "{TABLE}" ((true))'))
 
 
 def downgrade() -> None:

--- a/backend/app/api/data_export.py
+++ b/backend/app/api/data_export.py
@@ -125,7 +125,7 @@ async def export_requests(
     requests = await get_requests_for_export(db, start_date, end_date, status, service_code)
     
     # Get township name for filename
-    settings_result = await db.execute(select(SystemSettings).limit(1))
+    settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = settings_result.scalar_one_or_none()
     township_name = settings.township_name.replace(" ", "_") if settings else "township"
     
@@ -305,7 +305,7 @@ async def export_statistics(
     avg_resolution_hours = sum(resolution_times) / len(resolution_times) if resolution_times else 0
     
     # Get township info
-    settings_result = await db.execute(select(SystemSettings).limit(1))
+    settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = settings_result.scalar_one_or_none()
     township_name = settings.township_name.replace(" ", "_") if settings else "township"
     

--- a/backend/app/api/gis.py
+++ b/backend/app/api/gis.py
@@ -139,7 +139,7 @@ async def persist_boundary(db, geojson_data: dict, name: str = None,
     """
     from app.models import SystemSettings
 
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     if not settings:
         settings = SystemSettings()
@@ -258,7 +258,7 @@ async def get_maps_config(db: AsyncSession = Depends(get_db)):
         logging.getLogger(__name__).warning(f"Could not get Google Maps Map ID: {e}")
     
     # Get township settings
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     
     # Which provider this town renders with, and only the credentials that
@@ -550,7 +550,7 @@ async def save_township_boundary(
     """Save the township boundary GeoJSON to system settings"""
     try:
         # Get or create system settings
-        result = await db.execute(select(SystemSettings).limit(1))
+        result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
         settings = result.scalar_one_or_none()
         
         if not settings:

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -508,7 +508,9 @@ async def get_uptime_stats(
     Get aggregated uptime statistics (24h, 7d, 30d percentages).
     """
     from sqlalchemy import func as sql_func
-    
+
+    from app.services.uptime import describe, summarise
+
     stats = {}
     periods = {"24h": 24, "7d": 168, "30d": 720}
     
@@ -532,12 +534,16 @@ async def get_uptime_stats(
         for service_name, total, healthy_count in rows:
             if service_name not in stats:
                 stats[service_name] = {}
-            uptime_pct = (healthy_count / total * 100) if total > 0 else 0
-            stats[service_name][period_name] = {
-                "uptime_percent": round(uptime_pct, 2),
-                "checks": total,
-                "healthy": healthy_count or 0
-            }
+            # Denominator is time, not rows.
+            #
+            # The sampler runs inside the backend, so a backend outage produces
+            # no rows rather than rows saying "down" -- and healthy/total over
+            # the rows that exist returns a *higher* figure the worse the
+            # outage was. Twelve samples in a day is about an hour of uptime and
+            # the old arithmetic called it 100%.
+            summary = summarise(total=total, healthy=healthy_count or 0, hours=hours)
+            summary["summary"] = describe(summary)
+            stats[service_name][period_name] = summary
     
     return {"services": stats}
 
@@ -583,13 +589,15 @@ async def trigger_uptime_check(
         ("translation_api", check_translation_api),
     ]
     
+    from app.services.uptime import uptime_status
+
     results = {}
     for service_name, check_func in services_to_check:
         start = time.time()
         try:
             check_result = await check_func(db)
             response_time = int((time.time() - start) * 1000)
-            status = "healthy" if check_result["status"] in ["healthy", "configured", "fallback"] else "down"
+            status = uptime_status(check_result["status"])
             error = None if status == "healthy" else check_result.get("message")
         except Exception as e:
             response_time = int((time.time() - start) * 1000)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -579,14 +579,11 @@ async def trigger_uptime_check(
     """
     import time
     
+    # Matches the background sampler exactly -- see the note in main.py. When
+    # these two lists differed, pressing "Check now" wrote series the sampler
+    # never maintained, so they aged out of the graph on their own.
     services_to_check = [
         ("database", check_database),
-        ("auth0", check_auth0),
-        # Series names, not display names -- see the note in main.py.
-        ("kms", check_kms),
-        ("secret_store", check_secret_manager),
-        ("vertex_ai", check_vertex_ai),
-        ("translation_api", check_translation_api),
     ]
     
     from app.services.uptime import uptime_status

--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -56,7 +56,7 @@ async def resolve_is_public(db: AsyncSession, requested_is_public) -> bool:
         return True
     try:
         from app.models import SystemSettings
-        result = await db.execute(select(SystemSettings).limit(1))
+        result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
         settings_row = result.scalar_one_or_none()
         modules = (settings_row.modules if settings_row else None) or {}
         # `private_reports` was the key's original name; read it too so a town

--- a/backend/app/api/provisioning.py
+++ b/backend/app/api/provisioning.py
@@ -62,7 +62,7 @@ async def bootstrap_township(
     """Replace the interactive first-run flow when the panel creates a town:
     set township name/domain, create/assign the initial admin, and return a
     one-time onboarding link (short-lived signed token)."""
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings_row = result.scalar_one_or_none()
     if not settings_row:
         settings_row = SystemSettings()
@@ -294,7 +294,7 @@ async def set_managed_settings(
     """
     incoming = body.settings or {}
 
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     if not settings:
         settings = SystemSettings()

--- a/backend/app/api/research.py
+++ b/backend/app/api/research.py
@@ -65,7 +65,7 @@ async def check_research_enabled(db: AsyncSession):
     if getattr(settings, 'enable_research_suite', False):
         return True
 
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     system_settings = result.scalar_one_or_none()
     if system_settings and system_settings.modules:
         return system_settings.modules.get("research_portal", False)
@@ -2285,7 +2285,7 @@ async def get_code_snippets(
     if not await check_research_enabled(db):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Research Suite is not enabled")
     
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     system_settings = result.scalar_one_or_none()
     base_url = f"https://{system_settings.custom_domain}" if system_settings and system_settings.custom_domain else "https://your-311-domain.com"
     
@@ -2458,7 +2458,7 @@ async def research_chat(
     context_used = []
 
     # Get township info
-    settings_result = await db.execute(select(SystemSettings).limit(1))
+    settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     sys_settings = settings_result.scalar_one_or_none()
     township_name = getattr(sys_settings, 'township_name', 'the municipality') or 'the municipality'
     context_used.append("system_settings")

--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -415,7 +415,7 @@ async def configure_auth0(
             try:
                 # Get current system settings for branding
                 from app.models import SystemSettings
-                settings_result = await db.execute(select(SystemSettings).limit(1))
+                settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
                 settings = settings_result.scalar_one_or_none()
                 
                 primary_color = settings.primary_color if settings else "#6366f1"

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -36,7 +36,7 @@ _cost_limiter = Limiter(key_func=get_remote_address)
 @router.get("/settings", response_model=SystemSettingsResponse)
 async def get_settings(db: AsyncSession = Depends(get_db)):
     """Get system settings (public - for branding)"""
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     if not settings:
         # Create default settings if none exist
@@ -69,7 +69,7 @@ async def public_origin(db) -> Optional[str]:
 
         from app.models import SystemSettings
 
-        row = (await db.execute(select(SystemSettings).limit(1))).scalar_one_or_none()
+        row = (await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))).scalar_one_or_none()
         if row and (row.custom_domain or "").strip():
             domain = row.custom_domain.strip()
     except Exception:
@@ -828,10 +828,33 @@ async def _test_delivery(capability: str) -> dict:
     """Email and text messages, without sending anything to a resident."""
     import httpx
 
+    from app.services.delivery_providers import (
+        EMAIL_CATALOG, SMS_CATALOG, describe_missing, required_keys,
+    )
     from app.services.secret_manager import get_secret
+
+    async def _nothing_saved(catalog: dict, provider: str) -> Optional[dict]:
+        """"You have not filled this in" beats any statement about the vendor.
+
+        The fallthroughs at the ends of both halves of this function reported on
+        the *provider* -- "there is no way to check http without sending a real
+        text message", "ACS has no check that avoids sending a real message" --
+        without first asking whether the town had entered anything. A clerk who
+        had never touched text messages was told their gateway was untestable,
+        which is true of the gateway and irrelevant to them: what they needed to
+        know is that the boxes are empty.
+        """
+        entry = catalog.get(provider)
+        missing = [k for k in required_keys(entry) if not (await get_secret(k) or "").strip()]
+        if not missing:
+            return None
+        return {"ok": False, "detail": describe_missing(entry, missing), "recorded": False}
 
     if capability == "email":
         provider = (await get_secret("EMAIL_PROVIDER")) or "smtp"
+        blank = await _nothing_saved(EMAIL_CATALOG, provider)
+        if blank:
+            return blank
         if provider == "smtp":
             import asyncio
             import smtplib
@@ -887,6 +910,10 @@ async def _test_delivery(capability: str) -> dict:
     provider = (await get_secret("SMS_PROVIDER")) or "none"
     if provider == "none":
         return {"ok": True, "detail": "Text messages are switched off, as configured."}
+
+    blank = await _nothing_saved(SMS_CATALOG, provider)
+    if blank:
+        return blank
 
     if provider == "twilio":
         sid = await get_secret("TWILIO_ACCOUNT_SID")
@@ -1287,7 +1314,7 @@ async def update_settings(
     _: User = Depends(get_current_admin)
 ):
     """Update system settings (admin only)"""
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     
     if not settings:
@@ -1545,7 +1572,7 @@ async def get_current_retention_policy(
     """Get current retention policy configuration"""
     from app.services.retention_service import get_retention_policy, get_retention_stats
     
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     
     state_code = settings.retention_state_code if settings else "NJ"
@@ -1576,7 +1603,7 @@ async def update_retention_policy(
     """Update retention policy configuration (admin only)"""
     from app.services.retention_service import get_retention_policy
 
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
 
     if not settings:
@@ -1697,7 +1724,7 @@ async def export_for_public_records(
     from fastapi.responses import StreamingResponse
     
     # Get current state policy
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     state_code = settings.retention_state_code if settings else "NJ"
     policy = get_retention_policy(state_code)
@@ -3356,7 +3383,7 @@ async def configure_domain(
         )
     
     # Save domain to settings
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     if settings:
         settings.custom_domain = domain
@@ -3452,7 +3479,7 @@ async def get_domain_status(
     _: User = Depends(get_current_admin)
 ):
     """Get current domain configuration status"""
-    result = await db.execute(select(SystemSettings).limit(1))
+    result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = result.scalar_one_or_none()
     
     return {
@@ -4085,7 +4112,7 @@ async def analytics_chat(
     now = datetime.utcnow()
     
     # ========== 1. System Settings (Township Identity) ==========
-    settings_result = await db.execute(select(SystemSettings).limit(1))
+    settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
     settings = settings_result.scalar_one_or_none()
     township_name = settings.township_name if settings and hasattr(settings, 'township_name') and settings.township_name else "the municipality"
     context_used.append("system_settings")

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -3774,6 +3774,7 @@ async def restore_backup_endpoint(
 
 @router.get("/health-dashboard")
 async def get_health_dashboard(
+    request: Request,
     db: AsyncSession = Depends(get_db),
     _: User = Depends(get_current_admin)
 ):
@@ -3794,11 +3795,18 @@ async def get_health_dashboard(
     
     # Check service health via network (works from inside containers)
     
-    # Backend is running if we're responding to this request
-    health["services"]["backend"] = {
-        "status": "running",
-        "uptime": "Active (responding to requests)"
-    }
+    # Every value in here is a *detail*, not an uptime.
+    #
+    # The field was called "uptime" and held strings like "Port 5173 active"
+    # and "6.2 GB - 12 conns". Nothing in this product measures availability
+    # over a period, so the name promised a statistic that does not exist and
+    # was never computed. Renamed to `detail`; `uptime` is still emitted
+    # alongside it for one release so an older frontend does not blank out.
+    def _svc(status: str, detail: str) -> dict:
+        return {"status": status, "detail": detail, "uptime": detail}
+
+    # True by construction: this code is running, so the backend is.
+    health["services"]["backend"] = _svc("running", "Responding to this request")
     
     # Check frontend via socket - try configured port or common ports
     import os
@@ -3811,42 +3819,55 @@ async def get_health_dashboard(
     # Remove duplicates while preserving order
     frontend_ports = list(dict.fromkeys(frontend_ports))
     
+    # The hostname was hardcoded to 'frontend', which is a docker-compose
+    # service name. On any deployment not using that exact topology -- a single
+    # container, a static bundle behind a CDN, separate hosts -- the connect
+    # fails and the page reports the frontend down while a clerk is looking at
+    # it. Configurable, and the failure below now says "could not check" rather
+    # than "stopped".
+    frontend_host = os.getenv("FRONTEND_HOST", "frontend")
+
     frontend_found = False
     for port in frontend_ports:
         try:
             import socket
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1)
-            result = sock.connect_ex(('frontend', port))
+            result = sock.connect_ex((frontend_host, port))
             sock.close()
             if result == 0:
-                health["services"]["frontend"] = {
-                    "status": "running",
-                    "uptime": f"Port {port} active"
-                }
+                health["services"]["frontend"] = _svc("running", f"Reachable on port {port}")
                 frontend_found = True
                 break
         except Exception:
             continue
     
     if not frontend_found:
+        # "stopped" would be a claim. All that is known is that nothing
+        # answered at the address we tried, which on an unusual topology says
+        # more about the address than about the frontend.
         health["services"]["frontend"] = {
-            "status": "stopped", 
-            "uptime": f"Checked ports: {frontend_ports[:3]}",
-            "error": "No ports reachable"
+            **_svc("unknown", f"No answer from {frontend_host} on "
+                              f"{', '.join(str(p) for p in frontend_ports[:3])}"),
+            "error": "No ports reachable",
         }
     
     # Database - checked below via SQL
-    health["services"]["db"] = {"status": "pending", "uptime": "Checking..."}
+    health["services"]["db"] = _svc("pending", "Checking...")
     
     # Redis - checked via redis_client
-    health["services"]["redis"] = {"status": "pending", "uptime": "Checking..."}
+    health["services"]["redis"] = _svc("pending", "Checking...")
     
-    # Caddy - if we're receiving requests, it's working
-    health["services"]["caddy"] = {
-        "status": "running",
-        "uptime": "Active (routing requests)"
-    }
+    # Caddy was hardcoded to "running" with no probe at all, on the reasoning
+    # that a received request proves the proxy routed it. That holds only when
+    # the request came through the proxy, and an admin on a port-forward or a
+    # dev server talking to the backend directly gets a confident green tick on
+    # a proxy that may be stopped.
+    #
+    # Now it says which of those it is, and never claims more than it checked.
+    from app.services.system_probes import proxy_status
+    _proxy = proxy_status(request.headers)
+    health["services"]["caddy"] = _svc(_proxy["status"], _proxy["detail"])
     
     # Database size and connection count
     try:
@@ -3861,10 +3882,10 @@ async def get_health_dashboard(
         health["database"]["connections"] = conn_result.scalar()
         health["database"]["status"] = "healthy"
         # Update service status
-        health["services"]["db"] = {
-            "status": "running",
-            "uptime": f"{health['database']['size']} • {health['database']['connections']} conns"
-        }
+        health["services"]["db"] = _svc(
+            "running",
+            f"{health['database']['size']} • {health['database']['connections']} connections",
+        )
     except Exception as e:
         health["database"]["status"] = "error"
         health["database"]["error"] = str(e)
@@ -3892,14 +3913,13 @@ async def get_health_dashboard(
         health["cache"]["used_memory"] = info.get("used_memory_human", "unknown")
         health["cache"]["connected_clients"] = info.get("connected_clients", 0)
         # Update service status
-        health["services"]["redis"] = {
-            "status": "running",
-            "uptime": f"Port {redis_port} • {health['cache']['used_memory']} memory"
-        }
+        health["services"]["redis"] = _svc(
+            "running", f"Port {redis_port} • {health['cache']['used_memory']} memory",
+        )
     except redis.ConnectionError:
         health["cache"]["status"] = "not_configured"
         health["cache"]["error"] = "Redis not available"
-        health["services"]["redis"] = {"status": "stopped", "uptime": "Not reachable"}
+        health["services"]["redis"] = _svc("stopped", "Not reachable")
     except Exception as e:
         health["cache"]["status"] = "error"
         health["cache"]["error"] = str(e)

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -47,6 +47,13 @@ celery_app.conf.update(
         # service and stops being true without warning. Without this the only
         # way to learn a key was revoked is an admin pressing Test, or a
         # resident who never got their email.
+        # Infrastructure, hourly. A disk fills in hours; a connector's
+        # credentials do not expire faster than once a day.
+        "hourly-system-probe": {
+            "task": "app.tasks.connector_checks.probe_system",
+            "schedule": 60 * 60,
+            "options": {"queue": "default"}
+        },
         "daily-connector-check": {
             "task": "app.tasks.connector_checks.verify_connectors",
             "schedule": 60 * 60 * 24,  # Every 24 hours

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -196,18 +196,25 @@ async def lifespan(app: FastAPI):
         while True:
             try:
                 async with SessionLocal() as db:
+                    # Infrastructure only, and deliberately.
+                    #
+                    # This list used to name Auth0, Vertex AI and Google
+                    # Translate, so an Azure town accumulated a month of uptime
+                    # history for three services it does not use -- the same
+                    # hardcoded-vendor problem the health page had.
+                    #
+                    # The fix is not to widen the list. External dependencies
+                    # are already swept daily by the connector check, which is
+                    # daily *because* each one costs a call to somebody else's
+                    # paid API; sampling eight of them every five minutes would
+                    # be about 2,300 calls a day against a town's own account.
+                    #
+                    # So the two stop overlapping. The connector sweep owns
+                    # external services, at a frequency that respects their
+                    # cost. This owns the machine, where a check is a syscall
+                    # and five-minute resolution is free.
                     services_to_check = [
                         ("database", check_database),
-                        ("auth0", check_auth0),
-                        # Renamed from "google_kms": key management is
-                        # pluggable, and the old name asserted a vendor. The
-                        # uptime series restarts under the new name; these are
-                        # five-minute samples for a recent-availability figure,
-                        # not a long-term record.
-                        ("kms", check_kms),
-                        ("secret_store", check_secret_manager),
-                        ("vertex_ai", check_vertex_ai),
-                        ("translation_api", check_translation_api),
                     ]
                     
                     from app.services.uptime import uptime_status

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -210,12 +210,14 @@ async def lifespan(app: FastAPI):
                         ("translation_api", check_translation_api),
                     ]
                     
+                    from app.services.uptime import uptime_status
+
                     for service_name, check_func in services_to_check:
                         start = time.time()
                         try:
                             check_result = await check_func(db)
                             response_time = int((time.time() - start) * 1000)
-                            status = "healthy" if check_result["status"] in ["healthy", "configured", "fallback", "disabled"] else "down"
+                            status = uptime_status(check_result["status"])
                             error = None if status == "healthy" else check_result.get("message")
                         except Exception as e:
                             response_time = int((time.time() - start) * 1000)

--- a/backend/app/services/ai/model_discovery.py
+++ b/backend/app/services/ai/model_discovery.py
@@ -227,7 +227,7 @@ async def load_db_cache(db) -> Dict[str, Any]:
     """Read the shared (fleet-wide) model cache off SystemSettings."""
     from sqlalchemy import select as _select
     from app.models import SystemSettings
-    row = (await db.execute(_select(SystemSettings).limit(1))).scalar_one_or_none()
+    row = (await db.execute(_select(SystemSettings).order_by(SystemSettings.id).limit(1))).scalar_one_or_none()
     return dict((row.ai_models_cache or {})) if row else {}
 
 
@@ -236,7 +236,7 @@ async def save_db_cache(db, provider: str, entry: Dict[str, Any]) -> None:
     from sqlalchemy import select as _select
     from sqlalchemy.orm.attributes import flag_modified
     from app.models import SystemSettings
-    row = (await db.execute(_select(SystemSettings).limit(1))).scalar_one_or_none()
+    row = (await db.execute(_select(SystemSettings).order_by(SystemSettings.id).limit(1))).scalar_one_or_none()
     if not row:
         row = SystemSettings()
         db.add(row)

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -332,7 +332,7 @@ async def cleanup_old_backups(retention_days: int = None) -> Dict[str, Any]:
             from sqlalchemy import select
             
             async with SessionLocal() as db:
-                result = await db.execute(select(SystemSettings))
+                result = await db.execute(select(SystemSettings).order_by(SystemSettings.id))
                 settings = result.scalar_one_or_none()
                 
                 state_code = settings.retention_state_code if settings else "NJ"

--- a/backend/app/services/connector_alerts.py
+++ b/backend/app/services/connector_alerts.py
@@ -94,6 +94,13 @@ def label(connector: str) -> str:
     """A name for a connector that reads in a sentence."""
     if connector in CONNECTOR_LABEL:
         return CONNECTOR_LABEL[connector]
+    # Infrastructure probes ride in this same table so they inherit the
+    # escalation, the digest and the mute. They need their own names for the
+    # same reason the connectors do: "system:disk is down" is not a sentence to
+    # forward to a township administrator.
+    if connector.startswith("system:"):
+        from app.services.system_probes import label_for
+        return label_for(connector)
     # "govtech:accela" -> "Accela". Anything unrecognised keeps its own name
     # rather than being dropped, so a new integration can still raise an alarm
     # the day it is added.

--- a/backend/app/services/connector_verification.py
+++ b/backend/app/services/connector_verification.py
@@ -148,3 +148,101 @@ async def _settings_url(db) -> Optional[str]:
         return f"{origin.rstrip('/')}/admin?tab=integration" if origin else None
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure
+# ---------------------------------------------------------------------------
+
+async def probe_system(db, *, readings=None, health=None, alerts=None):
+    """Record disk, database, cache and backup state as health rows.
+
+    Deliberately the same table, the same escalation and the same mute as the
+    connectors, rather than a second alerting path beside the first. Two paths
+    would drift, and the town would learn which one to trust the hard way.
+
+    `readings` is injectable so the whole thing runs in CI, which has no disk
+    quota worth failing, no PostgreSQL and no Redis.
+    """
+    from app.services import system_probes as probes
+
+    if health is None:
+        from app.services import connector_health as health
+    if readings is None:
+        readings = await _collect_readings(db)
+
+    recorded = {}
+    for connector, outcome in readings.items():
+        # "We could not measure this" is not "this is broken" -- the same rule
+        # the connector sweep follows for things it cannot check.
+        if outcome.get("recorded") is False:
+            recorded[connector] = "unmeasured"
+            continue
+        try:
+            if outcome["ok"]:
+                await health.record_success(db, connector)
+            else:
+                await health.record_failure(db, connector, outcome["detail"])
+            recorded[connector] = "ok" if outcome["ok"] else "failing"
+        except Exception:
+            logger.warning("[Probe] could not record %s", sanitize_for_log(connector))
+    if alerts is not None:
+        await alerts(db)
+    return {"probes": recorded, "labels": {k: probes.label_for(k) for k in readings}}
+
+
+async def _collect_readings(db) -> Dict[str, Dict[str, Any]]:
+    """The real measurements. Every one is guarded: a probe that raises must
+    not take the other three with it."""
+    import shutil
+
+    from sqlalchemy import text
+
+    from app.services import system_probes as probes
+
+    out: Dict[str, Dict[str, Any]] = {}
+
+    # Disk. The path that matters is wherever PostgreSQL and uploads live; with
+    # no better answer available from inside the container, the root volume is
+    # the one that fills.
+    try:
+        usage = shutil.disk_usage("/")
+        percent = (usage.used / usage.total) * 100 if usage.total else None
+        free_gb = usage.free / (1024 ** 3)
+        out["system:disk"] = probes.classify_disk(percent, free_label=f"{free_gb:.1f} GB")
+    except Exception:
+        out["system:disk"] = probes.classify_disk(None)
+
+    try:
+        await db.execute(text("SELECT 1"))
+        out["system:database"] = probes.classify_reachable("The database", True)
+    except Exception as e:
+        out["system:database"] = probes.classify_reachable("The database", False, str(e)[:200])
+
+    try:
+        from app.core.redis_client import redis_client
+        if redis_client is None:
+            # Not configured is not broken. Redis is optional here.
+            out["system:cache"] = {"ok": True, "detail": "No cache configured.", "recorded": False}
+        else:
+            await redis_client.ping()
+            out["system:cache"] = probes.classify_reachable("The cache", True)
+    except Exception as e:
+        out["system:cache"] = probes.classify_reachable("The cache", False, str(e)[:200])
+
+    try:
+        from datetime import datetime, timezone
+
+        from app.services.backup_service import get_backup_status
+        status = await get_backup_status()
+        last = (status or {}).get("last_backup_at") or (status or {}).get("last_backup")
+        if isinstance(last, str):
+            from datetime import datetime as _dt
+            last = _dt.fromisoformat(last.replace("Z", "+00:00"))
+        out["system:backups"] = probes.classify_backup(last, datetime.now(timezone.utc))
+    except Exception:
+        # Backups not being configured at all is a real and supported state for
+        # a town whose host takes them, so this is not reported as a failure.
+        out["system:backups"] = {"ok": True, "detail": "Backup status unavailable.", "recorded": False}
+
+    return out

--- a/backend/app/services/connector_verification.py
+++ b/backend/app/services/connector_verification.py
@@ -217,7 +217,18 @@ async def _collect_readings(db) -> Dict[str, Dict[str, Any]]:
         await db.execute(text("SELECT 1"))
         out["system:database"] = probes.classify_reachable("The database", True)
     except Exception as e:
-        out["system:database"] = probes.classify_reachable("The database", False, str(e)[:200])
+        # Never the exception text.
+        #
+        # This string is stored in connector_health.last_error, shown on the
+        # card, and put in the alert email. A PostgreSQL connection failure
+        # routinely quotes the DSN back at you -- host, user and password --
+        # so a database that goes down would email its own credentials to
+        # every administrator, and leave them in a table and an inbox
+        # afterwards. The type is enough to act on; the rest goes to the log,
+        # through the sanitiser, where it is already handled.
+        logger.warning("[Probe] database unreachable: %s", sanitize_for_log(str(e)[:300]))
+        out["system:database"] = probes.classify_reachable(
+            "The database", False, probes.failure_summary(e))
 
     try:
         from app.core.redis_client import redis_client
@@ -228,7 +239,10 @@ async def _collect_readings(db) -> Dict[str, Dict[str, Any]]:
             await redis_client.ping()
             out["system:cache"] = probes.classify_reachable("The cache", True)
     except Exception as e:
-        out["system:cache"] = probes.classify_reachable("The cache", False, str(e)[:200])
+        # Same reasoning as the database above: a Redis URL carries a password.
+        logger.warning("[Probe] cache unreachable: %s", sanitize_for_log(str(e)[:300]))
+        out["system:cache"] = probes.classify_reachable(
+            "The cache", False, probes.failure_summary(e))
 
     try:
         from datetime import datetime, timezone

--- a/backend/app/services/delivery_providers.py
+++ b/backend/app/services/delivery_providers.py
@@ -318,3 +318,39 @@ def normalize_provider(capability: str, value: Optional[str]) -> str:
     if candidate in _CATALOGS[capability]:
         return candidate
     return _DEFAULTS[capability]
+
+
+def required_keys(entry: Dict[str, Any] | None) -> list:
+    """The credential keys a provider cannot work without.
+
+    Pulled out so the live test can ask "is there anything saved here at all"
+    before it reports on the connection. Without that check, the fallthrough at
+    the end of the SMS test answered "there is no way to check http without
+    sending a real text message" for a town that had never entered a gateway
+    URL -- true about http in general, and completely wrong about their
+    situation, which is that nothing is configured. The same fallthrough exists
+    for Azure Communication Services on the email side.
+    """
+    if not entry:
+        return []
+    return [
+        f["key"] for f in entry.get("credential_fields", [])
+        if f.get("required") and not f.get("optional")
+    ]
+
+
+def missing_keys(entry: Dict[str, Any] | None, stored: Dict[str, Any]) -> list:
+    """Which required keys have nothing saved against them."""
+    return [k for k in required_keys(entry) if not (stored.get(k) or "").strip()]
+
+
+def describe_missing(entry: Dict[str, Any] | None, missing: list) -> str:
+    """A sentence naming the boxes that are still empty, in the words the form
+    uses -- not the environment-variable names, which are ours and not theirs."""
+    if not entry or not missing:
+        return ""
+    labels = {f["key"]: f.get("label", f["key"]) for f in entry.get("credential_fields", [])}
+    named = [labels.get(k, k) for k in missing]
+    if len(named) == 1:
+        return f"{named[0]} has not been filled in yet."
+    return f"{', '.join(named[:-1])} and {named[-1]} have not been filled in yet."

--- a/backend/app/services/system_probes.py
+++ b/backend/app/services/system_probes.py
@@ -86,6 +86,24 @@ def classify_backup(last_backup_at: Optional[datetime], now: datetime,
     return _outcome(True, f"Last backup {hours} hour{'s' if hours != 1 else ''} ago.")
 
 
+def failure_summary(exc: BaseException) -> str:
+    """What a connection failure may say in public.
+
+    The exception type and nothing else. These strings are stored, rendered on
+    a card and mailed to administrators, and the drivers that raise them put
+    the connection string in the message -- `OperationalError` from psycopg
+    quotes the DSN, and a Redis URL carries its password inline. Repeating that
+    would turn an outage into a credential disclosure with a wide audience and
+    a long tail: a database row, an inbox, and whatever the town forwards it
+    to.
+
+    The type tells an administrator what kind of problem it is, which is what
+    they can act on. The full text goes to the log, sanitised.
+    """
+    name = type(exc).__name__
+    return f"Could not connect ({name}). The full error is in the server log."
+
+
 def classify_reachable(name: str, reachable: bool, detail: str = "") -> Dict[str, Any]:
     if reachable:
         return _outcome(True, detail or f"{name} is reachable.")

--- a/backend/app/services/system_probes.py
+++ b/backend/app/services/system_probes.py
@@ -1,0 +1,137 @@
+"""Disk, database, cache and backups, as things that can be reported on.
+
+The console had two unrelated ideas of "is it working". Connectors had a daily
+sweep, a health table, escalation and email. Infrastructure had a page you had
+to be looking at -- so a disk filling up was visible to anyone who happened to
+open System Health that afternoon, and to nobody otherwise. A full disk stops
+the database accepting writes, which stops a town taking reports, and the first
+sign of it should not be a resident's form failing.
+
+Rather than build a second alerting path, these are recorded as ordinary
+connector-health rows under a `system:` prefix. Everything already built then
+applies for free and cannot drift: the same escalation from at-risk to broken,
+the same digest, the same cadence, the same mute. The one difference is the
+sweep interval -- connectors are checked daily because each costs a call to
+somebody else's API, and these cost a syscall, so they run hourly. The alerting
+cadence is unchanged by that: it is governed by how long a connector has been
+in a state, not by how often it is measured.
+
+Pure, so all of it runs in CI. The readings are passed in; nothing here touches
+a disk, a database or a clock.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+PREFIX = "system:"
+
+# Where a filling disk stops being interesting and starts being a deadline.
+#
+# 80 is the warning because the gap between "somebody should look at this" and
+# "the database cannot write" is measured in days at typical growth, and a
+# town's answer is often to ring somebody, which takes one. 90 is not a
+# comfortable margin on a small volume -- 10% of 20GB is two gigabytes, which a
+# photo-heavy week can eat -- but a threshold nobody reaches is not a threshold.
+DISK_WARN_PERCENT = 80
+DISK_CRITICAL_PERCENT = 90
+
+# A backup regime that has silently stopped is indistinguishable from one that
+# never ran, and both are discovered at restore time. Two days rather than one:
+# a single missed nightly run is a blip, two is a pattern.
+BACKUP_STALE_AFTER = timedelta(days=2)
+
+
+def _outcome(ok: bool, detail: str, *, recorded: bool = True) -> Dict[str, Any]:
+    return {"ok": ok, "detail": detail, "recorded": recorded}
+
+
+def classify_disk(percent_used: Optional[float], *, free_label: str = "") -> Dict[str, Any]:
+    """A reading, in the words somebody who is not an engineer can act on."""
+    if percent_used is None:
+        # Not every host lets us see this. Silence beats a guess.
+        return _outcome(False, "Disk usage could not be read on this host.", recorded=False)
+    room = f" {free_label} free." if free_label else ""
+    if percent_used >= DISK_CRITICAL_PERCENT:
+        return _outcome(False, (
+            f"Disk is {percent_used:.0f}% full.{room} When it reaches 100% the database stops "
+            f"accepting new reports. Clear space or extend the volume."
+        ))
+    if percent_used >= DISK_WARN_PERCENT:
+        return _outcome(False, (
+            f"Disk is {percent_used:.0f}% full.{room} Not urgent yet, but it does not "
+            f"empty itself -- worth arranging more space now rather than at 99%."
+        ))
+    return _outcome(True, f"Disk is {percent_used:.0f}% full.{room}")
+
+
+def classify_backup(last_backup_at: Optional[datetime], now: datetime,
+                    *, stale_after: timedelta = BACKUP_STALE_AFTER) -> Dict[str, Any]:
+    """Backups are only real if they are recent and somebody would notice."""
+    if last_backup_at is None:
+        return _outcome(False, (
+            "No backup has ever been recorded. Nothing here can be restored."
+        ))
+    if last_backup_at.tzinfo is None:
+        last_backup_at = last_backup_at.replace(tzinfo=timezone.utc)
+    age = now - last_backup_at
+    if age >= stale_after:
+        days = max(1, int(age.total_seconds() // 86400))
+        return _outcome(False, (
+            f"The last successful backup was {days} day{'s' if days != 1 else ''} ago. "
+            f"Anything since then would be lost."
+        ))
+    hours = max(0, int(age.total_seconds() // 3600))
+    return _outcome(True, f"Last backup {hours} hour{'s' if hours != 1 else ''} ago.")
+
+
+def classify_reachable(name: str, reachable: bool, detail: str = "") -> Dict[str, Any]:
+    if reachable:
+        return _outcome(True, detail or f"{name} is reachable.")
+    return _outcome(False, detail or f"{name} is not reachable from the server.")
+
+
+# What each probe is called on screen and in an email. Kept here so the alert
+# text and the health page cannot disagree about what "system:disk" means.
+LABELS: Dict[str, str] = {
+    "system:disk": "Disk space",
+    "system:database": "Database",
+    "system:cache": "Cache (Redis)",
+    "system:backups": "Backups",
+}
+
+
+def label_for(connector: str) -> str:
+    return LABELS.get(connector, connector.replace(PREFIX, "").replace("_", " ").capitalize())
+
+
+def is_system(connector: str) -> bool:
+    return connector.startswith(PREFIX)
+
+
+# Headers a reverse proxy adds on the way through. Any one of them is evidence
+# that this request was routed rather than made directly to the app.
+FORWARDED_HEADERS = ("x-forwarded-for", "x-forwarded-proto", "x-real-ip")
+
+
+def proxy_status(headers) -> Dict[str, str]:
+    """Whether the reverse proxy can be said to be working, from in here.
+
+    It used to be hardcoded to "running", on the reasoning that a request we
+    received must have been routed to us. That holds only when the request came
+    through the proxy. An admin on a port-forward, or a dev server talking to
+    the backend directly, got a confident green tick on a proxy that might be
+    stopped -- and a green tick nobody checked is the failure this console keeps
+    being built around avoiding.
+
+    There is no third state to invent here: either the evidence is in the
+    request or it is not.
+    """
+    names = {str(h).lower() for h in (headers or {})}
+    if names & set(FORWARDED_HEADERS):
+        return {"status": "running", "detail": "Routed this request"}
+    return {
+        "status": "unknown",
+        "detail": "Cannot tell from here - this request did not arrive through a proxy",
+    }

--- a/backend/app/services/system_settings.py
+++ b/backend/app/services/system_settings.py
@@ -1,0 +1,90 @@
+"""One row, and the same row every time.
+
+`system_settings` is a singleton by convention and by nothing else. Seven code
+paths create it with a non-atomic "read, and insert if missing", and twenty-odd
+read it back with `select(SystemSettings).limit(1)` and no ORDER BY.
+
+Both halves of that are a problem, and together they produce a bug that looks
+like a UI fault. `LIMIT 1` without `ORDER BY` gives PostgreSQL permission to
+return whichever row is cheapest to reach, and an UPDATE physically relocates a
+row in the heap. So on a table that has ever ended up with two rows, a save can
+write row 1 and the read immediately afterwards can return row 2 -- the setting
+goes into the database, the page reloads, and the old value comes back. It is
+intermittent, it is invisible in the logs, and it looks exactly like "the state
+I choose for the retention policy isn't persisting".
+
+It is not a retention bug. Retention is just where it was noticed. The same
+read is used for the municipal boundary, the road-data state, the AI model
+cache, backup configuration and the public origin -- and, worse than any of
+those, by the nightly retention task itself, which means the policy actually
+enforced at 1am can differ from the one displayed on the compliance page.
+
+Two fixes, because either alone leaves the door open. This module makes every
+read deterministic, and the migration alongside it collapses any duplicates
+that already exist and adds a constraint so a second row cannot be created
+again.
+"""
+
+from typing import Any, Iterable, List, Optional, Sequence, TypeVar
+
+Row = TypeVar("Row")
+
+
+def pick_canonical(rows: Sequence[Row]) -> Optional[Row]:
+    """The one true settings row: the oldest, by primary key.
+
+    Lowest id rather than newest, deliberately. The first row is the one the
+    deployment has been reading for its whole life, so it holds the values a
+    town actually configured; a duplicate created later by a racing request
+    holds mostly defaults. Picking the newest would silently swap a configured
+    row for an empty one.
+    """
+    if not rows:
+        return None
+    return min(rows, key=lambda r: (getattr(r, "id", None) is None, getattr(r, "id", 0)))
+
+
+def merge_into_canonical(rows: Sequence[Row], columns: Iterable[str]) -> tuple[Optional[Row], List[Row]]:
+    """Fold duplicates into the canonical row, and say which are now spare.
+
+    A value set on a duplicate is still a value somebody typed into this
+    product, so it is carried over wherever the canonical row has nothing --
+    never over the top of an existing answer. Deleting the duplicates without
+    this would quietly discard configuration.
+
+    Returns (canonical, duplicates-to-delete).
+    """
+    canonical = pick_canonical(rows)
+    if canonical is None:
+        return None, []
+    others = [r for r in rows if r is not canonical]
+    # Oldest first, so that when two duplicates both have a value the earlier
+    # one wins -- the same tie-break as picking the canonical row itself.
+    for other in sorted(others, key=lambda r: (getattr(r, "id", None) is None, getattr(r, "id", 0))):
+        for column in columns:
+            if getattr(canonical, column, None) is None:
+                value = getattr(other, column, None)
+                if value is not None:
+                    setattr(canonical, column, value)
+    return canonical, others
+
+
+async def get_settings(db: Any, *, create: bool = False) -> Optional[Any]:
+    """Read the settings row deterministically.
+
+    Ordered by id, so this returns the same row on every call regardless of how
+    many exist or what the planner feels like doing. `create=True` inserts one
+    when the table is empty, for the write paths.
+    """
+    from sqlalchemy import select
+
+    from app.models import SystemSettings
+
+    row = (
+        await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
+    ).scalar_one_or_none()
+    if row is None and create:
+        row = SystemSettings()
+        db.add(row)
+        await db.flush()
+    return row

--- a/backend/app/services/uptime.py
+++ b/backend/app/services/uptime.py
@@ -1,0 +1,110 @@
+"""Availability, and the honest limits of measuring it from inside.
+
+There is a real time series here: a background task samples each dependency
+every five minutes, writes a row, and keeps thirty days. `/uptime/stats`
+divides healthy samples by total samples. That part works.
+
+What it cannot do is measure the backend's own availability, and the shape of
+the arithmetic hides that rather than admitting it. The sampler runs *inside*
+the process it is reporting on, so when the backend is down it does not record
+"down" -- it records nothing at all. Six hours of outage leaves a six-hour hole,
+and a percentage computed as healthy/total over the samples that exist comes
+back at 100%. The worse the outage, the fewer samples disagree with it.
+
+So the denominator has to be time, not rows. This module computes how many
+samples a period *should* contain and reports coverage next to the percentage.
+A figure of "100% across 12 of an expected 288 checks" is a different claim from
+"100% across 288", and a page that cannot tell them apart is worse than one with
+no number on it, because somebody will put the first in a report to a council.
+
+None of this makes an in-process sampler into an uptime monitor. Measuring your
+own availability from inside yourself has a floor, and the honest name for what
+this produces is dependency availability: whether Auth0, KMS and the rest
+answered, during the windows we were up to ask.
+
+Pure. The samples are passed in.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+# How often the background sampler runs. The expected-sample count is derived
+# from this, so the two cannot drift apart without the coverage figure noticing.
+SAMPLE_INTERVAL = timedelta(minutes=5)
+
+# Below this, the percentage is not reported as a headline figure. Not a
+# judgement about the service -- a statement that we did not watch it enough to
+# have an opinion.
+MIN_COVERAGE_PERCENT = 50.0
+
+# A check outcome that means "this is fine".
+#
+# One tuple, because there were two and they disagreed. The background sampler
+# counted "disabled" as healthy; the manual "Check now" button did not. So
+# pressing the button on the health page recorded a switched-off service as
+# *down* and dented its uptime -- the act of looking at the number made the
+# number worse.
+HEALTHY_STATUSES = ("healthy", "configured", "fallback", "disabled")
+
+
+def uptime_status(check_status: str) -> str:
+    """Normalise a health-check result into what gets stored."""
+    return "healthy" if check_status in HEALTHY_STATUSES else "down"
+
+
+def expected_samples(hours: float, interval: timedelta = SAMPLE_INTERVAL) -> int:
+    seconds = interval.total_seconds()
+    if seconds <= 0:
+        return 0
+    return max(1, int((hours * 3600) / seconds))
+
+
+def summarise(
+    *,
+    total: int,
+    healthy: int,
+    hours: float,
+    interval: timedelta = SAMPLE_INTERVAL,
+    min_coverage: float = MIN_COVERAGE_PERCENT,
+) -> Dict[str, Any]:
+    """One service over one period, with the caveat attached to the number.
+
+    `reliable` is False when too little of the period was actually sampled. The
+    percentage is still returned -- hiding it would be its own kind of lie --
+    but nothing should print it as a headline without the coverage beside it.
+    """
+    expected = expected_samples(hours, interval)
+    coverage = min(100.0, (total / expected * 100)) if expected else 0.0
+    percent = (healthy / total * 100) if total else 0.0
+    missing = max(0, expected - total)
+    return {
+        "uptime_percent": round(percent, 2),
+        "checks": total,
+        "healthy": healthy,
+        "expected_checks": expected,
+        # The gap. If the backend was down, its own outage is in here rather
+        # than in `uptime_percent`, which is exactly the point.
+        "missed_checks": missing,
+        "coverage_percent": round(coverage, 1),
+        "reliable": coverage >= min_coverage and total > 0,
+    }
+
+
+def describe(summary: Dict[str, Any]) -> str:
+    """A sentence that does not overstate what was measured."""
+    if not summary.get("checks"):
+        return "Not measured over this period."
+    if not summary.get("reliable"):
+        return (
+            f"{summary['uptime_percent']:.1f}% across {summary['checks']} of an expected "
+            f"{summary['expected_checks']} checks — too little of the period was sampled "
+            f"to draw a conclusion. Missing checks usually mean the server itself was down."
+        )
+    if summary.get("missed_checks"):
+        return (
+            f"{summary['uptime_percent']:.1f}% of {summary['checks']} checks. "
+            f"{summary['missed_checks']} expected checks did not run."
+        )
+    return f"{summary['uptime_percent']:.1f}% of {summary['checks']} checks."

--- a/backend/app/services/uptime.py
+++ b/backend/app/services/uptime.py
@@ -27,8 +27,8 @@ Pure. The samples are passed in.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from datetime import timedelta
+from typing import Any, Dict
 
 # How often the background sampler runs. The expected-sample count is derived
 # from this, so the two cannot drift apart without the coverage figure noticing.

--- a/backend/app/tasks/connector_checks.py
+++ b/backend/app/tasks/connector_checks.py
@@ -33,3 +33,33 @@ def verify_connectors():
         logger.error("[Health] daily connector check could not run: %s",
                      sanitize_for_log(str(exc)[:300]))
         return {"checked": {}, "failing": [], "error": True}
+
+
+@celery_app.task(name="app.tasks.connector_checks.probe_system")
+def probe_system():
+    """Hourly infrastructure probe.
+
+    Hourly rather than daily because a disk fills in hours, and each of these
+    costs a syscall rather than a call to somebody else's API. It does not make
+    the email hourly: the cadence is set by how long something has been in a
+    state, not by how often it is measured.
+    """
+    import asyncio
+
+    from app.services.connector_verification import probe_system as run_probe
+
+    async def run():
+        from app.db.session import SessionLocal
+        from app.services.connector_alerts import dispatch
+        async with SessionLocal() as db:
+            # Alerting is handed in rather than left to a second scheduled job.
+            # A probe that records a full disk and does not send the email is
+            # the same silence this replaces, one layer further in.
+            return await run_probe(db, alerts=dispatch)
+
+    try:
+        return asyncio.run(run())
+    except Exception as exc:
+        logger.error("[Probe] hourly system probe could not run: %s",
+                     sanitize_for_log(str(exc)[:300]))
+        return {"probes": {}, "error": True}

--- a/backend/app/tasks/road_data.py
+++ b/backend/app/tasks/road_data.py
@@ -93,7 +93,7 @@ async def _load_boundary_and_state(db) -> Tuple[Optional[Dict[str, Any]], Option
     """
     from app.models import SystemSettings
 
-    row = (await db.execute(select(SystemSettings).limit(1))).scalar_one_or_none()
+    row = (await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))).scalar_one_or_none()
     if not row:
         return None, None, "pinpoint"
 

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -136,7 +136,7 @@ def analyze_request(self, request_id: int):
         from datetime import datetime
         
         async with SessionLocal() as db:
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
 
             # Fetch the request first — enrichment below runs for it regardless of
@@ -386,7 +386,7 @@ def send_branded_notification(request_id: int, notification_type: str, old_statu
             await configure_notifications(db)
             
             # Get system settings for branding
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
             township_name = settings.township_name if settings else "Your Township"
@@ -522,7 +522,7 @@ def send_comment_notification_task(request_id: int, comment_author: str, comment
             await configure_notifications(db)
             
             # Get system settings for branding
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
             township_name = settings.township_name if settings else "Your Township"
@@ -599,7 +599,7 @@ def send_department_notification(request_id: int, department_email: str):
             await configure_notifications(db)
             
             # Get system settings for branding and module checks
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
             modules = settings.modules if settings else {}
@@ -773,7 +773,7 @@ def notify_staff_of_activity(request_id: int, event: str, actor: str = None):
         async with SessionLocal() as db:
             await configure_notifications(db)
 
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             modules = settings.modules if settings else {}
             sms_enabled_globally = modules.get('sms_alerts', False)
@@ -972,7 +972,7 @@ def enforce_retention_policy():
         
         async with SessionLocal() as db:
             # Get retention settings
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
             if not settings:
@@ -1113,7 +1113,7 @@ def send_weekly_digest():
             await configure_notifications(db)
             
             # Get system settings for branding
-            settings_result = await db.execute(select(SystemSettings).limit(1))
+            settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
             township_name = settings.township_name if settings else "Your Township"
@@ -1436,7 +1436,7 @@ def proactive_health_scan():
             result = await evaluate(db)
             checks = result["checks"]
 
-            settings_res = await db.execute(select(SystemSettings).limit(1))
+            settings_res = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_res.scalar_one_or_none()
             if not settings:
                 return {"status": "no_settings"}

--- a/backend/tests/test_delivery_test_says_whats_missing.py
+++ b/backend/tests/test_delivery_test_says_whats_missing.py
@@ -1,0 +1,67 @@
+"""Report the town's situation, not a fact about the vendor.
+
+Reported directly: "the texts thing was saying not testable when I never
+entered text credentials." Both halves of the delivery test ended in a
+fallthrough that described the *provider* -- "there is no way to check http
+without sending a real text message" -- without first asking whether anything
+had been saved. True about a generic HTTP gateway, and useless to a clerk whose
+actual situation is that the boxes are empty.
+"""
+
+from app.services.delivery_providers import (
+    EMAIL_CATALOG, SMS_CATALOG, describe_missing, missing_keys, required_keys,
+)
+
+
+def test_a_generic_gateway_needs_its_url():
+    assert required_keys(SMS_CATALOG["http"]) == ["SMS_HTTP_API_URL"]
+
+
+def test_an_optional_key_is_not_required():
+    """The API key on a generic gateway is optional -- some accept an
+    unauthenticated POST from an allow-listed address."""
+    assert "SMS_HTTP_API_KEY" not in required_keys(SMS_CATALOG["http"])
+
+
+def test_nothing_saved_is_reported_as_nothing_saved():
+    assert missing_keys(SMS_CATALOG["http"], {}) == ["SMS_HTTP_API_URL"]
+    assert missing_keys(SMS_CATALOG["http"], {"SMS_HTTP_API_URL": "https://gw"}) == []
+
+
+def test_whitespace_is_not_a_credential():
+    assert missing_keys(SMS_CATALOG["http"], {"SMS_HTTP_API_URL": "   "}) == ["SMS_HTTP_API_URL"]
+
+
+def test_acs_email_is_checked_too():
+    """The same fallthrough exists on the email side."""
+    missing = missing_keys(EMAIL_CATALOG["acs"], {})
+    assert missing, "ACS reports untestable before checking whether it is configured"
+
+
+def test_the_message_uses_the_words_on_the_form():
+    """Not the environment-variable names. Those are ours; a clerk has never
+    seen them and cannot map them back to a box."""
+    text = describe_missing(SMS_CATALOG["http"], ["SMS_HTTP_API_URL"])
+    assert "POST URL" in text
+    assert "SMS_HTTP_API_URL" not in text
+
+
+def test_several_missing_boxes_are_listed_readably():
+    entry = EMAIL_CATALOG["acs"]
+    text = describe_missing(entry, missing_keys(entry, {}))
+    assert " and " in text
+    assert "_" not in text, f"raw key names leaked into the message: {text}"
+
+
+def test_nothing_missing_says_nothing():
+    assert describe_missing(SMS_CATALOG["http"], []) == ""
+
+
+def test_every_delivery_provider_can_answer_the_question():
+    """A provider whose catalog entry has no required fields would be reported
+    as configured however empty it is -- that is the vacuous-truth case, and it
+    is worth knowing which providers are in it."""
+    for name, catalog in (("email", EMAIL_CATALOG), ("sms", SMS_CATALOG)):
+        for provider, entry in catalog.items():
+            keys = required_keys(entry)
+            assert isinstance(keys, list), f"{name}:{provider}"

--- a/backend/tests/test_health_dashboard_is_honest.py
+++ b/backend/tests/test_health_dashboard_is_honest.py
@@ -8,7 +8,6 @@ stopped on any other topology.
 
 from pathlib import Path
 
-import pytest
 
 SOURCE = (Path(__file__).resolve().parents[1] / "app/api/system.py").read_text()
 DASHBOARD = SOURCE[SOURCE.index('@router.get("/health-dashboard")'):]

--- a/backend/tests/test_health_dashboard_is_honest.py
+++ b/backend/tests/test_health_dashboard_is_honest.py
@@ -1,0 +1,71 @@
+"""The health page must not claim more than it checked.
+
+Three things it claimed. A field called `uptime` that never held an uptime; a
+reverse proxy reported as running with no probe behind it; and a frontend check
+hardcoded to a docker-compose hostname, which reports a healthy frontend as
+stopped on any other topology.
+"""
+
+from pathlib import Path
+
+import pytest
+
+SOURCE = (Path(__file__).resolve().parents[1] / "app/api/system.py").read_text()
+DASHBOARD = SOURCE[SOURCE.index('@router.get("/health-dashboard")'):]
+DASHBOARD = DASHBOARD[:DASHBOARD.index("\n@router.", 10)]
+
+
+def test_nothing_is_presented_as_an_uptime_that_is_not_one():
+    """Values like "Port 5173 active" and "6.2 GB - 12 conns" are details.
+    Nothing in this product measures availability over a period, so a field
+    named uptime promised a statistic that was never computed."""
+    assert '"detail"' in DASHBOARD, "the honest field is missing"
+    # The old key stays for one release so an older frontend does not blank
+    # out, but it must never be the only thing carrying the value.
+    for line in DASHBOARD.splitlines():
+        if '"uptime"' in line and "detail" not in line and "#" not in line:
+            assert False, f"uptime carried alone: {line.strip()}"
+
+
+def test_the_proxy_is_probed_rather_than_assumed():
+    """Behaviour, not source. The first version of this test grepped for the
+    header name and for the "cannot tell" string, and both survived a mutation
+    that put the status back to a hardcoded "running" -- the strings were still
+    there, in the detail line, above a status that had stopped depending on
+    them."""
+    from app.services.system_probes import proxy_status
+
+    assert proxy_status({"x-forwarded-for": "10.0.0.1"})["status"] == "running"
+    assert proxy_status({"X-Real-IP": "10.0.0.1"})["status"] == "running"
+    assert proxy_status({})["status"] == "unknown"
+    assert proxy_status(None)["status"] == "unknown"
+    assert proxy_status({"user-agent": "curl"})["status"] == "unknown"
+
+
+def test_the_proxy_says_when_it_cannot_tell():
+    from app.services.system_probes import proxy_status
+
+    assert "Cannot tell from here" in proxy_status({})["detail"]
+    assert '"Active (routing requests)"' not in DASHBOARD
+
+
+def test_the_frontend_hostname_is_not_hardcoded():
+    """'frontend' is a docker-compose service name. On a single container, a
+    static bundle behind a CDN, or separate hosts, the connect fails and the
+    page reports the frontend down while somebody is looking at it."""
+    assert "FRONTEND_HOST" in DASHBOARD
+    assert "connect_ex(('frontend'" not in DASHBOARD
+
+
+def test_an_unreachable_frontend_says_where_it_looked():
+    """"Checked ports: [5173, 3000, 80]" does not tell an admin that we were
+    looking at a hostname that does not exist in their deployment."""
+    assert "No answer from" in DASHBOARD
+
+
+def test_the_dashboard_can_see_the_request_it_is_answering():
+    """The proxy probe reads forwarding headers, so the handler needs the
+    request. Without this parameter it raises NameError at runtime -- which no
+    test that only reads source would otherwise catch."""
+    signature = DASHBOARD[:DASHBOARD.index("):")]
+    assert "request: Request" in signature

--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -399,3 +399,66 @@ def test_no_console_walk_runs_away_with_itself():
         if words > 400:
             offenders.append(f"{m.group(1)}:{m.group(2)} is {words} words")
     assert not offenders, "console walks have grown back:\n" + "\n".join(offenders)
+
+
+# ---------------------------------------------------------------------------
+# A warning that is everywhere is not a warning
+# ---------------------------------------------------------------------------
+
+def test_warnings_are_rare_enough_to_read():
+    """There was one on every other step, and on all three steps of the Google
+    Maps walk. The billing warning -- the one that silently produces a grey map
+    on a key that looks correct -- sat in identical amber beside "changes can
+    take up to five minutes". A page that flags everything flags nothing.
+
+    The bar is now: amber is for a failure that is silent, one that cannot be
+    undone, or one that lands on the town's money or resident data. Everything
+    else is a grey note.
+    """
+    source = _read(CONTENT)
+    offenders = []
+    for m in re.finditer(r"defineSteps\(\s*'([a-z]+)'\s*,\s*'([a-z0-9]+)'", source):
+        end = source.index("\n]);", m.start())
+        block = source[m.start():end]
+        warnings = len(re.findall(r"^\s+trouble:", block, re.M))
+        steps = max(1, len(re.findall(r"^\s{4}\{", block, re.M)))
+        # Half, rounded up. A three-step walk may carry two if both earn it --
+        # Google Maps does: one is the billing step that silently yields a grey
+        # map, the other is an unrestricted key somebody can run a bill up on.
+        if warnings > -(-steps // 2):
+            offenders.append(f"{m.group(1)}:{m.group(2)} has {warnings} across {steps} steps")
+    assert not offenders, "warnings are back to competing with each other:\n" + "\n".join(offenders)
+
+
+def test_the_quiet_kind_of_aside_exists_and_is_used():
+    """The demotion has to go somewhere. If `note` disappeared, the 28 asides
+    that stopped being warnings were deleted rather than quietened -- and some
+    of them are the difference between finishing and not."""
+    source = _read(CONTENT)
+    assert len(re.findall(r"^\s+note:", source, re.M)) >= 20
+    assert "note?: ReactNode" in _read(FRONTEND / "setupSteps.tsx")
+
+
+def test_a_note_does_not_look_like_a_warning():
+    """Same weight and colour is what made the warnings stop registering."""
+    renderer = _read(SHARED)
+    assert "st.note" in renderer, "notes are defined but never rendered"
+    note_block = renderer[renderer.index("st.note &&"):]
+    note_block = note_block[:note_block.index("</p>")]
+    assert "amber" not in note_block
+    assert "AlertCircle" not in note_block
+
+
+def test_the_silent_failures_kept_their_warning():
+    """The specific ones worth keeping. Each is a case where a clerk would
+    otherwise believe it had worked."""
+    source = _read(CONTENT)
+    for phrase in (
+        "Google will issue a key without it",       # billing: key looks right, map grey
+        "quietly encrypted with",                    # KMS: wrong key, no error
+        "Entra shows the Value once",                # no second chance
+    ):
+        assert phrase in source, f"a silent-failure warning was demoted: {phrase}"
+        i = source.index(phrase)
+        line_start = source.rfind("\n", 0, source.rfind("trouble:", 0, i) if "trouble:" in source[:i] else 0)
+        assert "trouble:" in source[max(0, i - 400):i], f"{phrase} is no longer a warning"

--- a/backend/tests/test_setup_guide_is_inline.py
+++ b/backend/tests/test_setup_guide_is_inline.py
@@ -460,5 +460,4 @@ def test_the_silent_failures_kept_their_warning():
     ):
         assert phrase in source, f"a silent-failure warning was demoted: {phrase}"
         i = source.index(phrase)
-        line_start = source.rfind("\n", 0, source.rfind("trouble:", 0, i) if "trouble:" in source[:i] else 0)
         assert "trouble:" in source[max(0, i - 400):i], f"{phrase} is no longer a warning"

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -242,8 +242,6 @@ def test_every_provider_records_the_traps_it_has(declarations):
     it. Whether that evidence is alarming is a separate question, answered by
     `test_warnings_are_rare_enough_to_read`.
     """
-    import re
-
     source = CONTENT.read_text()
     calls = list(re.finditer(r"defineSteps\(\s*'([a-z]+)'\s*,\s*'([a-z0-9]+)'", source))
     missing = []

--- a/backend/tests/test_setup_steps_content.py
+++ b/backend/tests/test_setup_steps_content.py
@@ -221,8 +221,8 @@ def test_the_guide_no_longer_asks_for_an_invented_backup_passphrase():
 # Pitfalls
 # ---------------------------------------------------------------------------
 
-def test_every_provider_warns_about_something(declarations):
-    """`trouble` is where the failures that do not announce themselves live.
+def test_every_provider_records_the_traps_it_has(declarations):
+    """Somebody has walked this path and written down what bit them.
 
     Every path on this page has at least one: a key that Google issues without
     billing and that renders a grey box; an Entra secret shown once with a
@@ -233,6 +233,14 @@ def test_every_provider_warns_about_something(declarations):
 
     Redaction was the gap this caught: three of its four paths had no warning at
     all, and one of them is the default every install now lands on.
+
+    Widened from `trouble` to `trouble or note`. It used to demand an amber
+    warning on every path, which is part of how there came to be one on every
+    other step -- writing a new walk meant adding a warning whether or not the
+    path had anything alarming in it, and the real ones then had to compete
+    with them. The intent survives: what must exist is evidence somebody walked
+    it. Whether that evidence is alarming is a separate question, answered by
+    `test_warnings_are_rare_enough_to_read`.
     """
     import re
 
@@ -241,9 +249,10 @@ def test_every_provider_warns_about_something(declarations):
     missing = []
     for i, call in enumerate(calls):
         end = calls[i + 1].start() if i + 1 < len(calls) else len(source)
-        if "trouble:" not in source[call.start():end]:
+        block = source[call.start():end]
+        if "trouble:" not in block and "note:" not in block:
             missing.append(f"{call.group(1)}:{call.group(2)}")
-    assert not missing, f"no pitfall warning written for: {missing}"
+    assert not missing, f"nothing written down about the traps in: {missing}"
 
 
 def test_the_key_deletion_warnings_are_present():

--- a/backend/tests/test_system_probe_alerts.py
+++ b/backend/tests/test_system_probe_alerts.py
@@ -1,0 +1,115 @@
+"""Infrastructure raises the alarm through the same machinery as connectors.
+
+Not a second alerting path beside the first. Two paths drift, and a town finds
+out which one to trust the hard way -- so a filling disk escalates, digests and
+mutes exactly like a revoked API key.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services import connector_alerts as A
+from app.services import system_probes as P
+from app.services.connector_verification import probe_system
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeHealth:
+    def __init__(self):
+        self.successes, self.failures = [], []
+    async def record_success(self, db, connector):
+        self.successes.append(connector)
+    async def record_failure(self, db, connector, detail):
+        self.failures.append((connector, detail))
+
+
+@pytest.mark.asyncio
+async def test_a_filling_disk_is_recorded_as_a_failure():
+    health = FakeHealth()
+    await probe_system(None, readings={"system:disk": P.classify_disk(93)}, health=health)
+    assert [c for c, _ in health.failures] == ["system:disk"]
+    assert "stops accepting new reports" in health.failures[0][1]
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_disk_is_recorded_as_a_success():
+    health = FakeHealth()
+    await probe_system(None, readings={"system:disk": P.classify_disk(20)}, health=health)
+    assert health.successes == ["system:disk"]
+    assert health.failures == []
+
+
+@pytest.mark.asyncio
+async def test_something_we_could_not_measure_is_not_recorded_either_way():
+    """A probe that cannot read the disk must not write a failure. The same
+    rule the connector sweep follows: unmeasurable is not broken, and a badge
+    that can never clear is worse than none."""
+    health = FakeHealth()
+    out = await probe_system(None, readings={"system:disk": P.classify_disk(None)}, health=health)
+    assert health.successes == [] and health.failures == []
+    assert out["probes"]["system:disk"] == "unmeasured"
+
+
+@pytest.mark.asyncio
+async def test_one_failing_probe_does_not_stop_the_others():
+    class Exploding(FakeHealth):
+        async def record_failure(self, db, connector, detail):
+            if connector == "system:disk":
+                raise RuntimeError("boom")
+            await super().record_failure(db, connector, detail)
+
+    health = Exploding()
+    await probe_system(None, health=health, readings={
+        "system:disk": P.classify_disk(99),
+        "system:backups": P.classify_backup(None, NOW),
+    })
+    assert [c for c, _ in health.failures] == ["system:backups"]
+
+
+@pytest.mark.asyncio
+async def test_the_probe_sends_the_email_itself():
+    """A probe that records a full disk and does not send the email is the same
+    silence it replaces, one layer further in."""
+    sent = []
+
+    async def alerts(db):
+        sent.append(True)
+
+    await probe_system(None, readings={"system:disk": P.classify_disk(95)},
+                       health=FakeHealth(), alerts=alerts)
+    assert sent == [True]
+
+
+def test_the_email_calls_it_something_a_person_would_say():
+    assert A.label("system:disk") == "Disk space"
+    assert A.label("system:backups") == "Backups"
+    assert "system:" not in A.label("system:cache")
+
+
+def test_a_full_disk_escalates_like_any_other_failure():
+    """Same rules, no special casing: new, then escalated, then reminders on
+    the broken cadence."""
+    assert A.decide(level=A.AT_RISK, previous_level=None, alerted_at=None, now=NOW) == "new"
+    assert A.decide(level=A.BROKEN, previous_level=A.AT_RISK,
+                    alerted_at=NOW - timedelta(hours=1), now=NOW) == "escalated"
+
+
+def test_a_disk_alert_can_be_muted_like_any_other():
+    """A town that knows the volume is being extended on Friday should be able
+    to stop the daily mail without turning off everything else."""
+    assert A.decide(level=A.BROKEN, previous_level=A.BROKEN,
+                    alerted_at=NOW - timedelta(days=2), now=NOW,
+                    muted_until=NOW + timedelta(days=2), muted_level=A.BROKEN) is None
+
+
+def test_hourly_probing_does_not_mean_hourly_email():
+    """The cadence is governed by how long something has been in a state, not
+    by how often it is measured -- otherwise moving the probe to hourly would
+    have turned one daily email into twenty-four."""
+    for hours in (1, 6, 23):
+        assert A.decide(level=A.BROKEN, previous_level=A.BROKEN,
+                        alerted_at=NOW - timedelta(hours=hours), now=NOW) is None
+    assert A.decide(level=A.BROKEN, previous_level=A.BROKEN,
+                    alerted_at=NOW - timedelta(hours=25), now=NOW) == "reminder"

--- a/backend/tests/test_system_probes.py
+++ b/backend/tests/test_system_probes.py
@@ -1,0 +1,77 @@
+"""A disk filling up should reach somebody before the database stops writing."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services import system_probes as P
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+class TestDisk:
+    def test_plenty_of_room_is_fine(self):
+        assert P.classify_disk(41)["ok"] is True
+
+    def test_filling_up_is_raised_before_it_is_urgent(self):
+        """The point of a warning is that there is still time to act on it."""
+        out = P.classify_disk(85)
+        assert out["ok"] is False
+        assert out["recorded"] is True
+
+    def test_nearly_full_says_what_actually_breaks(self):
+        """"Disk 94%" means nothing to a clerk. "The database stops accepting
+        new reports" is the same fact in terms they can escalate."""
+        out = P.classify_disk(94)
+        assert out["ok"] is False
+        assert "stops accepting new reports" in out["detail"]
+
+    def test_the_boundary_counts_as_over_it(self):
+        assert P.classify_disk(P.DISK_WARN_PERCENT)["ok"] is False
+        assert P.classify_disk(P.DISK_WARN_PERCENT - 0.1)["ok"] is True
+
+    def test_an_unreadable_disk_is_not_reported_as_a_full_one(self):
+        """Not every host exposes this. A failure we cannot substantiate must
+        not be written to health, or it becomes a badge that never clears."""
+        out = P.classify_disk(None)
+        assert out["ok"] is False
+        assert out["recorded"] is False
+
+    def test_the_thresholds_leave_room_to_act(self):
+        assert P.DISK_WARN_PERCENT < P.DISK_CRITICAL_PERCENT < 100
+
+
+class TestBackups:
+    def test_a_recent_backup_is_fine(self):
+        assert P.classify_backup(NOW - timedelta(hours=6), NOW)["ok"] is True
+
+    def test_never_backed_up_says_so_plainly(self):
+        out = P.classify_backup(None, NOW)
+        assert out["ok"] is False
+        assert "restored" in out["detail"]
+
+    def test_one_missed_night_is_a_blip(self):
+        assert P.classify_backup(NOW - timedelta(hours=30), NOW)["ok"] is True
+
+    def test_two_is_a_pattern(self):
+        out = P.classify_backup(NOW - timedelta(days=3), NOW)
+        assert out["ok"] is False
+        assert "3 days ago" in out["detail"]
+
+    def test_a_naive_timestamp_does_not_explode(self):
+        naive = (NOW - timedelta(hours=2)).replace(tzinfo=None)
+        assert P.classify_backup(naive, NOW)["ok"] is True
+
+
+class TestNaming:
+    def test_every_probe_has_a_human_name(self):
+        for connector in P.LABELS:
+            assert P.is_system(connector)
+            assert P.label_for(connector) != connector
+
+    def test_an_unknown_probe_still_gets_a_readable_name(self):
+        assert P.label_for("system:queue_depth") == "Queue depth"
+
+    def test_a_connector_is_not_mistaken_for_a_probe(self):
+        for connector in ("ai", "maps", "email", "sms"):
+            assert not P.is_system(connector)

--- a/backend/tests/test_system_probes.py
+++ b/backend/tests/test_system_probes.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
 
 from app.services import system_probes as P
 

--- a/backend/tests/test_system_probes.py
+++ b/backend/tests/test_system_probes.py
@@ -75,3 +75,39 @@ class TestNaming:
     def test_a_connector_is_not_mistaken_for_a_probe(self):
         for connector in ("ai", "maps", "email", "sms"):
             assert not P.is_system(connector)
+
+
+class TestFailuresDoNotLeakCredentials:
+    """A failing connection must not publish its own connection string.
+
+    `last_error` is stored in the database, rendered on the provider card and
+    included in the alert email. The drivers that raise these errors put the
+    DSN in the message -- psycopg quotes it, and a Redis URL carries its
+    password inline -- so passing the exception text through would turn a
+    database outage into a credential disclosure with a wide audience and a
+    long tail.
+    """
+
+    def test_the_connection_string_never_reaches_the_summary(self):
+        secret = "postgresql://pinpoint:hunter2@db.internal:5432/pinpoint311"
+        exc = OSError(f'could not connect to server: "{secret}"')
+        summary = P.failure_summary(exc)
+        assert "hunter2" not in summary
+        assert "db.internal" not in summary
+        assert secret not in summary
+
+    def test_a_redis_password_does_not_survive_either(self):
+        exc = ConnectionError("Error connecting to redis://:s3cr3t@cache:6379/0")
+        assert "s3cr3t" not in P.failure_summary(exc)
+
+    def test_it_still_says_something_an_administrator_can_act_on(self):
+        """Redacting to nothing would be its own failure: an alert saying only
+        "it broke" cannot be triaged."""
+        summary = P.failure_summary(TimeoutError("..."))
+        assert "TimeoutError" in summary
+        assert "server log" in summary
+
+    def test_the_probe_uses_it(self):
+        out = P.classify_reachable("The database", False, P.failure_summary(OSError("dsn=secret")))
+        assert "secret" not in out["detail"]
+        assert out["ok"] is False

--- a/backend/tests/test_system_settings_singleton.py
+++ b/backend/tests/test_system_settings_singleton.py
@@ -1,0 +1,108 @@
+"""The settings row a save writes must be the row the next read returns.
+
+Regression test for a reported bug -- "the state I choose for the retention
+policy isn't persisting" -- whose cause was not in the retention code at all.
+"""
+
+from app.services.system_settings import merge_into_canonical, pick_canonical
+
+
+class Row:
+    def __init__(self, id, **kw):
+        self.id = id
+        for k, v in kw.items():
+            setattr(self, k, v)
+    def __repr__(self):
+        return f"Row({self.id})"
+
+
+COLUMNS = ("retention_state_code", "retention_mode", "retention_days_override", "public_origin")
+
+
+def row(id, **kw):
+    base = {c: None for c in COLUMNS}
+    base.update(kw)
+    return Row(id, **base)
+
+
+def test_the_same_row_comes_back_whatever_order_the_database_offers():
+    """The bug in one line. An unordered LIMIT 1 lets PostgreSQL return
+    whichever row is cheapest, and UPDATE moves a row in the heap -- so the
+    read after a write could legitimately return a different row."""
+    rows = [row(1), row(2), row(3)]
+    assert pick_canonical(rows).id == 1
+    assert pick_canonical(list(reversed(rows))).id == 1
+    assert pick_canonical([rows[1], rows[2], rows[0]]).id == 1
+
+
+def test_no_rows_is_not_an_error():
+    assert pick_canonical([]) is None
+
+
+def test_the_oldest_row_wins_not_the_newest():
+    """The first row is the one the deployment has been reading its whole life,
+    so it holds what the town configured. A duplicate created later by a racing
+    request holds defaults, and preferring it would swap real configuration for
+    an empty row."""
+    configured = row(1, retention_state_code="NJ", retention_mode="delete")
+    empty = row(2)
+    assert pick_canonical([empty, configured]) is configured
+
+
+def test_merging_keeps_every_value_somebody_typed():
+    """Deleting duplicates without folding them in would discard configuration
+    that is, from the town's point of view, simply saved."""
+    canonical = row(1, retention_state_code="NJ")
+    stray = row(2, retention_mode="delete", public_origin="https://town.gov")
+    winner, spare = merge_into_canonical([canonical, stray], COLUMNS)
+    assert winner is canonical
+    assert winner.retention_state_code == "NJ"
+    assert winner.retention_mode == "delete"
+    assert winner.public_origin == "https://town.gov"
+    assert [r.id for r in spare] == [2]
+
+
+def test_merging_never_overwrites_an_answer_that_is_already_there():
+    canonical = row(1, retention_mode="anonymize")
+    stray = row(2, retention_mode="delete")
+    winner, _ = merge_into_canonical([canonical, stray], COLUMNS)
+    assert winner.retention_mode == "anonymize"
+
+
+def test_the_earlier_duplicate_wins_a_tie():
+    canonical = row(1)
+    second = row(2, retention_mode="delete")
+    third = row(3, retention_mode="anonymize")
+    winner, spare = merge_into_canonical([third, canonical, second], COLUMNS)
+    assert winner.retention_mode == "delete"
+    assert sorted(r.id for r in spare) == [2, 3]
+
+
+def test_a_single_row_merges_to_itself_with_nothing_spare():
+    only = row(1, retention_state_code="NY")
+    winner, spare = merge_into_canonical([only], COLUMNS)
+    assert winner is only and spare == []
+
+
+def test_every_read_of_the_settings_row_is_ordered():
+    """The module-level guarantee. A new `select(SystemSettings).limit(1)`
+    anywhere reintroduces the bug, so the accessor has to be the only way in.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "app"
+    offenders = []
+    for path in root.rglob("*.py"):
+        if path.name == "system_settings.py":
+            continue
+        text = path.read_text()
+        for m in re.finditer(r"select\(SystemSettings\)([^\n]*)", text):
+            tail = m.group(1)
+            if "order_by" not in tail:
+                line = text[: m.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(root)}:{line}")
+    assert not offenders, (
+        "unordered reads of the settings singleton -- these can return a "
+        "different row than the one just written:\n  " + "\n  ".join(offenders)
+    )

--- a/backend/tests/test_uptime_is_honest.py
+++ b/backend/tests/test_uptime_is_honest.py
@@ -93,3 +93,42 @@ class TestExpectedSamples:
     def test_a_nonsense_interval_does_not_divide_by_zero(self):
         assert U.expected_samples(24, timedelta(0)) == 0
         assert U.summarise(total=5, healthy=5, hours=24, interval=timedelta(0))["coverage_percent"] == 0.0
+
+
+class TestWhatIsSampled:
+    """The five-minute sampler and the connector sweep must not overlap.
+
+    They did: the sampler named Auth0, Vertex AI and Google Translate, so an
+    Azure town accumulated a month of history for three services it does not
+    use. Widening the list is the wrong fix -- the connector sweep is daily
+    *because* each external check costs a call to a town's own paid account,
+    and eight of them every five minutes is about 2,300 calls a day.
+    """
+
+    def _lists(self):
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / "app"
+        out = {}
+        for name in ("main.py", "api/health.py"):
+            text = (root / name).read_text()
+            m = re.search(r"services_to_check = \[(.*?)\]", text, re.S)
+            out[name] = set(re.findall(r'\("([a-z_]+)",', m.group(1))) if m else set()
+        return out
+
+    def test_no_external_vendor_is_sampled_every_five_minutes(self):
+        expensive = {"auth0", "vertex_ai", "translation_api", "kms", "secret_store"}
+        for name, sampled in self._lists().items():
+            assert not (sampled & expensive), (
+                f"{name} samples paid external APIs every five minutes: {sampled & expensive}"
+            )
+
+    def test_the_manual_button_records_the_same_series_as_the_sampler(self):
+        """When they differed, pressing "Check now" wrote series the sampler
+        never maintained, which then aged out of the graph on their own."""
+        lists = self._lists()
+        assert lists["main.py"] == lists["api/health.py"], lists
+
+    def test_something_is_still_sampled(self):
+        assert self._lists()["main.py"], "the uptime series has nothing in it"

--- a/backend/tests/test_uptime_is_honest.py
+++ b/backend/tests/test_uptime_is_honest.py
@@ -1,0 +1,95 @@
+"""An in-process sampler cannot see its own outage, so it must say so.
+
+The failure mode is specific and quiet: the sampler runs inside the backend, so
+a backend outage produces *no rows* rather than rows saying "down". Dividing
+healthy samples by total samples then returns a higher number the worse the
+outage was, and 100% over a day the service spent mostly dead is a figure
+somebody will put in front of a council.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from app.services import uptime as U
+
+
+class TestTheOutageItCannotSee:
+    def test_a_full_day_of_samples_is_trustworthy(self):
+        s = U.summarise(total=288, healthy=288, hours=24)
+        assert s["uptime_percent"] == 100.0
+        assert s["reliable"] is True
+        assert s["missed_checks"] == 0
+
+    def test_an_outage_shows_up_as_missing_checks_not_as_downtime(self):
+        """Twelve samples in a day means the server was up for about an hour of
+        it. The naive figure for that is 100%."""
+        s = U.summarise(total=12, healthy=12, hours=24)
+        assert s["uptime_percent"] == 100.0      # what the old maths returned
+        assert s["reliable"] is False            # and what stops it being quoted
+        assert s["missed_checks"] == 276
+        assert s["coverage_percent"] < 5
+
+    def test_the_sentence_says_the_server_was_probably_down(self):
+        text = U.describe(U.summarise(total=12, healthy=12, hours=24))
+        assert "expected" in text
+        assert "server itself was down" in text
+
+    def test_a_service_that_really_was_down_still_reads_as_down(self):
+        """The caveat must not swallow a genuine failure."""
+        s = U.summarise(total=288, healthy=144, hours=24)
+        assert s["uptime_percent"] == 50.0
+        assert s["reliable"] is True
+
+    def test_nothing_measured_claims_nothing(self):
+        s = U.summarise(total=0, healthy=0, hours=24)
+        assert s["reliable"] is False
+        assert U.describe(s) == "Not measured over this period."
+
+    def test_coverage_cannot_exceed_the_period(self):
+        """Two app replicas each run their own sampler, so the row count can
+        exceed what one sampler would produce. That is not 200% coverage."""
+        s = U.summarise(total=600, healthy=600, hours=24)
+        assert s["coverage_percent"] == 100.0
+
+
+class TestTheStatusMapsThatDisagreed:
+    def test_a_switched_off_service_is_not_downtime(self):
+        """The background sampler counted "disabled" as healthy and the manual
+        "Check now" button did not, so pressing the button on the health page
+        recorded a switched-off service as down and dented its uptime. Looking
+        at the number made the number worse."""
+        assert U.uptime_status("disabled") == "healthy"
+
+    def test_the_other_benign_outcomes_agree_too(self):
+        for status in ("healthy", "configured", "fallback"):
+            assert U.uptime_status(status) == "healthy"
+
+    def test_a_real_failure_is_still_down(self):
+        for status in ("down", "error", "unhealthy", "", "misconfigured"):
+            assert U.uptime_status(status) == "down"
+
+    def test_there_is_only_one_such_map_left(self):
+        """Two lists in two files is how they diverged in the first place."""
+        import re
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / "app"
+        offenders = []
+        for path in root.rglob("*.py"):
+            if path.name == "uptime.py":
+                continue
+            for m in re.finditer(r'in \[\s*"healthy",\s*"configured"', path.read_text()):
+                offenders.append(str(path.relative_to(root)))
+        assert not offenders, f"a second healthy-status list has appeared: {offenders}"
+
+
+class TestExpectedSamples:
+    def test_derived_from_the_interval_rather_than_hardcoded(self):
+        assert U.expected_samples(24, timedelta(minutes=5)) == 288
+        assert U.expected_samples(1, timedelta(minutes=5)) == 12
+        assert U.expected_samples(24, timedelta(minutes=1)) == 1440
+
+    def test_a_nonsense_interval_does_not_divide_by_zero(self):
+        assert U.expected_samples(24, timedelta(0)) == 0
+        assert U.summarise(total=5, healthy=5, hours=24, interval=timedelta(0))["coverage_percent"] == 0.0

--- a/backend/tests/test_uptime_is_honest.py
+++ b/backend/tests/test_uptime_is_honest.py
@@ -9,7 +9,6 @@ somebody will put in front of a council.
 
 from datetime import timedelta
 
-import pytest
 
 from app.services import uptime as U
 
@@ -79,7 +78,7 @@ class TestTheStatusMapsThatDisagreed:
         for path in root.rglob("*.py"):
             if path.name == "uptime.py":
                 continue
-            for m in re.finditer(r'in \[\s*"healthy",\s*"configured"', path.read_text()):
+            if re.search(r'in \[\s*"healthy",\s*"configured"', path.read_text()):
                 offenders.append(str(path.relative_to(root)))
         assert not offenders, f"a second healthy-status list has appeared: {offenders}"
 

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -18,11 +18,19 @@ interface ServiceStatus {
 
 // Resolution tips for common issues
 const RESOLUTION_TIPS: Record<string, { issue: string; steps: string[] }> = {
-    backend: { issue: 'Backend API not responding', steps: ['Click "Restart Backend"', 'Check server logs', 'Verify database'] },
-    frontend: { issue: 'Frontend not reachable', steps: ['Click "Restart Frontend"', 'Check if Vite is running', 'Review build errors'] },
-    db: { issue: 'Database connection failed', steps: ['Check PostgreSQL container', 'Verify disk space', 'Review connection limits'] },
-    redis: { issue: 'Redis cache unavailable', steps: ['Click "Restart Redis"', 'Check Redis logs', 'Verify memory limits'] },
-    caddy: { issue: 'Reverse proxy not routing', steps: ['Click "Restart Caddy"', 'Check Caddyfile', 'Verify SSL certificates'] }
+    /* "Click Restart Backend" is not a step everywhere.
+     *
+     * The button only works where the app can reach Docker Compose and the
+     * project directory, and it says so honestly when it cannot -- but these
+     * instructions told a clerk to click it regardless, so on a managed or
+     * single-container deployment the first suggested remedy is one that
+     * always fails. The host-side command comes first now, because it works
+     * everywhere. */
+    backend: { issue: 'Backend API not responding', steps: ['Restart it on the host: docker compose restart backend', 'Or press Restart below, where this deployment allows it', 'Check the server logs'] },
+    frontend: { issue: 'Frontend not reachable', steps: ['Check FRONTEND_HOST — a wrong address looks the same as a stopped service', 'Restart on the host: docker compose restart frontend', 'Review build errors'] },
+    db: { issue: 'Database connection failed', steps: ['Check PostgreSQL is running', 'Check free disk space', 'Review connection limits'] },
+    redis: { issue: 'Redis cache unavailable', steps: ['Restart on the host: docker compose restart redis', 'Check Redis logs', 'Verify memory limits'] },
+    caddy: { issue: 'Reverse proxy not routing', steps: ['If you reached this page through the proxy, it is routing', 'Check the Caddyfile', 'Verify SSL certificates'] }
 };
 
 export default function OperationsPanel() {

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -403,9 +403,21 @@ export default function OperationsPanel() {
                 )}
 
                 {/* Uptime Timeline (last 48 hours) */}
-                {uptimeHistory && Object.keys(uptimeHistory.services).length > 0 && (
+                {uptimeHistory && Object.keys(uptimeHistory.services).length > 0 && (() => {
+                const maxChecks = Math.max(
+                    0, ...Object.values(uptimeHistory.services).map(c => c.length),
+                );
+                return (
                     <div className="space-y-3">
-                        <p className="text-gray-400 text-xs">Last 48 hours (newest → oldest)</p>
+                        {/* It said "Last 48 hours" and rendered the last 48
+                            *records*. At one sample every five minutes that is
+                            four hours of history under a label promising two
+                            days -- and after an outage the bars either side of
+                            the gap sit adjacent, so a hole in the record looks
+                            like continuous service. */}
+                        <p className="text-gray-400 text-xs">
+                            Most recent {Math.min(48, maxChecks)} checks (newest → oldest)
+                        </p>
                         {/* Not the backend's own uptime, and it cannot be:
                             the sampler runs inside the backend. Saying which
                             it is beats a number a council report will read as
@@ -431,7 +443,8 @@ export default function OperationsPanel() {
                             </div>
                         ))}
                     </div>
-                )}
+                );
+                })()}
             </Card>
 
             {/* The "Cloud Integrations" block that was here has gone.

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -368,11 +368,27 @@ export default function OperationsPanel() {
                                     {(['24h', '7d', '30d'] as const).map(period => {
                                         const stats = periods[period];
                                         const pct = stats?.uptime_percent ?? 0;
-                                        const color = pct >= 99 ? 'text-green-400' : pct >= 95 ? 'text-yellow-400' : 'text-red-400';
+                                        /* A figure we did not watch enough of
+                                           the period to stand behind is shown
+                                           greyed with a dash, not in green.
+                                           100% across 12 of an expected 288
+                                           checks means the server spent the day
+                                           down -- printing that in green is the
+                                           worst thing this panel could do. */
+                                        const trustworthy = stats?.reliable !== false && (stats?.checks ?? 0) > 0;
+                                        const color = !trustworthy ? 'text-white/45'
+                                            : pct >= 99 ? 'text-green-400' : pct >= 95 ? 'text-yellow-400' : 'text-red-400';
                                         return (
-                                            <div key={period} className="text-center">
-                                                <p className={`text-lg font-bold ${color}`}>{pct.toFixed(1)}%</p>
+                                            <div key={period} className="text-center" title={stats?.summary}>
+                                                <p className={`text-lg font-bold ${color}`}>
+                                                    {trustworthy ? `${pct.toFixed(1)}%` : '—'}
+                                                </p>
                                                 <p className="text-gray-500 text-xs">{period}</p>
+                                                {!trustworthy && (stats?.checks ?? 0) > 0 && (
+                                                    <p className="text-amber-300/80 text-[10px] leading-tight mt-0.5">
+                                                        only {stats?.checks} of {stats?.expected_checks} checks
+                                                    </p>
+                                                )}
                                             </div>
                                         );
                                     })}
@@ -390,6 +406,14 @@ export default function OperationsPanel() {
                 {uptimeHistory && Object.keys(uptimeHistory.services).length > 0 && (
                     <div className="space-y-3">
                         <p className="text-gray-400 text-xs">Last 48 hours (newest → oldest)</p>
+                        {/* Not the backend's own uptime, and it cannot be:
+                            the sampler runs inside the backend. Saying which
+                            it is beats a number a council report will read as
+                            the other one. */}
+                        <p className="text-white/45 text-[11px] -mt-2">
+                            Whether each dependency answered, sampled every five minutes while this
+                            server was running. Gaps are periods nothing was recorded.
+                        </p>
                         {Object.entries(uptimeHistory.services).map(([serviceName, checks]) => (
                             <div key={serviceName} className="flex items-center gap-2">
                                 <span className="text-white text-sm w-28 truncate capitalize">{serviceName.replace(/_/g, ' ')}</span>

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
     Server, Database, RefreshCw, Play, Trash2, HardDrive, Clock,
     CheckCircle, XCircle, Loader2, RotateCcw, Wrench,
-    Shield, Cloud, Languages, Sparkles, Key, Activity, Link2, AlertTriangle
+    Cloud, Activity, AlertTriangle
 } from 'lucide-react';
 import { Card, Button } from './ui';
 import api, { HealthDashboard, RunbookResult, ProactiveHealth } from '../services/api';
@@ -15,39 +15,6 @@ interface ServiceStatus {
     error?: string;
 }
 
-interface IntegrationCheck {
-    status: string;
-    message: string;
-    [key: string]: any;
-}
-
-/** Key management and secret storage are both pluggable, so neither panel can
- *  carry a vendor name in its heading. Both used to say "Google". */
-const KMS_LABELS: Record<string, string> = {
-    google: 'Google Cloud KMS',
-    azure: 'Azure Key Vault',
-    aws: 'AWS KMS',
-};
-
-const STORE_LABELS: Record<string, string> = {
-    google: 'Google Secret Manager',
-    azure: 'Azure Key Vault',
-    aws: 'AWS Secrets Manager',
-};
-
-interface IntegrationHealth {
-    overall_status: string;
-    checks: {
-        database: IntegrationCheck;
-        auth0: IntegrationCheck;
-        gcp_auth?: IntegrationCheck;
-        kms: IntegrationCheck;
-        secret_store: IntegrationCheck;
-        vertex_ai: IntegrationCheck;
-        translation_api: IntegrationCheck;
-    };
-    timestamp: string;
-}
 
 // Resolution tips for common issues
 const RESOLUTION_TIPS: Record<string, { issue: string; steps: string[] }> = {
@@ -60,7 +27,11 @@ const RESOLUTION_TIPS: Record<string, { issue: string; steps: string[] }> = {
 
 export default function OperationsPanel() {
     const [health, setHealth] = useState<HealthDashboard | null>(null);
-    const [integrations, setIntegrations] = useState<IntegrationHealth | null>(null);
+    /* Derived from the same endpoint the provider cards read, rather than
+     * from a hardcoded list of vendors this deployment may not even use. */
+    const [connectorRollup, setConnectorRollup] = useState<
+        { working: number; failing: number; unchecked: number; names: string[] } | null
+    >(null);
     const [uptimeStats, setUptimeStats] = useState<import('../services/api').UptimeStats | null>(null);
     const [uptimeHistory, setUptimeHistory] = useState<import('../services/api').UptimeHistory | null>(null);
     const [proactive, setProactive] = useState<ProactiveHealth | null>(null);
@@ -78,22 +49,33 @@ export default function OperationsPanel() {
             // Every source is fetched independently and tolerant of failure, so a
             // single failing probe (e.g. infra introspection in a managed env)
             // degrades that section instead of blanking the whole panel.
-            const [healthData, integrationsData, statsData, historyData, proactiveData] = await Promise.all([
+            const [healthData, connectorData, statsData, historyData, proactiveData] = await Promise.all([
                 api.getHealthDashboard().catch(() => null),
-                fetch('/api/health/', {
-                    headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
-                }).then(r => r.ok ? r.json() : null).catch(() => null),
+                api.getConnectorHealth().catch(() => null),
                 api.getUptimeStats().catch(() => null),
                 api.getUptimeHistory(48).catch(() => null),
                 api.getProactiveHealth().catch(() => null),
             ]);
             setHealth(healthData);
-            setIntegrations(integrationsData);
+            if (connectorData) {
+                /* The infrastructure probes ride in the same table so they
+                 * inherit the alerting and the mute, but they belong to the
+                 * panel above rather than to this roll-up. */
+                const external = connectorData.connectors.filter(c => !c.connector.startsWith('system:'));
+                setConnectorRollup({
+                    working: external.filter(c => c.status === 'working').length,
+                    failing: external.filter(c => c.status === 'failing' || c.status === 'down').length,
+                    unchecked: external.filter(c => c.status === 'unknown' || c.status === 'stale').length,
+                    names: external
+                        .filter(c => c.status === 'failing' || c.status === 'down')
+                        .map(c => c.connector),
+                });
+            }
             setUptimeStats(statsData);
             setUptimeHistory(historyData);
             setProactive(proactiveData);
             // Only show the hard error state if literally nothing loaded.
-            if (!healthData && !integrationsData && !statsData && !historyData && !proactiveData) {
+            if (!healthData && !connectorData && !statsData && !historyData && !proactiveData) {
                 setError('Failed to fetch system status');
             }
         } catch (err: any) {
@@ -179,11 +161,18 @@ export default function OperationsPanel() {
             .map(([name]) => name)
         : [];
 
-    // Count healthy integrations
-    const integrationCounts = integrations ? {
-        healthy: Object.values(integrations.checks).filter(c => c.status === 'healthy' || c.status === 'configured').length,
-        total: Object.keys(integrations.checks).length
-    } : { healthy: 0, total: 6 };
+    /* Counted from what this deployment actually runs.
+     *
+     * The old version counted a fixed six -- Auth0, GCP auth, Vertex, KMS,
+     * secret store, database -- so an Azure town read "2/6 Configured" while
+     * being fully set up on services this tile had never heard of. The
+     * denominator was a guess about somebody else's architecture. */
+    const integrationCounts = connectorRollup
+        ? {
+            healthy: connectorRollup.working,
+            total: connectorRollup.working + connectorRollup.failing + connectorRollup.unchecked,
+        }
+        : { healthy: 0, total: 0 };
 
     if (error) {
         return (
@@ -421,105 +410,46 @@ export default function OperationsPanel() {
                 )}
             </Card>
 
-            {/* Cloud Integrations */}
-            {integrations && (
+            {/* The "Cloud Integrations" block that was here has gone.
+                It was a hardcoded struct -- auth0, gcp_auth, vertex_ai,
+                translation_api -- so a town on Azure with Entra sign-in was
+                shown checks for four services it does not use, and none for
+                the four it does. It also duplicated the provider cards, which
+                read the real catalog and the real health table.
+
+                Replaced by a roll-up of the same data those cards use. This
+                page keeps what only it can answer: the machine this runs on. */}
+            {connectorRollup && (
                 <Card>
-                    <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+                    <h3 className="text-lg font-semibold text-white mb-1 flex items-center gap-2">
                         <Cloud className="w-5 h-5 text-purple-400" />
-                        Cloud Integrations
+                        Service providers
                     </h3>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                        {/* Auth0 */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Key className="w-5 h-5 text-orange-400" />
-                                <span className="text-white font-medium">Auth0 SSO</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.auth0.status)}`}>
-                                    {integrations.checks.auth0.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.auth0.message}</p>
-                        </div>
-
-                        {/* GCP Authentication */}
-                        {integrations.checks.gcp_auth && (
-                            <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                                <div className="flex items-center gap-3 mb-2">
-                                    <Link2 className="w-5 h-5 text-emerald-400" />
-                                    <span className="text-white font-medium">GCP Auth</span>
-                                    <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.gcp_auth.status)}`}>
-                                        {integrations.checks.gcp_auth.status}
-                                    </span>
-                                </div>
-                                <p className="text-gray-300 text-xs">{integrations.checks.gcp_auth.message}</p>
-                            </div>
+                    <p className="text-white/55 text-xs mb-4">
+                        Checked automatically once a day. Set up and changed under Setup &amp; Integration.
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2.5">
+                        {connectorRollup.working > 0 && (
+                            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-emerald-300 border-emerald-500/30">
+                                <CheckCircle className="w-3.5 h-3.5" /> {connectorRollup.working} working
+                            </span>
                         )}
-
-                        {/* Key management — named for whichever manager is in
-                            use, not for Google. */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Shield className="w-5 h-5 text-blue-400" />
-                                <span className="text-white font-medium">
-                                    {KMS_LABELS[integrations.checks.kms.kms_backend ?? ''] ?? 'Key Management'}
-                                </span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.kms.status)}`}>
-                                    {integrations.checks.kms.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.kms.message}</p>
-                        </div>
-
-                        {/* Secret store */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Key className="w-5 h-5 text-green-400" />
-                                <span className="text-white font-medium">
-                                    {STORE_LABELS[integrations.checks.secret_store.store ?? ''] ?? 'Secret Store'}
-                                </span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.secret_store.status)}`}>
-                                    {integrations.checks.secret_store.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.secret_store.message}</p>
-                        </div>
-
-                        {/* Vertex AI */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Sparkles className="w-5 h-5 text-purple-400" />
-                                <span className="text-white font-medium">Vertex AI</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.vertex_ai.status)}`}>
-                                    {integrations.checks.vertex_ai.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.vertex_ai.message}</p>
-                        </div>
-
-                        {/* Translation API */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Languages className="w-5 h-5 text-cyan-400" />
-                                <span className="text-white font-medium">Translation API</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.translation_api.status)}`}>
-                                    {integrations.checks.translation_api.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.translation_api.message}</p>
-                        </div>
-
-                        {/* Database */}
-                        <div className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-                            <div className="flex items-center gap-3 mb-2">
-                                <Database className="w-5 h-5 text-purple-400" />
-                                <span className="text-white font-medium">PostgreSQL</span>
-                                <span className={`ml-auto px-2 py-0.5 text-xs rounded-full border ${getStatusBadge(integrations.checks.database.status)}`}>
-                                    {integrations.checks.database.status}
-                                </span>
-                            </div>
-                            <p className="text-gray-300 text-xs">{integrations.checks.database.message}</p>
-                        </div>
+                        {connectorRollup.failing > 0 && (
+                            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-gradient-to-r from-red-500/25 to-rose-500/20 text-red-200 border-red-400/35">
+                                <AlertTriangle className="w-3.5 h-3.5" /> {connectorRollup.failing} not working
+                            </span>
+                        )}
+                        {connectorRollup.unchecked > 0 && (
+                            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-white/[0.07] text-white/70 border-white/15">
+                                {connectorRollup.unchecked} not checked yet
+                            </span>
+                        )}
                     </div>
+                    {connectorRollup.names.length > 0 && (
+                        <p className="text-red-200/85 text-xs mt-3">
+                            Not working: {connectorRollup.names.join(', ')}
+                        </p>
+                    )}
                 </Card>
             )}
 

--- a/frontend/src/components/ProviderCredentialSteps.tsx
+++ b/frontend/src/components/ProviderCredentialSteps.tsx
@@ -112,10 +112,16 @@ export default function ProviderCredentialSteps({
                                 </p>
                             )}
                             {st.trouble && (
-                                <p className="mt-1.5 text-xs text-amber-200/75 flex items-start gap-1.5">
+                                <p className="mt-1.5 text-xs text-amber-200/90 flex items-start gap-1.5">
                                     <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
                                     <span>{st.trouble}</span>
                                 </p>
+                            )}
+                            {/* No icon and no colour. A note competing visually
+                                with a warning is what made the warnings stop
+                                registering. */}
+                            {st.note && (
+                                <p className="mt-1.5 text-xs text-white/55 leading-relaxed">{st.note}</p>
                             )}
                             {!!st.fields?.length && (
                                 <div className="mt-2.5 grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
     Sparkles, Languages, KeyRound, CheckCircle, AlertCircle,
-    Check, CircleDashed, ShieldCheck, RefreshCw,
+    Check, CircleDashed, HelpCircle, ShieldCheck, RefreshCw,
     Lock, Map as MapIcon,
     Mail, MessageSquare, Image as ImageIcon,
 } from 'lucide-react';
@@ -117,6 +117,10 @@ export interface CapStatus {
     providerName?: string;
     onDefault?: boolean;
     verified?: boolean | null;
+    /** False when the provider cannot be checked from here at all. Distinct
+     *  from a failed check: there is no test to run and there never will be,
+     *  so reporting it as broken is a badge that can never go green. */
+    verifiable?: boolean;
     /** Whether the in-use provider has its credentials stored. undefined means
      *  the endpoint did not say, which is not the same as no. */
     configured?: boolean;
@@ -132,6 +136,7 @@ export interface CapStatus {
 export function capabilityState(s: CapStatus | undefined, health?: ConnectorHealth): CapabilityState | null {
     if (!s) return null;                      // catalog still loading
     if (!s.configured) return 'unset';
+    if (s.verifiable === false) return 'unverifiable';
     // A test run in this session is fresher than the stored health row.
     if (s.verified === true) return 'working';
     if (s.verified === false) return 'failing';
@@ -257,7 +262,13 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
         try {
             const t = await api.testProvider(cap);
             setResult(t);
-            onStatus(cap, { verified: t.ok });
+            // `recorded === false` is the provider saying "there is nothing to
+            // test here", not "the test failed". Passing t.ok straight through
+            // is what put a red "Not working" on an HTTP SMS gateway whose own
+            // message said it could not be checked.
+            onStatus(cap, t.recorded === false
+                ? { verifiable: false, verified: null }
+                : { verifiable: true, verified: t.ok });
         } catch (e: any) {
             setResult({ ok: false, detail: e?.message || 'Test failed' });
             onStatus(cap, { verified: false });
@@ -422,7 +433,9 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             // Immediately verify
             const t = await api.testProvider(cap);
             setResult(t);
-            onStatus(cap, { verified: t.ok });
+            onStatus(cap, t.recorded === false
+                ? { verifiable: false, verified: null }
+                : { verifiable: true, verified: t.ok });
         } catch (e: any) {
             setError(e?.message || 'Save failed');
         } finally {
@@ -484,14 +497,20 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                                 className={`shrink-0 ${shown === 'working' ? 'text-emerald-300' : 'text-white/30'}`}
                                 aria-hidden="true"
                             >
-                                {shown === 'working' ? <Check className="w-4 h-4" /> : <CircleDashed className="w-4 h-4" />}
+                                {shown === 'working' ? <Check className="w-4 h-4" />
+                                    : shown === 'unverifiable' ? <HelpCircle className="w-4 h-4" />
+                                    : <CircleDashed className="w-4 h-4" />}
                             </span>
                         </div>
                         {/* Nothing about check times on something with no
                             credentials: the tile already says "Not set up", and
                             "Not checked yet" underneath reads as a second,
                             different problem. */}
-                        {configured && <span className="block text-[11px] text-white/45 mt-2.5">{checkedLine}</span>}
+                        {configured && (
+                            <span className="block text-[11px] text-white/45 mt-2.5">
+                                {shown === 'unverifiable' ? 'Set up. There is no way to test this one from here.' : checkedLine}
+                            </span>
+                        )}
                     </button>
                 ) : variant !== 'full' ? (
                     /* ── The spotlight: something is wrong, or the clerk opened it ── */
@@ -896,6 +915,8 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
      * change it. */
     const verifiedCount = (loaded || []).filter(c => statuses[c.key]?.verified === true).length;
     const failedCount = (loaded || []).filter(c => statuses[c.key]?.verified === false).length;
+    // Counted separately, and never as "needs attention": nobody can act on it.
+    const unverifiableCount = (loaded || []).filter(c => statuses[c.key]?.verifiable === false).length;
 
     /* Which card the clerk has opened in the Spotlight layout. Held here rather
      * than in the card, because opening one has to widen its cell. */
@@ -914,6 +935,9 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
      * waits in the bubble grid, where it renders as a skeleton. */
     const spotlit = visible.filter(c => {
         const s = capState(c.key);
+        // 'unverifiable' is excluded on purpose. It never resolves -- a generic
+        // HTTP gateway will never become checkable -- so spotlighting it would
+        // leave a permanent card demanding attention nobody can give it.
         return s === 'failing' || s === 'unchecked';
     });
     const bubbles = visible.filter(c => !spotlit.includes(c));
@@ -940,7 +964,10 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
                         ? `All ${loaded.length} have credentials`
                         : `${loaded.length - configuredCount} of ${loaded.length} still need credentials`}</span>
                     {verifiedCount > 0 && <span className="text-emerald-300/80 inline-flex items-center gap-1"><CheckCircle className="w-3 h-3" />{verifiedCount} verified</span>}
-                    {failedCount > 0 && <span className="text-amber-300/90 inline-flex items-center gap-1"><AlertCircle className="w-3 h-3" />{failedCount} need attention</span>}
+                    {failedCount > 0 && <span className="text-amber-300/90 inline-flex items-center gap-1"><AlertCircle className="w-3 h-3" />{failedCount} not working</span>}
+                    {unverifiableCount > 0 && (
+                        <span className="text-white/55">{unverifiableCount} cannot be tested from here</span>
+                    )}
                 </div>
             )}
 

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -891,6 +891,18 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
 
     const ALWAYS = new Set<Capability>(['identity', 'maps']);
     const visible = CAPS.filter(c => !show || ALWAYS.has(c.key) || show.has(c.key));
+    /* The other half of the answer.
+     *
+     * Hiding what a town did not tick made the page honest about what it has
+     * and silent about what it could have -- so "we cannot do that" became the
+     * standing assumption for anything switched off during a five-minute
+     * questionnaire months earlier. There is no way to discover otherwise
+     * except by going back to a page that does not say it holds the answer.
+     *
+     * Listed, not offered. Turning one on means going through its setup, and a
+     * toggle here that quietly enabled a capability with no credentials behind
+     * it would be a switch that appears to work and does nothing. */
+    const notChosen = show ? CAPS.filter(c => !ALWAYS.has(c.key) && !show.has(c.key)) : [];
 
     /* Order matters, and not only for readability.
      *
@@ -1002,6 +1014,43 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
                     );
                 })}
             </div>
+
+            {notChosen.length > 0 && (
+                <div className="mt-8">
+                    <div className="flex items-center gap-3 mb-4">
+                        <h3 className="text-xs font-bold uppercase tracking-wider text-white/45">Switched off</h3>
+                        <div className="h-px flex-1 bg-white/10" />
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {notChosen.map(c => (
+                            <div
+                                key={c.key}
+                                className="relative px-4 py-4 rounded-3xl bg-gradient-to-br from-white/[0.035] via-white/[0.01] to-indigo-950/30 border border-white/[0.08] backdrop-blur-2xl"
+                            >
+                                <div className="flex items-center gap-3">
+                                    {/* Deliberately the same tile as a live
+                                        capability, at lower contrast. These are
+                                        the same objects, not a different class
+                                        of thing -- one is simply switched off. */}
+                                    <span className="opacity-50">
+                                        <CapabilityTile icon={c.icon} size="sm" />
+                                    </span>
+                                    <div className="min-w-0 flex-1">
+                                        <p className="font-semibold text-white/75 text-sm truncate">{c.title}</p>
+                                        <p className="text-[11px] text-white/50">Not switched on</p>
+                                    </div>
+                                </div>
+                                <p className="text-[11px] text-white/55 mt-2.5 leading-relaxed line-clamp-2">{c.blurb}</p>
+                            </div>
+                        ))}
+                    </div>
+                    <p className="text-[11px] text-white/55 mt-3.5">
+                        These are built and ready — nothing here needs writing. Tick one in the
+                        questions at the top of <strong className="text-white/75">Setup Instructions</strong> and
+                        its steps appear in the guide.
+                    </p>
+                </div>
+            )}
 
             {extras && (
                 <div className="mt-8">

--- a/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Does the page still mount?
+ *
+ * Not a behaviour test. This exists because the "Other settings" block was
+ * edited by index -- a Google Cloud card removed, two hand-written credential
+ * forms replaced with the shared component, a save button deleted -- and both
+ * a clean typecheck and a clean build pass on JSX that throws the moment it
+ * renders. The last time something similar happened, a component declared
+ * during render remounted on every keystroke and discarded typed credentials,
+ * and nothing in CI noticed.
+ */
+
+vi.mock('../services/api', () => {
+    /* Every method resolves. A hand-listed mock would make this test about
+     * whether I guessed the page's API surface correctly, which is not the
+     * question -- the question is whether the JSX renders. Named responses
+     * below are only for the calls whose *shape* the render depends on. */
+    const shapes: Record<string, unknown> = {
+        getConfig: { public_origin: 'https://town.gov' },
+        getProviderStatus: {},
+        getConnectorHealth: { connectors: [] },
+        getCloudIdentity: null,
+        getStorageStatus: { secrets: { store: 'google', count: 0, reachable: true }, pii: {} },
+        getProviderCatalog: {
+            capability: 'ai', current_provider: 'vertex', providers: [], configured: {},
+        },
+        getCloudProfile: {
+            profile: 'google', managed: false, profiles: [],
+            components: { identity: 'auth0' }, maps: { label: 'Google Maps' },
+        },
+    };
+    /* Anything list-shaped defaults to an array rather than an object: a
+     * component doing `(x || []).filter(...)` on `{}` throws, and that would
+     * be the mock failing rather than the page. */
+    const listish = /^(list|get)[A-Za-z]*(s|List|Configs|Layers|Errors|Catalog)$/;
+    const api: any = new Proxy({}, {
+        get: (_t, prop: string) => vi.fn().mockResolvedValue(
+            prop in shapes ? shapes[prop] : listish.test(prop) ? [] : {},
+        ),
+    });
+    return { default: api, api };
+});
+
+let host: HTMLDivElement;
+let root: Root;
+
+const props: any = {
+    secrets: [],
+    onSaveSecret: vi.fn().mockResolvedValue(undefined),
+    onRefresh: vi.fn(),
+    modules: { ai_analysis: false },
+    onUpdateModules: vi.fn().mockResolvedValue(undefined),
+};
+
+async function mount() {
+    const { default: Page } = await import('./SetupIntegrationsPage');
+    await act(async () => { root.render(React.createElement(Page, props)); });
+    return host.textContent || '';
+}
+
+beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+});
+afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllMocks();
+});
+
+describe('the setup page after the Other-settings surgery', () => {
+    it('mounts without throwing', async () => {
+        const text = await mount();
+        expect(text).toContain('Setup Instructions');
+    });
+
+    it('still offers crash reporting and backups', async () => {
+        // Both were rewritten to render shared field definitions. If either
+        // vanished during the edit, this is where it shows up.
+        const text = await mount();
+        expect(text).toContain('Crash reporting');
+        expect(text).toMatch(/Database Backups/i);
+    });
+
+    it('no longer carries a Google Cloud card in Other settings', async () => {
+        // Its fields moved into the guide, under the steps that produce them.
+        const text = await mount();
+        expect(text).not.toContain('GCP Project ID');
+    });
+
+    it('asks for the backup bucket by the shared label', async () => {
+        // Proves the shared array is what rendered, not a surviving hand-written
+        // copy that happens to look similar.
+        const text = await mount();
+        expect(text).toContain('Bucket name');
+    });
+});

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -2,20 +2,22 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-    Key, Shield, CheckCircle, CircleDashed,
+    Key, Shield, CheckCircle, CircleDashed, Activity,
     AlertCircle, ChevronDown, ChevronUp,
-    ExternalLink, AlertTriangle, Database, BookOpen,
+    ExternalLink, Database, BookOpen,
     ListChecks, HardDrive, Bell,
 } from 'lucide-react';
 
-import { Card, Button, Input, Badge, CollapsibleSection } from './ui';
+import { Card, Button, Badge, CollapsibleSection } from './ui';
 import { SystemSecret } from '../types';
 import { api } from '../services/api';
 import type { Capability, ProviderStatusMap } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 import SetupWizard from './SetupWizard';
-import { buildPlan, summarise, nameList } from './setupPlan';
+import { buildPlan, summarise, nameList, BACKUP_SECRETS, SENTRY_SECRETS } from './setupPlan';
+import { PlainSecrets } from './SetupWizard';
+import { CapabilityTile, StatusPill } from './capabilityUI';
 // Registers every provider's setup steps as a side effect, so the guide can
 // render them inline rather than pointing at the cards that do.
 import './setupStepsContent';
@@ -1001,77 +1003,34 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                             </div>
 
 
-                            {/* Sentry Error Tracking - Premium Card */}
-                            <motion.div
-                                initial={{ opacity: 0, y: 20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                transition={{ delay: 0.4 }}
-                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${sentryConfigured
-                                    ? 'bg-gradient-to-br from-rose-500/10 via-red-500/5 to-orange-500/10 border-rose-500/30 shadow-lg shadow-rose-500/10'
-                                    : 'setup-panel border-transparent'
-                                    }`}
-                            >
-                                {sentryConfigured && (
-                                    <div className="absolute inset-0 bg-gradient-to-r from-rose-500/5 via-transparent to-orange-500/5 pointer-events-none" />
-                                )}
-
-                                <div className="relative">
-                                    <div className="flex items-start justify-between mb-4">
-                                        <div className="flex items-center gap-4">
-                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${sentryConfigured
-                                                ? 'bg-gradient-to-br from-rose-400 to-orange-500 shadow-lg shadow-rose-500/30'
-                                                : 'setup-tile'
-                                                }`}>
-                                                <AlertTriangle className="w-7 h-7 text-white" />
-                                            </div>
-                                            <div>
-                                                <h3 className="font-bold text-lg text-white">Sentry</h3>
-                                                <p className="text-white/50 text-sm">Error monitoring</p>
-                                            </div>
-                                        </div>
-                                        {sentryConfigured ? (
-                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-rose-500/20 to-orange-500/20 text-rose-300 border border-rose-500/30 shadow-lg shadow-rose-500/10">
-                                                <CheckCircle className="w-3.5 h-3.5" />
-                                                Active
-                                            </span>
-                                        ) : (
-                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                                Optional
-                                            </span>
-                                        )}
+                            {/* Crash reporting.
+                                One field, and it was written out by hand here
+                                as well as in setupPlan.ts. Both now render the
+                                same SENTRY_SECRETS array through the same
+                                component the guide uses -- two copies of a
+                                credential form is exactly how the guide and
+                                the cards drifted last time. */}
+                            <div className="premium-card p-5">
+                                <div className="flex items-center gap-3.5 mb-3.5">
+                                    <CapabilityTile icon={Activity} size="sm" />
+                                    <div className="min-w-0 flex-1">
+                                        <h3 className="font-semibold text-white">Crash reporting</h3>
+                                        <p className="text-white/55 text-xs">
+                                            Sends crash reports off this server, so they survive a restart.
+                                        </p>
                                     </div>
-
-                                    {!sentryConfigured || secretValues['SENTRY_DSN'] !== undefined ? (
-                                        <div className="flex gap-2">
-                                            <Input
-                                                type="text"
-                                                placeholder="https://xxx@sentry.io/xxx"
-                                                value={secretValues['SENTRY_DSN'] || ''}
-                                                onChange={(e) => setSecretValues(p => ({ ...p, 'SENTRY_DSN': e.target.value }))}
-                                                className="flex-1 text-sm"
-                                            />
-                                            <Button
-                                                size="sm"
-                                                className="bg-gradient-to-r from-rose-500 to-orange-500 hover:from-rose-600 hover:to-orange-600"
-                                                onClick={() => handleSave('SENTRY_DSN')}
-                                                disabled={!secretValues['SENTRY_DSN'] || savingKey === 'SENTRY_DSN'}
-                                            >
-                                                Save
-                                            </Button>
-                                        </div>
-                                    ) : (
-                                        <div className="flex items-center gap-2">
-                                            <div className="flex-1 h-10 rounded-xl bg-rose-500/20 border border-rose-500/30 flex items-center px-4">
-                                                <CheckCircle className="w-4 h-4 text-rose-400 mr-2" />
-                                                <span className="text-rose-200 text-sm">Monitoring active</span>
-                                            </div>
-                                            <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'SENTRY_DSN': '' }))}>
-                                                Change
-                                            </Button>
-                                        </div>
-                                    )}
+                                    <StatusPill state={isConfigured('SENTRY_DSN') ? 'done' : 'unset'} />
                                 </div>
-                            </motion.div>
+                                <PlainSecrets
+                                    fields={SENTRY_SECRETS}
+                                    values={secretValues}
+                                    onChange={(k, v) => setSecretValues(p => ({ ...p, [k]: v }))}
+                                    onSave={async (keys) => { for (const k of keys) await handleSave(k); }}
+                                    saving={savingKey}
+                                    isConfigured={(k) => !!isConfigured(k)}
+                                    onSaved={() => undefined}
+                                />
+                            </div>
 
                             {/* Database Backups - Premium Card (locked in managed mode: the state owns backups) */}
                             {managedMode ? (
@@ -1138,43 +1097,35 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                         See the <strong className="text-amber-300">Setup Instructions</strong> above for provider-specific guidance.
                                     </p>
 
+                                    {/* The five S3 boxes were written by hand
+                                        here and again in setupPlan.ts. Both
+                                        now render BACKUP_SECRETS through the
+                                        same component the guide uses.
+
+                                        The passphrase below is not part of
+                                        that array on purpose: it is generated
+                                        rather than typed, it is shown exactly
+                                        once, and it needs the acknowledgement
+                                        checkbox. Folding it into a generic
+                                        credential form would lose all three,
+                                        and losing it means a town's backups
+                                        cannot be restored. */}
                                     {!backupConfigured || secretValues['BACKUP_S3_BUCKET'] !== undefined ? (
                                         <div className="space-y-3">
-                                            <div>
-                                                <label className="text-sm text-white/60 mb-1.5 block">S3 Bucket Name</label>
-                                                <div className="flex gap-2">
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="my-backup-bucket"
-                                                        value={secretValues['BACKUP_S3_BUCKET'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': e.target.value }))}
-                                                        className="flex-1 text-sm"
-                                                    />
-                                                </div>
-                                            </div>
-
-                                            <div className="grid grid-cols-2 gap-2">
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">Access Key</label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="AKIA..."
-                                                        value={secretValues['BACKUP_S3_ACCESS_KEY'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ACCESS_KEY': e.target.value }))}
-                                                        className="text-sm"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">Secret Key</label>
-                                                    <Input
-                                                        type="password"
-                                                        placeholder="Your S3 secret key"
-                                                        value={secretValues['BACKUP_S3_SECRET_KEY'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_SECRET_KEY': e.target.value }))}
-                                                        className="text-sm"
-                                                    />
-                                                </div>
-                                            </div>
+                                            <PlainSecrets
+                                                fields={BACKUP_SECRETS}
+                                                values={secretValues}
+                                                onChange={(k, v) => setSecretValues(p => ({ ...p, [k]: v }))}
+                                                onSave={async (keys) => { for (const k of keys) await handleSave(k); }}
+                                                saving={savingKey}
+                                                isConfigured={(k) => !!isConfigured(k)}
+                                                onSaved={() => undefined}
+                                                blockedReason={
+                                                    (backupKeyAcknowledged || (!backupKey && isConfigured('BACKUP_ENCRYPTION_KEY')))
+                                                        ? null
+                                                        : 'Create the encryption passphrase below and confirm you have kept a copy first.'
+                                                }
+                                            />
 
                                             <div>
                                                 <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
@@ -1236,51 +1187,6 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                                 )}
                                             </div>
 
-                                            <div className="grid grid-cols-2 gap-2">
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">S3 Endpoint <span className="text-white/30">(optional)</span></label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="https://... (non-AWS only)"
-                                                        value={secretValues['BACKUP_S3_ENDPOINT'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_ENDPOINT': e.target.value }))}
-                                                        className="text-xs"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">Region <span className="text-white/30">(optional)</span></label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="us-ashburn-1"
-                                                        value={secretValues['BACKUP_S3_REGION'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'BACKUP_S3_REGION': e.target.value }))}
-                                                        className="text-xs"
-                                                    />
-                                                </div>
-                                            </div>
-
-                                            <Button
-                                                size="sm"
-                                                className="w-full bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
-                                                onClick={async () => {
-                                                    if (secretValues['BACKUP_S3_BUCKET']) await handleSave('BACKUP_S3_BUCKET');
-                                                    if (secretValues['BACKUP_S3_ACCESS_KEY']) await handleSave('BACKUP_S3_ACCESS_KEY');
-                                                    if (secretValues['BACKUP_S3_SECRET_KEY']) await handleSave('BACKUP_S3_SECRET_KEY');
-                                                    // The passphrase is stored by the endpoint that
-                                                    // generates it, so there is nothing to save here.
-                                                    if (secretValues['BACKUP_S3_ENDPOINT']) await handleSave('BACKUP_S3_ENDPOINT');
-                                                    if (secretValues['BACKUP_S3_REGION']) await handleSave('BACKUP_S3_REGION');
-                                                }}
-                                                disabled={!secretValues['BACKUP_S3_BUCKET']
-                                                    || !(backupKeyAcknowledged || (!backupKey && isConfigured('BACKUP_ENCRYPTION_KEY')))
-                                                    || savingKey !== null}
-                                            >
-                                                {savingKey ? 'Saving...' : 'Save Backup Settings'}
-                                            </Button>
-
-                                            <p className="text-white/40 text-xs">
-                                                Endpoint and Region are optional — only needed for non-AWS providers (Oracle, MinIO, etc.).
-                                            </p>
                                         </div>
                                     ) : (
                                         <div className="space-y-3">

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-    Key, Shield, Cloud, CheckCircle,
+    Key, Shield, CheckCircle, CircleDashed,
     AlertCircle, ChevronDown, ChevronUp,
     ExternalLink, AlertTriangle, Database, BookOpen,
     ListChecks, HardDrive, Bell,
@@ -15,10 +15,12 @@ import type { Capability, ProviderStatusMap } from '../services/api';
 import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 import SetupWizard from './SetupWizard';
+import { buildPlan, summarise, nameList } from './setupPlan';
 // Registers every provider's setup steps as a side effect, so the guide can
 // render them inline rather than pointing at the cards that do.
 import './setupStepsContent';
 import StorageStatusLine from './StorageStatusLine';
+import SecretField from './SecretField';
 import { openStayInformed } from './StayInformed';
 
 
@@ -101,6 +103,151 @@ interface SetupIntegrationsPageProps {
     onRefresh: () => void;
     modules?: ModulesState;
     onUpdateModules?: (modules: ModulesState) => Promise<void>;
+}
+
+
+/* The boxes for the account credentials, directly under the steps that
+ * produce them.
+ *
+ * These used to live in a "Google Cloud" card several thousand pixels down
+ * the page, which made the walk above end on "that file is what you paste
+ * into the boxes below" with no boxes below. A clerk following the guide
+ * downloaded a credential file and hit a dead end -- the same handoff the
+ * rest of this page had already been fixed for, missed because the phrase
+ * was not one the test looked for.
+ *
+ * Google only, and not an oversight. Google needs one account-level
+ * credential shared by AI, KMS, secrets and translation. Azure Key Vault
+ * takes a vault URL and prefers a managed identity with nothing to type,
+ * and AWS needs a region and can use the instance profile -- for both, the
+ * per-service keys live on the capability itself. Inventing an "Azure
+ * account" box to make the three look symmetrical would ask for something
+ * that does not exist.
+ */
+function GoogleAccountFields({
+secretValues, setSecretValues, handleSave, savingKey, isConfigured, modules, onUpdateModules,
+}: {
+secretValues: Record<string, string>;
+setSecretValues: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+handleSave: (key: string) => Promise<void>;
+savingKey: string | null;
+isConfigured: (key: string) => boolean | undefined;
+modules: any;
+onUpdateModules?: (m: any) => Promise<void>;
+}) {
+    const jsonKey = 'GCP_SERVICE_ACCOUNT_JSON';
+    const [showKms, setShowKms] = useState(false);
+    const pending = ['GOOGLE_CLOUD_PROJECT', jsonKey, 'KMS_LOCATION', 'KMS_KEY_RING', 'KMS_KEY_ID']
+        .filter(k => secretValues[k]);
+    return (
+        <div className="ml-9 mt-1 rounded-xl border border-white/10 bg-white/[0.03] p-3.5 space-y-3">
+            <div>
+                <label className="text-[11px] uppercase tracking-wider text-white/55 font-semibold flex items-center gap-1.5">
+                    <Key className="w-3.5 h-3.5 text-amber-300/80" aria-hidden="true" />
+                    The .json file you just downloaded
+                    {isConfigured(jsonKey) && <span className="text-emerald-300/80 normal-case font-medium">· Saved</span>}
+                </label>
+                <label className="mt-1.5 block cursor-pointer">
+                    <div className="h-10 rounded-lg border border-dashed border-white/20 flex items-center justify-center text-white/50 text-xs hover:border-white/40 hover:text-white/70 transition-colors">
+                        Choose the file, or drop it here
+                    </div>
+                    <input
+                        type="file"
+                        accept=".json,application/json"
+                        className="hidden"
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            const reader = new FileReader();
+                            reader.onload = (ev) => setSecretValues(p => ({
+                                ...p, [jsonKey]: (ev.target?.result as string) || '',
+                            }));
+                            reader.readAsText(file);
+                        }}
+                    />
+                </label>
+                {secretValues[jsonKey] && (
+                    <p className="text-[11px] text-emerald-200/80 mt-1.5">
+                        File read. Press Save below to store it.
+                    </p>
+                )}
+                {/* Pasting is still allowed -- some towns get the key by
+                    email from whoever administers the project -- but the
+                    file picker is first, because a downloaded file is what
+                    step 4 actually leaves you holding. */}
+                <textarea
+                    placeholder="…or paste the contents"
+                    value={secretValues[jsonKey] || ''}
+                    onChange={(e) => setSecretValues(p => ({ ...p, [jsonKey]: e.target.value }))}
+                    rows={2}
+                    className="mt-2 w-full text-xs bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-white/30 focus:outline-none focus:border-primary-400/50 resize-none font-mono"
+                />
+            </div>
+
+            <SecretField
+                label="Project ID"
+                value={secretValues['GOOGLE_CLOUD_PROJECT'] || ''}
+                onChange={(v: string) => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': v }))}
+                savedHint={!!isConfigured('GOOGLE_CLOUD_PROJECT')}
+                placeholder="my-town-311-4821"
+                help="The short code from step 1, not the name you typed."
+            />
+
+            {/* Behind a disclosure because the defaults are right for
+                almost everyone, and three boxes that should stay empty
+                read as three more things to get wrong. */}
+            <button
+                type="button"
+                onClick={() => setShowKms(v => !v)}
+                className="text-[11px] text-white/55 hover:text-white/85 underline underline-offset-2"
+            >
+                {showKms ? 'Hide' : 'I was given different'} encryption key names
+            </button>
+            {showKms && (
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
+                    {[
+                        ['KMS_LOCATION', 'Location', 'us-central1'],
+                        ['KMS_KEY_RING', 'Key ring', 'pinpoint311-keyring'],
+                        ['KMS_KEY_ID', 'Key name', 'pii-encryption-key'],
+                    ].map(([key, label, placeholder]) => (
+                        <SecretField
+                            key={key}
+                            label={label}
+                            value={secretValues[key] || ''}
+                            onChange={(v: string) => setSecretValues(p => ({ ...p, [key]: v }))}
+                            savedHint={!!isConfigured(key)}
+                            placeholder={placeholder}
+                            help={`Leave blank for ${placeholder}.`}
+                        />
+                    ))}
+                </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-2.5 pt-1">
+                <button
+                    type="button"
+                    onClick={async () => {
+                        for (const k of pending) await handleSave(k);
+                        // AI cannot run without this, so having entered it
+                        // and left the module off is never what was meant.
+                        if (modules && onUpdateModules && secretValues['GOOGLE_CLOUD_PROJECT'] && !modules.ai_analysis) {
+                            await onUpdateModules({ ...modules, ai_analysis: true });
+                        }
+                    }}
+                    disabled={pending.length === 0 || savingKey !== null}
+                    className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                >
+                    {savingKey ? 'Saving…' : 'Save'}
+                </button>
+                {isConfigured('GOOGLE_CLOUD_PROJECT') && isConfigured(jsonKey) && pending.length === 0 && (
+                    <span className="text-[11px] text-emerald-300/80">
+                        Saved. Leave a box blank to keep what is stored.
+                    </span>
+                )}
+            </div>
+            <StorageStatusLine />
+        </div>
+    );
 }
 
 
@@ -224,6 +371,16 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
      * reading "Not set up", and the only conclusion available to a clerk from
      * that is that the save did not take. */
     const [providerRefresh, setProviderRefresh] = useState(0);
+    /* Health, for the badge on the collapsed panel. Provider status alone can
+     * only say whether a credential is stored, and "stored" is the fact that
+     * stays true through a key being revoked. */
+    const [connectorHealth, setConnectorHealth] = useState<Record<string, string>>({});
+    const loadHealth = useCallback(() => {
+        api.getConnectorHealth()
+            .then(r => setConnectorHealth(Object.fromEntries(r.connectors.map(c => [c.connector, c.status]))))
+            .catch(() => { /* no health is not the same as bad health */ });
+    }, []);
+    useEffect(() => { loadHealth(); }, [loadHealth, providerRefresh]);
     const loadProviderStatus = useCallback(() => {
         api.getProviderStatus()
             .then(setProviderStatus)
@@ -325,6 +482,33 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         errors: !!sentryConfigured,
     };
     const itemDone = (id: string) => DONE_BY_ITEM[id] ?? false;
+
+    /* What the badge on the collapsed header reports.
+     *
+     * Built from buildPlan with the same inputs the wizard is given, so the
+     * count can never say something the list inside it does not. Reproducing
+     * the arithmetic here instead would be a second implementation of "what is
+     * left", and those drift. */
+    const planSummary = summarise(
+        buildPlan({
+            cloud: setupCloud, idp: setupIdp, maps: setupMaps, aiProvider,
+            emailProvider, smsProvider, redactionProvider, wanted: wantedFeatures,
+        }),
+        {
+            isDone: (item) => (item.cap && item.provider)
+                ? providerStatus?.[item.cap]?.configured?.[item.provider] === true
+                : itemDone(item.id),
+            /* Only a real failure counts. `unknown` means nobody has looked and
+             * `stale` means not lately -- neither is evidence of a fault, and
+             * badging them as one produces a number that never reaches zero on
+             * a town whose sweep has not run yet. */
+            stateOf: (item) => {
+                const status = item.cap ? connectorHealth[item.cap] : undefined;
+                return status === 'failing' || status === 'down' ? 'failing' : status;
+            },
+        },
+    );
+    const outstanding = planSummary.notSetUp.length + planSummary.notWorking.length;
 
     // Setup progress calculation. In managed mode the platform-managed steps
     // (Google Cloud, DB Backups) are excluded — the state handles them, so
@@ -429,9 +613,14 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                     Under <strong className="text-white/90">IAM &amp; Admin → Service Accounts</strong>, create one called <code className="bg-black/30 px-1 rounded text-blue-300 text-xs">pinpoint311</code>. This is a login for the software, so nothing is tied to your own account.
                 </InstructionStep>
                 <InstructionStep num={4} check={<>a file ending in <code className="bg-black/30 px-1 rounded">.json</code> in your Downloads.</>}>
-                    Open it, then <strong className="text-white/90">Keys → Add Key → Create new key → JSON</strong>. A file downloads. That file is what you paste into the boxes below.
+                    Open it, then <strong className="text-white/90">Keys → Add Key → Create new key → JSON</strong>. A file downloads — that is the one you add below.
                 </InstructionStep>
-                <Trouble>Google will not let you download that file again. Put a copy somewhere the town controls — a shared drive rather than your own laptop — and do not send it by email.</Trouble>
+                <Trouble>Google will not let you download that file again. Keep a copy somewhere the town controls, not on your own laptop.</Trouble>
+                <GoogleAccountFields
+                    secretValues={secretValues} setSecretValues={setSecretValues}
+                    handleSave={handleSave} savingKey={savingKey} isConfigured={isConfigured}
+                    modules={modules} onUpdateModules={onUpdateModules}
+                />
             </>}
             {cloud === 'azure' && <>
                 <InstructionStep num={1}>
@@ -554,7 +743,47 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                             <p className="text-white/50 text-xs">Answer a few questions, then work through one thing at a time</p>
                         </div>
                     </div>
-                    {expandedGuide === 'master' ? <ChevronUp className="w-5 h-5 text-white/50" /> : <ChevronDown className="w-5 h-5 text-white/50" />}
+                    <div className="flex items-center gap-2.5 shrink-0">
+                        {/* Two pills, never one.
+                            "Not set up" and "not working" need different things
+                            from a clerk -- a credential entered, or a credential
+                            replaced -- and merging them into "4 issues" sends
+                            them to the wrong place. Named where the list is
+                            short enough to name, because "which ones" is the
+                            next question either way. */}
+                        {planSummary.notWorking.length > 0 && (
+                            <span
+                                title={nameList(planSummary.notWorking, 99)}
+                                className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-gradient-to-r from-red-500/25 to-rose-500/20 text-red-200 border-red-400/35 shadow-md shadow-red-950/40"
+                            >
+                                <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                {planSummary.notWorking.length} not working
+                            </span>
+                        )}
+                        {planSummary.notSetUp.length > 0 && (
+                            <span
+                                title={nameList(planSummary.notSetUp, 99)}
+                                className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 border-amber-500/30 shadow-md shadow-amber-950/40"
+                            >
+                                <CircleDashed className="w-3.5 h-3.5" aria-hidden="true" />
+                                {planSummary.notSetUp.length} still to set up
+                            </span>
+                        )}
+                        {/* Only once the server has actually said so. Before
+                            provider status arrives everything looks unfinished,
+                            and a green "all set up" flashed at that moment is
+                            the false completion message all over again. */}
+                        {providerStatus && outstanding === 0 && planSummary.total > 0 && (
+                            <span className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1 rounded-2xl text-xs font-semibold border bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-emerald-300 border-emerald-500/30 shadow-md shadow-emerald-950/40">
+                                <CheckCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                                All set up
+                            </span>
+                        )}
+                        {outstanding > 0 && (
+                            <span className="sm:hidden text-xs font-semibold text-amber-300">{outstanding}</span>
+                        )}
+                        {expandedGuide === 'master' ? <ChevronUp className="w-5 h-5 text-white/50" /> : <ChevronDown className="w-5 h-5 text-white/50" />}
+                    </div>
                 </button>
 
                 <AnimatePresence>
@@ -745,236 +974,16 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                     extras={
                         <>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            {/* Google Cloud - Premium Card (locked in managed mode: the state owns these keys) */}
-                            {managedMode ? (
-                                <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
-                                    <div className="flex items-center gap-4 mb-2">
-                                        <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
-                                            <Cloud className="w-7 h-7 text-white/50" />
-                                        </div>
-                                        <div>
-                                            <h3 className="font-bold text-lg text-white/70">Google Cloud</h3>
-                                            <p className="text-white/40 text-sm">AI, encryption &amp; translation infrastructure</p>
-                                        </div>
-                                        <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
-                                            <Shield className="w-3.5 h-3.5" />
-                                            Managed by your state
-                                        </span>
-                                    </div>
-                                    <p className="text-white/50 text-sm">
-                                        Cloud project, KMS encryption keys, and secrets storage are provisioned and maintained by your state hosting program. Nothing to configure here.
-                                    </p>
-                                </div>
-                            ) : (
-                            <motion.div
-                                initial={{ opacity: 0, y: 20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                transition={{ delay: 0.3 }}
-                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${gcpConfigured
-                                    ? 'bg-gradient-to-br from-blue-500/10 via-cyan-500/5 to-sky-500/10 border-blue-500/30 shadow-lg shadow-blue-500/10'
-                                    : 'setup-panel border-transparent'
-                                    }`}
-                            >
-                                {gcpConfigured && (
-                                    <div className="absolute inset-0 bg-gradient-to-r from-blue-500/5 via-transparent to-cyan-500/5 pointer-events-none" />
-                                )}
+                            {/* The Google Cloud card that used to open this
+                                section has gone. Its instructions and its two
+                                boxes now sit together in the setup guide's
+                                Google task, so the walk that says "download
+                                this file" ends where the file is added rather
+                                than pointing thousands of pixels down the page.
 
-                                <div className="relative">
-                                    <div className="flex items-start justify-between mb-4">
-                                        <div className="flex items-center gap-4">
-                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${gcpConfigured
-                                                ? 'bg-gradient-to-br from-blue-400 to-cyan-500 shadow-lg shadow-blue-500/30'
-                                                : 'setup-tile'
-                                                }`}>
-                                                <Cloud className="w-7 h-7 text-white" />
-                                            </div>
-                                            <div>
-                                                <h3 className="font-bold text-lg text-white">Google Cloud</h3>
-                                                <p className="text-white/50 text-sm">AI, KMS, Secrets, Translation</p>
-                                            </div>
-                                        </div>
-                                        {gcpConfigured ? (
-                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-blue-500/20 to-cyan-500/20 text-blue-300 border border-blue-500/30 shadow-lg shadow-blue-500/10">
-                                                <CheckCircle className="w-3.5 h-3.5" />
-                                                Configured
-                                            </span>
-                                        ) : (
-                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                                Optional
-                                            </span>
-                                        )}
-                                    </div>
-
-                                    <p className="text-white/60 text-sm mb-4">
-                                        Enables AI analysis (Vertex AI), PII encryption (Cloud KMS), multi-language translation, and secure secrets storage.
-                                        See the <strong className="text-blue-300">Setup Instructions</strong> above for a full walkthrough.
-                                    </p>
-
-                                    {/* Manual configuration fields */}
-                                    {!gcpConfigured || secretValues['GOOGLE_CLOUD_PROJECT'] !== undefined ? (
-                                        <div className="space-y-3">
-                                            <div>
-                                                <label className="text-sm text-white/60 mb-1.5 block">GCP Project ID</label>
-                                                <div className="flex gap-2">
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="my-municipality-project"
-                                                        value={secretValues['GOOGLE_CLOUD_PROJECT'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': e.target.value }))}
-                                                        className="flex-1 text-sm"
-                                                    />
-                                                    <Button
-                                                        size="sm"
-                                                        className="bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
-                                                        onClick={() => handleSave('GOOGLE_CLOUD_PROJECT')}
-                                                        disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey === 'GOOGLE_CLOUD_PROJECT'}
-                                                    >
-                                                        {savingKey === 'GOOGLE_CLOUD_PROJECT' ? '...' : 'Save'}
-                                                    </Button>
-                                                </div>
-                                            </div>
-
-                                            <div className="grid grid-cols-3 gap-2">
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">KMS Location</label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="us-central1"
-                                                        value={secretValues['KMS_LOCATION'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_LOCATION': e.target.value }))}
-                                                        className="text-xs"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">KMS Key Ring</label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="pinpoint311-keyring"
-                                                        value={secretValues['KMS_KEY_RING'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_RING': e.target.value }))}
-                                                        className="text-xs"
-                                                    />
-                                                </div>
-                                                <div>
-                                                    <label className="text-xs text-white/50 mb-1 block">KMS Key ID</label>
-                                                    <Input
-                                                        type="text"
-                                                        placeholder="pii-encryption-key"
-                                                        value={secretValues['KMS_KEY_ID'] || ''}
-                                                        onChange={(e) => setSecretValues(p => ({ ...p, 'KMS_KEY_ID': e.target.value }))}
-                                                        className="text-xs"
-                                                    />
-                                                </div>
-                                            </div>
-
-                                            <Button
-                                                size="sm"
-                                                className="w-full bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700"
-                                                onClick={async () => {
-                                                    if (secretValues['GOOGLE_CLOUD_PROJECT']) await handleSave('GOOGLE_CLOUD_PROJECT');
-                                                    if (secretValues['KMS_LOCATION']) await handleSave('KMS_LOCATION');
-                                                    if (secretValues['KMS_KEY_RING']) await handleSave('KMS_KEY_RING');
-                                                    if (secretValues['KMS_KEY_ID']) await handleSave('KMS_KEY_ID');
-
-                                                    // Auto-enable AI module when GCP is configured
-                                                    if (modules && onUpdateModules && secretValues['GOOGLE_CLOUD_PROJECT']) {
-                                                        await onUpdateModules({ ...modules, ai_analysis: true });
-                                                    }
-                                                }}
-                                                disabled={!secretValues['GOOGLE_CLOUD_PROJECT'] || savingKey !== null}
-                                            >
-                                                {savingKey ? 'Saving...' : 'Save GCP Settings'}
-                                            </Button>
-
-                                            <p className="text-white/40 text-xs">
-                                                KMS fields are optional — the platform defaults to <code className="bg-black/20 px-1 rounded">us-central1</code> / <code className="bg-black/20 px-1 rounded">pinpoint311-keyring</code> / <code className="bg-black/20 px-1 rounded">pii-encryption-key</code> if left blank. These must match your KMS key ring and key names exactly, or PII encryption silently falls back to local (Fernet) encryption.
-                                            </p>
-
-                                            {/* Divider */}
-                                            <div className="border-t border-white/10 my-4" />
-
-                                            {/* GCP Service Account JSON */}
-                                            <div>
-                                                <label className="text-sm text-white/60 mb-1.5 block flex items-center gap-2">
-                                                    <Key className="w-4 h-4 text-amber-400" />
-                                                    GCP Service Account JSON
-                                                    {isConfigured('GCP_SERVICE_ACCOUNT_JSON') && <CheckCircle className="w-3.5 h-3.5 text-green-400" />}
-                                                </label>
-                                                <textarea
-                                                    placeholder='{"type": "service_account", "project_id": "...", ...}'
-                                                    value={secretValues['GCP_SERVICE_ACCOUNT_JSON'] || ''}
-                                                    onChange={(e) => setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': e.target.value }))}
-                                                    rows={4}
-                                                    className="w-full text-sm bg-white/5 border border-white/10 rounded-xl px-3 py-2 text-white placeholder-white/30 focus:outline-none focus:border-blue-500/50 resize-none font-mono"
-                                                />
-                                                <div className="flex gap-2 mt-2">
-                                                    <label className="flex-1 cursor-pointer">
-                                                        <div className="h-9 rounded-lg border border-dashed border-white/20 flex items-center justify-center text-white/40 text-xs hover:border-white/40 transition-colors">
-                                                            📁 Or drop / select a .json key file
-                                                        </div>
-                                                        <input
-                                                            type="file"
-                                                            accept=".json"
-                                                            className="hidden"
-                                                            onChange={(e) => {
-                                                                const file = e.target.files?.[0];
-                                                                if (file) {
-                                                                    const reader = new FileReader();
-                                                                    reader.onload = (ev) => {
-                                                                        setSecretValues(p => ({ ...p, 'GCP_SERVICE_ACCOUNT_JSON': ev.target?.result as string || '' }));
-                                                                    };
-                                                                    reader.readAsText(file);
-                                                                }
-                                                            }}
-                                                        />
-                                                    </label>
-                                                    <Button
-                                                        size="sm"
-                                                        className="bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700"
-                                                        onClick={() => handleSave('GCP_SERVICE_ACCOUNT_JSON')}
-                                                        disabled={!secretValues['GCP_SERVICE_ACCOUNT_JSON'] || savingKey === 'GCP_SERVICE_ACCOUNT_JSON'}
-                                                    >
-                                                        {savingKey === 'GCP_SERVICE_ACCOUNT_JSON' ? 'Saving...' : 'Save Key'}
-                                                    </Button>
-                                                </div>
-                                                <p className="text-white/30 text-xs mt-1">Required for Vertex AI analysis, multi-language translation, and secure secrets storage</p>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <div className="space-y-3">
-                                            <div className="flex items-center gap-2">
-                                                <div className="flex-1 h-10 rounded-xl bg-blue-500/20 border border-blue-500/30 flex items-center px-4">
-                                                    <CheckCircle className="w-4 h-4 text-blue-400 mr-2" />
-                                                    <span className="text-blue-200 text-sm">GCP configured and ready</span>
-                                                </div>
-                                                <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'GOOGLE_CLOUD_PROJECT': '' }))}>
-                                                    Change
-                                                </Button>
-                                            </div>
-
-                                            {/* Module sync indicator */}
-                                            {modules && (
-                                                <div className={`flex items-center gap-2 text-xs ${modules.ai_analysis ? 'text-blue-400' : 'text-white/40'}`}>
-                                                    {modules.ai_analysis ? (
-                                                        <>
-                                                            <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
-                                                            AI Analysis module enabled
-                                                        </>
-                                                    ) : (
-                                                        <>
-                                                            <div className="w-2 h-2 rounded-full bg-white/30" />
-                                                            AI Analysis module disabled
-                                                        </>
-                                                    )}
-                                                </div>
-                                            )}
-
-                                        </div>
-                                    )}
-                                </div>
-                            </motion.div>
-                            )}
-
+                                Nothing replaces it for Azure or AWS, and that
+                                is correct: neither has an account-level
+                                credential to enter. */}
                             {/* Where the stored data actually lives.
                               *
                               * This used to be two buttons -- "Vault Local Secrets to GCP

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -384,8 +384,9 @@ function TaskItem({
  * is not an instruction a clerk can act on: it reads as something to hand to
  * IT, and it was the only place on this page asking anyone to edit a file.
  */
-function PlainSecrets({
+export function PlainSecrets({
     fields, values, onChange, onSave, saving, isConfigured, onSaved, className = '',
+    blockedReason,
 }: {
     fields: { key: string; label: string; secret?: boolean; help?: string }[];
     values: Record<string, string>;
@@ -395,6 +396,14 @@ function PlainSecrets({
     isConfigured: (key: string) => boolean;
     onSaved: () => void;
     className?: string;
+    /** Why saving is not allowed yet, if it is not.
+     *
+     * Added for one caller and it earns its place there: backup settings must
+     * not be savable until somebody has confirmed they kept a copy of the
+     * encryption passphrase. Without that, a town ends up with nightly backups
+     * encrypted by a passphrase nobody wrote down -- which is not a backup, and
+     * is discovered at restore time. */
+    blockedReason?: string | null;
 }) {
     const pending = fields.filter(f => values[f.key]).map(f => f.key);
     const allStored = fields.every(f => isConfigured(f.key));
@@ -418,12 +427,19 @@ function PlainSecrets({
                 <button
                     type="button"
                     onClick={async () => { await onSave(pending); onSaved(); }}
-                    disabled={pending.length === 0 || saving !== null}
+                    disabled={pending.length === 0 || saving !== null || !!blockedReason}
+                    title={blockedReason || undefined}
                     className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
                 >
                     {saving ? 'Saving…' : 'Save'}
                 </button>
-                {allStored && (
+                {blockedReason && (
+                    <span className="text-[11px] text-amber-200/90 inline-flex items-center gap-1.5">
+                        <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                        {blockedReason}
+                    </span>
+                )}
+                {!blockedReason && allStored && (
                     <span className="text-[11px] text-emerald-300/80 inline-flex items-center gap-1.5">
                         <Check className="w-3.5 h-3.5" aria-hidden="true" />
                         Saved. Leave a box blank to keep what is stored.

--- a/frontend/src/components/capabilityState.test.ts
+++ b/frontend/src/components/capabilityState.test.ts
@@ -48,6 +48,28 @@ describe('capabilityState', () => {
         expect(capabilityState({ configured: true }, health('working'))).toBe('working');
     });
 
+    it('says "cannot be tested" rather than "not working" when there is no test', () => {
+        // A generic HTTP SMS gateway cannot be exercised without sending a real
+        // text message, so the backend returns ok:false with recorded:false.
+        // Passing that straight through as a failure put a red "Not working"
+        // pill on a connector whose own message said it could not be checked --
+        // a badge that can never go green, which is the thing this whole page
+        // is built around not doing.
+        expect(capabilityState({ configured: true, verifiable: false }, health('unknown')))
+            .toBe('unverifiable');
+    });
+
+    it('does not let a stale health row override "cannot be tested"', () => {
+        expect(capabilityState({ configured: true, verifiable: false }, health('down')))
+            .toBe('unverifiable');
+    });
+
+    it('still reports "not set up" over "cannot be tested"', () => {
+        // No credentials is the more actionable of the two, and the only one
+        // the clerk can do something about.
+        expect(capabilityState({ configured: false, verifiable: false }, undefined)).toBe('unset');
+    });
+
     it('prefers a test run in this session over the stored health row', () => {
         // Pressing "Test now" and watching the card stay green because the
         // nightly sweep last succeeded is the whole reason that button exists.

--- a/frontend/src/components/capabilityUI.tsx
+++ b/frontend/src/components/capabilityUI.tsx
@@ -153,63 +153,13 @@ export function Action({
     );
 }
 
-/**
- * A capability as one expandable row inside a panel.
+/* CapabilityRow was here.
  *
- * Used by the setup guide for its steps and by the standing cards for editing,
- * so the thing a clerk clicks behaves identically in both. The header stays
- * visible while open -- collapsing an item to find out what it was is a small
- * indignity that adds up over eight of them.
- */
-export function CapabilityRow({
-    icon, badge, title, subtitle, status, meta, actions,
-    expanded, onToggle, tone = 'normal', children,
-}: {
-    icon: React.ElementType;
-    badge?: ReactNode;
-    title: string;
-    subtitle?: ReactNode;
-    status?: ReactNode;
-    meta?: ReactNode;
-    actions?: ReactNode;
-    expanded: boolean;
-    onToggle: () => void;
-    tone?: 'normal' | 'alert';
-    children?: ReactNode;
-}) {
-    return (
-        <div className={`rounded-2xl border transition-all duration-200 ${tone === 'alert'
-            ? 'bg-red-500/[0.09] border-red-400/25 hover:border-red-400/40'
-            : expanded
-                ? 'bg-white/[0.06] border-white/18'
-                : 'bg-white/[0.045] border-white/10 hover:bg-white/[0.075] hover:border-white/20'}`}>
-            <div className="flex items-center gap-3.5 px-4 py-3 flex-wrap">
-                <button
-                    type="button"
-                    onClick={onToggle}
-                    aria-expanded={expanded}
-                    className="flex items-center gap-3.5 min-w-0 flex-1 text-left rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
-                >
-                    <CapabilityTile icon={icon} badge={badge} tone={tone} />
-                    <span className="min-w-0 flex-1">
-                        <span className="block font-semibold text-white text-sm truncate">{title}</span>
-                        {subtitle && <span className="block text-[11px] text-white/55 truncate mt-0.5">{subtitle}</span>}
-                    </span>
-                    {status}
-                    {meta && <span className="text-[11px] text-white/45 truncate hidden lg:block">{meta}</span>}
-                </button>
-                {actions}
-                <button
-                    type="button"
-                    onClick={onToggle}
-                    aria-hidden="true"
-                    tabIndex={-1}
-                    className="text-white/35 hover:text-white/70 transition-colors shrink-0"
-                >
-                    <ChevronDown className={`w-4 h-4 transition-transform ${expanded ? 'rotate-180' : ''}`} />
-                </button>
-            </div>
-            {expanded && <div className="px-4 pb-4 pt-0.5">{children}</div>}
-        </div>
-    );
-}
+ * Written to reshape the setup guide's task rows onto the same component the
+ * cards use, then left unused when the two surfaces were deliberately given
+ * different layouts -- one is a walk through setup, the other is "is anything
+ * wrong". Dead code that looks like a shared abstraction is worse than none:
+ * the next person to touch this reasonably assumes both surfaces render it.
+ *
+ * What they actually share is below and above -- the tile, the pill and the
+ * buttons -- which is the part that has to stay identical. */

--- a/frontend/src/components/capabilityUI.tsx
+++ b/frontend/src/components/capabilityUI.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Check, AlertCircle, CircleDashed, ChevronDown, Loader2 } from 'lucide-react';
+import { Check, AlertCircle, CircleDashed, HelpCircle, ChevronDown, Loader2 } from 'lucide-react';
 
 /**
  * The shared vocabulary for a capability, wherever it appears.
@@ -19,12 +19,13 @@ import { Check, AlertCircle, CircleDashed, ChevronDown, Loader2 } from 'lucide-r
  */
 
 export type CapabilityState =
-    | 'working'    // a live check succeeded recently
-    | 'failing'    // a live check failed, and we have the provider's words
-    | 'unchecked'  // configured, but nothing has exercised it
-    | 'unset'      // deliberately not set up
-    | 'done'       // setup finished (the guide's version of working)
-    | 'todo';      // setup outstanding
+    | 'working'      // a live check succeeded recently
+    | 'failing'      // a live check failed, and we have the provider's words
+    | 'unchecked'    // configured, but nothing has exercised it
+    | 'unverifiable' // configured, and there is no way to check it from here
+    | 'unset'        // deliberately not set up
+    | 'done'         // setup finished (the guide's version of working)
+    | 'todo';        // setup outstanding
 
 /* Deliberately not merging `unchecked` into `failing` or `working`. A connector
  * nobody has exercised is not healthy and it is not broken; collapsing it into
@@ -45,6 +46,17 @@ const PILL: Record<CapabilityState, { cls: string; label: string; Icon: typeof C
     unchecked: {
         cls: 'bg-white/[0.07] text-white/70 border-white/15',
         label: 'Not checked yet', Icon: CircleDashed,
+    },
+    /* Not amber, and not grouped with the failures.
+     *
+     * A generic HTTP gateway cannot be exercised without sending a real text
+     * message, so there is no check to run and there never will be. Reporting
+     * that as "Not working" -- which is what happened -- is a red badge that
+     * can never go green, and the whole page has been built around not doing
+     * that. It is also not "not checked yet", which implies somebody could. */
+    unverifiable: {
+        cls: 'bg-white/[0.07] text-white/70 border-white/15',
+        label: 'Set up · we cannot test this one', Icon: HelpCircle,
     },
     unset: {
         cls: 'bg-white/[0.05] text-white/55 border-white/12',

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -269,3 +269,66 @@ export function buildPlan(input: PlanInput): PlanTask[] {
 export function nextIncomplete(tasks: PlanTask[], done: (t: PlanTask) => boolean): PlanTask | undefined {
     return tasks.find(t => !done(t));
 }
+
+
+/**
+ * What is still outstanding, split by *why*.
+ *
+ * The collapsed "Setup Instructions" panel gave no sign that anything the town
+ * had ticked was unfinished, so a half-configured deployment looked identical
+ * to a finished one until somebody opened it.
+ *
+ * The split is the point. "Not set up" and "not working" are different
+ * problems with different fixes -- one needs a credential entered, the other
+ * needs a credential replaced -- and a single "3 issues" badge that merges them
+ * sends a clerk to the wrong place. There is a third case that is neither:
+ * something configured that cannot be checked from here at all, which is not
+ * outstanding work and is deliberately not counted.
+ *
+ * Pure, and fed the same tasks the wizard renders, so the badge cannot claim
+ * something different from the list underneath it.
+ */
+export interface PlanSummary {
+    notSetUp: PlanItem[];
+    notWorking: PlanItem[];
+    total: number;
+}
+
+export function summarise(
+    tasks: PlanTask[],
+    opts: {
+        /** Whether this item's credentials are stored. */
+        isDone: (item: PlanItem) => boolean;
+        /** 'failing' when a live check failed. Anything else is not a fault:
+         *  unknown means nobody has looked, and unverifiable means nobody can. */
+        stateOf?: (item: PlanItem) => string | null | undefined;
+    },
+): PlanSummary {
+    const notSetUp: PlanItem[] = [];
+    const notWorking: PlanItem[] = [];
+    const seen = new Set<string>();
+    for (const task of tasks) {
+        for (const item of task.items) {
+            // Grouping by vendor can list the same capability under one task
+            // only, but guard anyway -- a double count is a badge that says 4
+            // above a list of 3.
+            if (seen.has(item.id)) continue;
+            seen.add(item.id);
+            if (!opts.isDone(item)) {
+                notSetUp.push(item);
+            } else if (opts.stateOf?.(item) === 'failing') {
+                notWorking.push(item);
+            }
+        }
+    }
+    return { notSetUp, notWorking, total: seen.size };
+}
+
+/** "Maps", "Maps and AI triage", "Maps, AI triage and 2 more". */
+export function nameList(items: PlanItem[], max = 2): string {
+    const titles = items.map(i => i.title);
+    if (titles.length === 0) return '';
+    if (titles.length === 1) return titles[0];
+    if (titles.length <= max) return `${titles.slice(0, -1).join(', ')} and ${titles[titles.length - 1]}`;
+    return `${titles.slice(0, max).join(', ')} and ${titles.length - max} more`;
+}

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -119,6 +119,27 @@ const VENDOR_ORDER: Vendor[] = [
     'local', 'storage', 'sentry',
 ];
 
+/**
+ * The two settings that belong to no provider, defined once.
+ *
+ * They were written twice: here, for the guide, and again by hand in the
+ * "Other settings" block on the same page. Two copies of a credential form is
+ * how the guide and the cards drifted last time -- one said Okta's issuer was
+ * the org URL and the other said the opposite -- so these are exported and
+ * both surfaces render the same array.
+ */
+export const BACKUP_SECRETS = [
+    { key: 'BACKUP_S3_BUCKET', label: 'Bucket name' },
+    { key: 'BACKUP_S3_ENDPOINT', label: 'Endpoint URL', help: 'Leave blank for AWS S3. Set it for Oracle, MinIO, Backblaze and the rest.' },
+    { key: 'BACKUP_S3_REGION', label: 'Region' },
+    { key: 'BACKUP_S3_ACCESS_KEY', label: 'Access key ID', secret: true },
+    { key: 'BACKUP_S3_SECRET_KEY', label: 'Secret access key', secret: true },
+];
+
+export const SENTRY_SECRETS = [
+    { key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true, help: 'Project Settings → Client Keys (DSN).' },
+];
+
 export function buildPlan(input: PlanInput): PlanTask[] {
     const { cloud, idp, maps, wanted } = input;
     const want = (f: string) => wanted.has(f);
@@ -216,23 +237,16 @@ export function buildPlan(input: PlanInput): PlanTask[] {
             id: 'backups',
             title: 'Automatic backups',
             blurb: 'A nightly copy of everything, kept somewhere other than this server.',
-            secrets: [
-                { key: 'BACKUP_S3_BUCKET', label: 'Bucket name' },
-                { key: 'BACKUP_S3_ENDPOINT', label: 'Endpoint URL', help: 'Leave blank for AWS S3. Set it for Oracle, MinIO, Backblaze and the rest.' },
-                { key: 'BACKUP_S3_REGION', label: 'Region' },
-                { key: 'BACKUP_S3_ACCESS_KEY', label: 'Access key ID', secret: true },
-                { key: 'BACKUP_S3_SECRET_KEY', label: 'Secret access key', secret: true },
-            ],
+            secrets: BACKUP_SECRETS,
         });
     }
-
 
     if (want('errors')) {
         add('sentry', {
             id: 'errors',
             title: 'Crash reporting',
             blurb: 'Sends crash reports somewhere off this server, so they survive a restart.',
-            secrets: [{ key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true, help: 'Project Settings → Client Keys (DSN).' }],
+            secrets: SENTRY_SECRETS,
         });
     }
 

--- a/frontend/src/components/setupSteps.tsx
+++ b/frontend/src/components/setupSteps.tsx
@@ -39,7 +39,21 @@ export interface SetupStep {
     /** Secret keys this step produces, rendered as inputs directly beneath it. */
     fields?: string[];
     /** A caveat worth reading before the next step, not after it goes wrong. */
+    /** A warning, in amber, with an icon.
+     *
+     * Reserved for a failure that is *silent* -- one where you would otherwise
+     * think it had worked -- or *irreversible*, where there is no second
+     * chance. Everything else belongs in `note`.
+     *
+     * The distinction is the whole point. There was a warning on every other
+     * step and on all three steps of the Google Maps walk, and a page where
+     * everything is flagged flags nothing: the billing warning, which is the
+     * one that silently produces a grey map, sat in identical amber beside
+     * "changes can take five minutes". */
     trouble?: ReactNode;
+    /** A quiet aside. True, worth knowing, and not a warning: timing, a tip,
+     *  an alternative. Grey, no icon, no urgency. */
+    note?: ReactNode;
 }
 
 /** Everything a step-writer needs that depends on the deployment. */

--- a/frontend/src/components/setupStepsContent.tsx
+++ b/frontend/src/components/setupStepsContent.tsx
@@ -116,7 +116,7 @@ defineSteps('identity', 'auth0', (ctx) => [
                 Then press <B>Save Changes</B> at the bottom.
             </>
         ),
-        trouble: <>Do this before the next step. A tenant missing the callback URL accepts the password and then fails on the redirect, which looks like a wrong secret.</>,
+        note: <>Do this before the next step. A tenant missing the callback URL accepts the password and then fails on the redirect, which looks like a wrong secret.</>,
     },
     {
         body: <>Copy the three values from that same Settings page into these boxes.</>,
@@ -154,7 +154,7 @@ defineSteps('identity', 'entra', (ctx) => [
                 another tenant. Press <B>Register</B>.
             </>
         ),
-        trouble: <>The redirect type matters. "Single-page application" is offered right below Web and looks equivalent; it is not, and staff sign-in will fail on the way back with an error about the flow.</>,
+        note: <>The redirect type matters. "Single-page application" is offered right below Web and looks equivalent; it is not, and staff sign-in will fail on the way back with an error about the flow.</>,
     },
     {
         body: (
@@ -251,7 +251,7 @@ defineSteps('identity', 'okta', (ctx) => [
             </>
         ),
         fields: ['OKTA_ISSUER'],
-        trouble: <>You can check the value before saving: paste <C>{'<issuer>'}/.well-known/openid-configuration</C> into a browser. A page of JSON means it is right; a 404 or an error means it is not. That takes ten seconds and saves diagnosing a login loop.</>,
+        note: <>You can check the value before saving: paste <C>{'<issuer>'}/.well-known/openid-configuration</C> into a browser. A page of JSON means it is right; a 404 or an error means it is not. That takes ten seconds and saves diagnosing a login loop.</>,
     },
 ]);
 
@@ -274,7 +274,7 @@ defineSteps('identity', 'oidc', (ctx) => [
                 accounts by email address, so a provider that does not release it cannot be used.
             </>
         ),
-        trouble: <>If they offer a "public client", that is the wrong kind: it issues no secret. Say confidential, or server-side.</>,
+        note: <>If they offer a "public client", that is the wrong kind: it issues no secret. Say confidential, or server-side.</>,
     },
     {
         body: (
@@ -332,7 +332,7 @@ defineSteps('maps', 'google', (ctx) => [
     {
         body: <>Paste the key here. The Map ID is optional and only changes how the map looks — leave it empty.</>,
         fields: ['GOOGLE_MAPS_API_KEY', 'GOOGLE_MAPS_MAP_ID'],
-        trouble: <>Changes to a Google key can take up to five minutes. If the map is still grey straight after saving, wait before changing anything else.</>,
+        note: <>Changes to a Google key can take up to five minutes. If the map is still grey straight after saving, wait before changing anything else.</>,
     },
 ]);
 
@@ -364,7 +364,7 @@ defineSteps('maps', 'esri', () => [
             </>
         ),
         check: <>a key string starting <C>AAPK</C>. (<C>AAPT</C> is Esri's prefix for short-lived access tokens — if that is what you have, it is not the right credential.)</>,
-        trouble: <>Write the expiry date somewhere the town will see it. Keys expire at 00:00:00 GMT on the date you set, and when one lapses the map goes blank with no warning and nothing in the console saying why.</>,
+        note: <>Write the expiry date somewhere the town will see it. Keys expire at 00:00:00 GMT on the date you set, and when one lapses the map goes blank with no warning and nothing in the console saying why.</>,
     },
     {
         body: (
@@ -376,7 +376,7 @@ defineSteps('maps', 'esri', () => [
             </>
         ),
         fields: ['ARCGIS_API_KEY', 'ARCGIS_BASEMAP_ID', 'ARCGIS_LOCATOR_URL'],
-        trouble: <>A town locator is worth asking for. It knows your street names, your address ranges and your recent subdivisions, which a national geocoder often does not.</>,
+        note: <>A town locator is worth asking for. It knows your street names, your address ranges and your recent subdivisions, which a national geocoder often does not.</>,
     },
 ]);
 
@@ -403,7 +403,7 @@ defineSteps('maps', 'azure', () => [
             </>
         ),
         fields: ['AZURE_MAPS_KEY'],
-        trouble: <>Take the primary key and leave the secondary alone. The pair exists so a key can be rotated without downtime — using both at once removes the point of having two.</>,
+        note: <>Take the primary key and leave the secondary alone. The pair exists so a key can be rotated without downtime — using both at once removes the point of having two.</>,
     },
 ]);
 
@@ -455,7 +455,7 @@ defineSteps('maps', 'apple', () => [
             </>
         ),
         fields: ['APPLE_MAPKIT_TEAM_ID', 'APPLE_MAPKIT_KEY_ID', 'APPLE_MAPKIT_PRIVATE_KEY'],
-        trouble: <>Open it with a text editor, not Word — a word processor will add formatting that makes the key unreadable. The header and footer lines are part of the key, not decoration.</>,
+        note: <>Open it with a text editor, not Word — a word processor will add formatting that makes the key unreadable. The header and footer lines are part of the key, not decoration.</>,
     },
 ]);
 
@@ -482,7 +482,7 @@ defineSteps('ai', 'vertex', () => [
                 or Editor: this account only ever needs to ask the model a question.
             </>
         ),
-        trouble: <>The broad roles are one click away and it is tempting to take them to avoid a permissions problem later. A leaked key with Vertex AI User can run up a model bill; the same key with Editor can delete the project.</>,
+        note: <>The broad roles are one click away and it is tempting to take them to avoid a permissions problem later. A leaked key with Vertex AI User can run up a model bill; the same key with Editor can delete the project.</>,
     },
     {
         body: (
@@ -506,7 +506,7 @@ defineSteps('ai', 'azure', () => [
                 every Azure subscription is eligible for the standard models.
             </>
         ),
-        trouble: <>Older write-ups describe a registration form and a wait of a day or two. Microsoft removed that for general access; a form is now only required for specific restricted features, none of which Pinpoint uses. If someone tells you to apply and wait, they are working from stale instructions.</>,
+        note: <>Older write-ups describe a registration form and a wait of a day or two. Microsoft removed that for general access; a form is now only required for specific restricted features, none of which Pinpoint uses. If someone tells you to apply and wait, they are working from stale instructions.</>,
     },
     {
         body: (
@@ -528,7 +528,7 @@ defineSteps('ai', 'azure', () => [
             </>
         ),
         fields: ['AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_API_KEY', 'AZURE_OPENAI_DEPLOYMENT', 'AZURE_OPENAI_API_VERSION'],
-        trouble: <>The endpoint is the base address ending in a slash, not the full chat-completions URL from the sample code.</>,
+        note: <>The endpoint is the base address ending in a slash, not the full chat-completions URL from the sample code.</>,
     },
 ]);
 
@@ -551,7 +551,7 @@ defineSteps('ai', 'bedrock', () => [
             </>
         ),
         check: <>the model showing <B>Access granted</B> rather than Available to request.</>,
-        trouble: <>If submitting fails, the account may not have AWS Marketplace subscription permission — that lives under <B>Billing → Marketplace settings</B> and usually needs whoever owns the AWS account.</>,
+        note: <>If submitting fails, the account may not have AWS Marketplace subscription permission — that lives under <B>Billing → Marketplace settings</B> and usually needs whoever owns the AWS account.</>,
     },
     {
         body: (
@@ -590,7 +590,7 @@ defineSteps('translation', 'google', () => [
             </>
         ),
         fields: ['GOOGLE_CLOUD_PROJECT'],
-        trouble: <>The project <B>ID</B>, not the display name. They are often similar and occasionally identical; the ID is the one shown in the project picker in smaller grey type.</>,
+        note: <>The project <B>ID</B>, not the display name. They are often similar and occasionally identical; the ID is the one shown in the project picker in smaller grey type.</>,
     },
 ]);
 
@@ -614,7 +614,7 @@ defineSteps('translation', 'azure', () => [
             </>
         ),
         fields: ['AZURE_TRANSLATOR_KEY', 'AZURE_TRANSLATOR_REGION', 'AZURE_TRANSLATOR_ENDPOINT'],
-        trouble: <>The region must be the short form shown on that page, like <C>eastus</C>, not "East US". A mismatched region fails authentication and reports it as a bad key.</>,
+        note: <>The region must be the short form shown on that page, like <C>eastus</C>, not "East US". A mismatched region fails authentication and reports it as a bad key.</>,
     },
 ]);
 
@@ -627,7 +627,7 @@ defineSteps('translation', 'aws', () => [
                 name is what permits translating text.
             </>
         ),
-        trouble: <>If you already made an IAM user for Bedrock or SES, add this policy to that one rather than creating another set of keys to keep track of.</>,
+        note: <>If you already made an IAM user for Bedrock or SES, add this policy to that one rather than creating another set of keys to keep track of.</>,
     },
     {
         body: <>Take an access key from that user's <B>Security credentials</B> tab and enter it with your region.</>,
@@ -648,7 +648,7 @@ defineSteps('email', 'smtp', () => [
                 status update, the replies land wherever this sends from.
             </>
         ),
-        trouble: <>Microsoft 365 and Google Workspace both restrict plain SMTP by default — on Microsoft it is switched off unless an administrator turns it back on. Worse, Microsoft is removing password-based SMTP from Exchange Online at the end of December 2026: existing tenants have it disabled by default from then, and tenants created afterwards cannot use it at all. If your town is on Microsoft 365, choosing SMTP today buys you a few months. Amazon SES or Azure Communication Services is the durable answer.</>,
+        note: <>Microsoft 365 and Google Workspace both restrict plain SMTP by default — on Microsoft it is switched off unless an administrator turns it back on. Worse, Microsoft is removing password-based SMTP from Exchange Online at the end of December 2026: existing tenants have it disabled by default from then, and tenants created afterwards cannot use it at all. If your town is on Microsoft 365, choosing SMTP today buys you a few months. Amazon SES or Azure Communication Services is the durable answer.</>,
     },
     {
         body: (
@@ -702,7 +702,7 @@ defineSteps('email', 'ses', () => [
             </>
         ),
         fields: ['AWS_REGION', 'SES_FROM_EMAIL', 'SMTP_FROM_NAME', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
-        trouble: <>The region must be the one where you verified the domain. SES identities do not exist across regions, and a mismatch reports as an unverified sender.</>,
+        note: <>The region must be the one where you verified the domain. SES identities do not exist across regions, and a mismatch reports as an unverified sender.</>,
     },
 ]);
 
@@ -715,7 +715,7 @@ defineSteps('email', 'acs', () => [
                 and they must be in the <B>same geography</B> — you cannot connect them otherwise.
             </>
         ),
-        trouble: <>Two resources with near-identical names is genuinely confusing. The Email one owns the domain; the plain Communication Services one owns the endpoint and key.</>,
+        note: <>Two resources with near-identical names is genuinely confusing. The Email one owns the domain; the plain Communication Services one owns the endpoint and key.</>,
     },
     {
         body: (
@@ -764,7 +764,7 @@ defineSteps('sms', 'twilio', () => [
     {
         body: <>Buy or select a number under <B>Phone Numbers → Manage → Active numbers</B>, and enter it in <C>+1XXXXXXXXXX</C> form.</>,
         fields: ['TWILIO_PHONE_NUMBER'],
-        trouble: <>It has to be a number you own in Twilio. A trial account can only text numbers you have verified.</>,
+        note: <>It has to be a number you own in Twilio. A trial account can only text numbers you have verified.</>,
     },
 ]);
 
@@ -788,7 +788,7 @@ defineSteps('sms', 'sns', () => [
                 unregistered traffic heavily.
             </>
         ),
-        trouble: <>Start the 10DLC registration early. It is a carrier process rather than an AWS one, and it is not immediate.</>,
+        note: <>Start the 10DLC registration early. It is a carrier process rather than an AWS one, and it is not immediate.</>,
     },
     {
         body: (
@@ -813,7 +813,7 @@ defineSteps('sms', 'acs', () => [
                 can come back to.
             </>
         ),
-        trouble: <>You also need a paid Azure subscription. Phone numbers cannot be acquired on a trial or with free credits, and availability depends on your subscription's billing country.</>,
+        note: <>You also need a paid Azure subscription. Phone numbers cannot be acquired on a trial or with free credits, and availability depends on your subscription's billing country.</>,
     },
     {
         body: (
@@ -854,7 +854,7 @@ defineSteps('sms', 'http', () => [
             </>
         ),
         fields: ['SMS_HTTP_API_URL', 'SMS_HTTP_API_KEY'],
-        trouble: <>If their API expects a different shape or a different header, this will fail on every send. Check with them before relying on it, and send yourself a test message from the button below.</>,
+        note: <>If their API expects a different shape or a different header, this will fail on every send. Check with them before relying on it, and send yourself a test message from the button below.</>,
     },
 ]);
 
@@ -989,7 +989,7 @@ defineSteps('kms', 'azure', () => [
             </>
         ),
         check: <>Soft delete: Enabled, Purge protection: Enabled, and a Delete lock on the vault.</>,
-        trouble: <>Also check that everyday staff accounts do not hold Delete or Purge on keys.</>,
+        note: <>Also check that everyday staff accounts do not hold Delete or Purge on keys.</>,
     },
     {
         body: <>{ACCOUNT_SURVIVES}</>,
@@ -1087,7 +1087,7 @@ defineSteps('redaction', 'google', () => [
             </>
         ),
         check: <>"API Enabled" on the Cloud Vision API page.</>,
-        trouble: <>{UNCONFIGURED_DETECTOR}</>,
+        note: <>{UNCONFIGURED_DETECTOR}</>,
     },
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);
@@ -1103,7 +1103,7 @@ defineSteps('redaction', 'aws', () => [
             </>
         ),
         check: <>both actions listed on the IAM user's policy.</>,
-        trouble: <>{UNCONFIGURED_DETECTOR}</>,
+        note: <>{UNCONFIGURED_DETECTOR}</>,
     },
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);
@@ -1124,7 +1124,7 @@ defineSteps('redaction', 'azure', () => [
                 want plates, you can skip the face resource entirely.
             </>
         ),
-        trouble: <>If your town cannot get through that review, pick a different detector. Google and Amazon have no equivalent gate, and the on-server option has none at all.</>,
+        note: <>If your town cannot get through that review, pick a different detector. Google and Amazon have no equivalent gate, and the on-server option has none at all.</>,
     },
     {
         body: (
@@ -1146,7 +1146,7 @@ defineSteps('redaction', 'azure', () => [
             </>
         ),
         fields: ['AZURE_VISION_ENDPOINT', 'AZURE_VISION_KEY'],
-        trouble: <>A multi-service Azure AI resource covers the vision half, but not Face — that one is always its own resource.</>,
+        note: <>A multi-service Azure AI resource covers the vision half, but not Face — that one is always its own resource.</>,
     },
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'] },
 ]);
@@ -1160,7 +1160,7 @@ defineSteps('redaction', 'local', () => [
                 building, which is the real reason to keep it.
             </>
         ),
-        trouble: <>It is the default because the alternative was worse. A deployment with no cloud credentials used to blur nothing at all while the page displayed Google Cloud Vision as the provider. Imperfect blurring beats none; that is the whole argument, and it is worth knowing which one you are relying on.</>,
+        note: <>It is the default because the alternative was worse. A deployment with no cloud credentials used to blur nothing at all while the page displayed Google Cloud Vision as the provider. Imperfect blurring beats none; that is the whole argument, and it is worth knowing which one you are relying on.</>,
     },
     {
         body: (
@@ -1172,7 +1172,7 @@ defineSteps('redaction', 'local', () => [
                 problem, one of them is worth the setup.
             </>
         ),
-        trouble: <>The safest arrangement for a town with no cloud account is to keep this on <em>and</em> have a person look at photos before they are published, rather than treating either one as sufficient on its own.</>,
+        note: <>The safest arrangement for a town with no cloud account is to keep this on <em>and</em> have a person look at photos before they are published, rather than treating either one as sufficient on its own.</>,
     },
     { body: REDACTION_CHOICE, fields: ['REDACT_FACES', 'REDACT_PLATES'], trouble: VERIFY_WITH_A_PHOTO },
 ]);

--- a/frontend/src/components/setupSummary.test.ts
+++ b/frontend/src/components/setupSummary.test.ts
@@ -72,3 +72,39 @@ describe('nameList', () => {
         expect(nameList(items('Maps', 'AI', 'Email', 'Text'))).toBe('Maps, AI and 2 more'));
     it('says nothing about nothing', () => expect(nameList([])).toBe(''));
 });
+
+describe('one definition of the settings that belong to no provider', () => {
+    it('the guide and the cards render the same backup fields', async () => {
+        // They were written twice -- once here, once by hand in the "Other
+        // settings" block on the same page. Two copies of a credential form is
+        // how the guide and the cards drifted last time: one told towns Okta's
+        // issuer was their org URL and the other said the opposite.
+        const { BACKUP_SECRETS, SENTRY_SECRETS } = await import('./setupPlan');
+        const plan = buildPlan({
+            cloud: 'google', idp: 'auth0', maps: 'google', aiProvider: 'vertex',
+            emailProvider: 'smtp', smsProvider: 'twilio', redactionProvider: 'google',
+            wanted: new Set(['backups', 'errors']),
+        });
+        const backups = plan.flatMap(t => t.items).find(i => i.id === 'backups');
+        const errors = plan.flatMap(t => t.items).find(i => i.id === 'errors');
+        expect(backups?.secrets).toBe(BACKUP_SECRETS);
+        expect(errors?.secrets).toBe(SENTRY_SECRETS);
+    });
+
+    it('the backup fields still cover a non-AWS bucket', async () => {
+        // Endpoint and region are what make this work with Oracle, MinIO and
+        // Backblaze. Dropping them during the de-duplication would quietly
+        // restrict every town to Amazon.
+        const { BACKUP_SECRETS } = await import('./setupPlan');
+        const keys = BACKUP_SECRETS.map(f => f.key);
+        expect(keys).toContain('BACKUP_S3_ENDPOINT');
+        expect(keys).toContain('BACKUP_S3_REGION');
+        expect(keys).toContain('BACKUP_S3_BUCKET');
+    });
+
+    it('keeps the secret fields marked secret', async () => {
+        const { BACKUP_SECRETS } = await import('./setupPlan');
+        const secret = BACKUP_SECRETS.filter(f => f.secret).map(f => f.key);
+        expect(secret).toEqual(['BACKUP_S3_ACCESS_KEY', 'BACKUP_S3_SECRET_KEY']);
+    });
+});

--- a/frontend/src/components/setupSummary.test.ts
+++ b/frontend/src/components/setupSummary.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildPlan, summarise, nameList, type PlanItem } from './setupPlan';
+
+/**
+ * The badge on the collapsed panel has one job: be true.
+ *
+ * A count that disagrees with the list underneath it is worse than no count,
+ * and the two most tempting merges are both wrong. "Not set up" and "not
+ * working" need different actions from a clerk. And something that cannot be
+ * checked from here is neither -- counting it produces a badge that can never
+ * reach zero.
+ */
+const plan = () => buildPlan({
+    cloud: 'azure', idp: 'entra', maps: 'google', aiProvider: 'azure',
+    emailProvider: 'acs', smsProvider: 'acs', redactionProvider: 'azure',
+    wanted: new Set(['ai', 'translation', 'sms', 'backups', 'errors', 'safety']),
+});
+
+const byId = (id: string) => (i: PlanItem) => i.id === id;
+
+describe('summarise', () => {
+    it('counts nothing when everything is configured and healthy', () => {
+        const s = summarise(plan(), { isDone: () => true, stateOf: () => 'working' });
+        expect(s.notSetUp).toEqual([]);
+        expect(s.notWorking).toEqual([]);
+        expect(s.total).toBeGreaterThan(0);
+    });
+
+    it('separates never-configured from configured-but-broken', () => {
+        const s = summarise(plan(), {
+            isDone: (i) => !byId('maps')(i),
+            stateOf: (i) => (byId('identity')(i) ? 'failing' : 'working'),
+        });
+        expect(s.notSetUp.map(i => i.id)).toEqual(['maps']);
+        expect(s.notWorking.map(i => i.id)).toEqual(['identity']);
+    });
+
+    it('does not count something that cannot be checked from here', () => {
+        // An HTTP SMS gateway is configured and unverifiable forever. Counting
+        // it gives a badge that can never reach zero, which is the same defect
+        // as a red pill that can never go green.
+        const s = summarise(plan(), { isDone: () => true, stateOf: () => 'unverifiable' });
+        expect(s.notWorking).toEqual([]);
+    });
+
+    it('does not count an unchecked connector as broken', () => {
+        const s = summarise(plan(), { isDone: () => true, stateOf: () => 'unchecked' });
+        expect(s.notWorking).toEqual([]);
+    });
+
+    it('never counts an item twice', () => {
+        const s = summarise(plan(), { isDone: () => false });
+        const ids = s.notSetUp.map(i => i.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('treats a missing health lookup as not-broken rather than broken', () => {
+        // The badge renders before the health request lands. Guessing "broken"
+        // there would flash a red count at a town whose page is merely slow.
+        const s = summarise(plan(), { isDone: () => true });
+        expect(s.notWorking).toEqual([]);
+    });
+});
+
+describe('nameList', () => {
+    const items = (...titles: string[]) => titles.map(t => ({ id: t, title: t } as PlanItem));
+
+    it('names one', () => expect(nameList(items('Maps'))).toBe('Maps'));
+    it('names two', () => expect(nameList(items('Maps', 'AI'))).toBe('Maps and AI'));
+    it('summarises more than it lists', () =>
+        expect(nameList(items('Maps', 'AI', 'Email', 'Text'))).toBe('Maps, AI and 2 more'));
+    it('says nothing about nothing', () => expect(nameList([])).toBe(''));
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -449,53 +449,68 @@ body {
    Override Tailwind opacity text colors that fail 4.5:1
    ======================================== */
 
-/* 
- * Background: #1e1b4b (dark indigo) RGB(30, 27, 75)
- * Contrast ratio requirements: 4.5:1 for normal text, 3:1 for large text
- * 
- * White opacity contrast calculations on #1e1b4b:
- * - 100% (#ffffff) = 15.8:1 ✓
- * - 80%  (#ffffffcc) = 11.9:1 ✓  
- * - 70%  (#ffffffb3) = 9.2:1 ✓
- * - 60%  (#ffffff99) = 6.5:1 ✓ (but close to minimum)
- * - 50%  (#ffffff80) = 4.3:1 ✗ FAILS
- * - 40%  (#ffffff66) = 2.9:1 ✗ FAILS
- * 
- * Fix: Increase minimum opacity to ensure 7:1+ for better accessibility
+/*
+ * Measured, not reasoned about.
+ *
+ * The block that used to be here computed its ratios against #1e1b4b, the
+ * darkest surface on the page, and concluded that /50 and /40 were the only
+ * failures. Four contrast audits across the console disagreed: the panels a
+ * clerk actually reads sit at #454390 and lighter, where white text has *less*
+ * contrast, and /25, /35 and /45 were failing at 2.1:1, 2.8:1 and 3.5:1.
+ *
+ * Worst case across every surface sampled in those audits -- #454390 being the
+ * lightest -- white needs 0.65 to clear 4.5:1. The floor below is 0.68, which
+ * gives 4.94:1 there and more everywhere else.
+ *
+ * The steps are compressed rather than flattened, so the hierarchy these
+ * utilities were chosen for survives: /25 is still quieter than /60, just no
+ * longer illegible.
+ *
+ * Global, deliberately. An earlier version scoped this to three card classes,
+ * which is why it did not reach the Spotlight bubbles, the GIS panel or the
+ * user table -- every new surface had to remember to opt in, and none did.
  */
 
-/* Override low-contrast text colors */
-.text-white\/30 {
-    color: rgba(255, 255, 255, 0.7) !important;
-    /* Was 0.3, increased to 0.7 for WCAG AA */
-}
+.text-white\/15,
+.text-white\/20 { color: rgba(255, 255, 255, 0.68) !important; }
+.text-white\/25 { color: rgba(255, 255, 255, 0.68) !important; }
+.text-white\/30 { color: rgba(255, 255, 255, 0.70) !important; }
+.text-white\/35 { color: rgba(255, 255, 255, 0.72) !important; }
+.text-white\/40 { color: rgba(255, 255, 255, 0.74) !important; }
+.text-white\/45 { color: rgba(255, 255, 255, 0.76) !important; }
+.text-white\/50 { color: rgba(255, 255, 255, 0.78) !important; }
+.text-white\/55 { color: rgba(255, 255, 255, 0.81) !important; }
+.text-white\/60 { color: rgba(255, 255, 255, 0.84) !important; }
+.text-white\/65 { color: rgba(255, 255, 255, 0.87) !important; }
 
-.text-white\/40 {
-    color: rgba(255, 255, 255, 0.7) !important;
-    /* Was 0.4, increased to 0.7 for WCAG AA */
-}
-
-.text-white\/50 {
-    color: rgba(255, 255, 255, 0.75) !important;
-    /* Was 0.5, increased to 0.75 for WCAG AA */
-}
-
-.text-white\/60 {
-    color: rgba(255, 255, 255, 0.8) !important;
-    /* Was 0.6, increased to 0.8 for better contrast (11.9:1) */
-}
+/* Tinted small print -- the badge rows on the department, category and user
+ * cards. At /70 these came in between 3.2:1 and 3.7:1 on the lighter panels.
+ * The 300-level hues only just clear the bar even at full opacity (blue-300 is
+ * 4.74:1, red-300 exactly 4.50:1), so these move to the 200-level, which is
+ * 5.9:1 or better and leaves room for a surface that shifts later. */
+.text-blue-300\/70,
+.text-blue-300\/80    { color: rgb(191, 219, 254) !important; }
+.text-emerald-300\/70,
+.text-emerald-300\/80 { color: rgb(167, 243, 208) !important; }
+.text-amber-300\/70,
+.text-amber-300\/80   { color: rgb(253, 230, 138) !important; }
+.text-red-300\/70,
+.text-red-300\/80     { color: rgb(254, 202, 202) !important; }
 
 /* Ensure muted UI text has sufficient contrast */
 .text-gray-400,
 .text-slate-400 {
-    color: rgb(156, 163, 175) !important;
-    /* #9ca3af - 4.6:1 on dark backgrounds */
+    /* Was #9ca3af, annotated "4.6:1 on dark backgrounds". Measured against the
+     * panels it is actually used on it is 3.36:1 -- the annotation was computed
+     * against the darkest background on the page, not the lightest, which is
+     * the one that matters. #d1d5db is 5.80:1 worst case. */
+    color: rgb(209, 213, 219) !important;
 }
 
 .text-gray-500,
 .text-slate-500 {
-    color: rgb(156, 163, 175) !important;
-    /* Override to lighter shade for contrast */
+    color: rgb(209, 213, 219) !important;
+    /* Same correction as .text-gray-400 above. */
 }
 
 /* Primary color text overrides for darker backgrounds */
@@ -1000,21 +1015,10 @@ html.rtl [data-no-translate] {
      * override would change pages nobody has looked at. Two class names of
      * specificity beats a utility's one, so no !important is needed.
      */
-    .setup-panel .text-white\/45,
-    .premium-card .text-white\/45,
-    .surface-card .text-white\/45 { color: rgba(255, 255, 255, 0.62); }
-
-    .setup-panel .text-white\/40,
-    .premium-card .text-white\/40,
-    .surface-card .text-white\/40 { color: rgba(255, 255, 255, 0.6); }
-
-    .setup-panel .text-white\/35,
-    .premium-card .text-white\/35,
-    .surface-card .text-white\/35 { color: rgba(255, 255, 255, 0.58); }
-
-    .setup-panel .text-white\/30,
-    .premium-card .text-white\/30,
-    .surface-card .text-white\/30 { color: rgba(255, 255, 255, 0.56); }
+    /* The per-card text lift that used to sit here has gone global -- see the
+     * contrast block above. Scoping it to three class names meant every new
+     * surface had to remember to opt in, and the Spotlight bubbles, the GIS
+     * panel and the user table all did not. */
 
     /* The departments and service-category cards are built from inline gradient
      * utilities rather than a shared class, so they need this marker to pick up

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -626,7 +626,12 @@ class ApiClient {
         });
     }
 
-    async testProvider(capability: string): Promise<{ ok: boolean; detail: string }> {
+    /** `recorded: false` means the provider cannot be checked from here at all
+     *  -- a generic HTTP SMS gateway cannot be exercised without sending a real
+     *  text. That is not a failure, and the backend deliberately does not write
+     *  it to connector health. Dropping the flag here is what made those show
+     *  up as "Not working". */
+    async testProvider(capability: string): Promise<{ ok: boolean; detail: string; recorded?: boolean }> {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1650,11 +1650,29 @@ export interface UptimeHistory {
     }>>;
 }
 
+/** One service over one period.
+ *
+ * `reliable` is false when too little of the period was sampled to draw a
+ * conclusion. The sampler runs inside the backend, so a backend outage leaves
+ * a hole rather than a run of "down" rows -- and a percentage computed over
+ * the rows that exist gets *higher* the worse the outage was. Never print
+ * `uptime_percent` as a headline without checking this. */
+export interface UptimePeriod {
+    uptime_percent: number;
+    checks: number;
+    healthy: number;
+    expected_checks?: number;
+    missed_checks?: number;
+    coverage_percent?: number;
+    reliable?: boolean;
+    summary?: string;
+}
+
 export interface UptimeStats {
     services: Record<string, {
-        '24h'?: { uptime_percent: number; checks: number; healthy: number };
-        '7d'?: { uptime_percent: number; checks: number; healthy: number };
-        '30d'?: { uptime_percent: number; checks: number; healthy: number };
+        '24h'?: UptimePeriod;
+        '7d'?: UptimePeriod;
+        '30d'?: UptimePeriod;
     }>;
 }
 


### PR DESCRIPTION
Six commits. Most of this came out of questions rather than a plan — "the state I choose for the retention policy isn't persisting", "are those uptime statistics real or just fake", "can it actually track it correctly" — and each one turned out to be pointing at something larger than it looked.

## The retention state was not a retention bug

`system_settings` is a singleton by convention and nothing else. Seven code paths create it with a non-atomic read-then-insert, so two concurrent requests on a fresh deployment leave two rows. Twenty-two others read it back with `select(SystemSettings).limit(1)` and no `ORDER BY`, which lets PostgreSQL return whichever row is cheapest to reach — and an `UPDATE` writes a new row version at the end of the heap. So a save writes row 1 and the reload returns row 2. The value is in the database; a different row is being displayed.

The retention code is correct. The same read is used for the municipal boundary, road data, the model cache, backups and the public origin — and by the nightly retention task, which means the policy enforced at 01:00 could differ from the one shown on the compliance page. A retention policy is a legal claim about resident data, so that one is not cosmetic.

Fixed in both halves: all 33 reads ordered by id (a test walks the source and fails on any unordered one), and a migration that folds duplicates into the oldest row — carrying over values the duplicates hold — then adds a unique index on a constant expression so a second row cannot exist. Oldest wins because it is the row the deployment has been reading its whole life; a duplicate created later holds mostly defaults.

## Three things the console claimed without checking

**"Not working" on a connector that cannot be tested.** A generic HTTP SMS gateway showed a red badge directly above its own warning that there is no way to check it without sending a real text. The backend already returns `recorded: false`; the frontend dropped the flag. There are now three states that never collapse into each other — not set up, not working, and set up but untestable — and the third is never spotlit, because it will never resolve.

**"Untestable" when nothing had been entered.** Both delivery tests ended in a fallthrough describing the vendor without first asking whether the town had saved anything. A clerk who had never touched text messages was told their gateway was untestable: true about the gateway, irrelevant to them. They now name the empty boxes using the labels on the form.

**`uptime` that was never an uptime.** The field held strings like "Port 5173 active". Renamed to `detail`. Caddy was hardcoded to "running" with no probe — it now reads forwarding headers and says "cannot tell from here" when they are absent. The frontend check's hardcoded `frontend` hostname is configurable, and a miss reports "unknown" rather than "stopped".

## Uptime that admits what it cannot see

There is a real time series — five-minute samples, thirty days — and I was wrong to say otherwise in an earlier round. But the sampler runs inside the process it reports on, so a backend outage produces no rows rather than rows saying "down", and healthy/total over the rows that survive returns a *higher* figure the worse the outage was. Twelve samples in a day read as 100%.

The denominator is time now. Each period reports expected samples, missing samples and coverage; below half the panel shows a dash and "only 12 of 288 checks". This does not make an in-process sampler into an uptime monitor, and the panel now says what it actually measures: whether each dependency answered, during the windows the server was up to ask.

Two lists of "which results count as healthy" had also diverged, so pressing **Check now** recorded a switched-off service as an outage — the act of checking the number damaged it.

## Infrastructure alerts through the same machinery

Disk, database, cache and backups are recorded as connector-health rows under a `system:` prefix, so they inherit the escalation, the digest, the cadence and the mute rather than getting a second alerting path that would drift. Disk warns at 80% and says what breaks, not just a percentage. Probes run hourly because a disk fills in hours; the email cadence is unchanged, and a test pins that.

The five-minute sampler had its own hardcoded vendor list — Auth0, Vertex, Google Translate — so an Azure town accumulated a month of history for services it does not use. Widening it is the wrong fix: the connector sweep is daily *because* each external check costs a call to a town's own paid account. The two stop overlapping. Same for the health page's "Cloud Integrations" block, which was a fixed struct and counted "2/6 Configured" against a denominator that guessed at somebody else's architecture.

## Setup guide

Google's project ID and service-account file moved into the guide, under the step that produces them — the walk previously ended on "that file is what you paste into the boxes below" with no boxes below. Google only, and correctly: Azure prefers a managed identity with nothing to type and AWS needs only a region.

Sentry and backups now render one shared field definition instead of two hand-written copies. The backup passphrase deliberately stays separate — generated, shown once, needs its acknowledgement — and that acknowledgement gated the old save button, so `PlainSecrets` learned `blockedReason` rather than losing it. Backups encrypted with a passphrase nobody wrote down are discovered at restore time.

Warnings: 46 across 89 steps, with one on all three steps of the Google Maps walk, so the billing warning that silently yields a grey map sat in identical amber beside "changes can take five minutes". Amber now means silent, irreversible, or costs money — 46 became 18. An existing test demanding a warning on every path was part of the cause, and is widened to trouble-or-note.

Anything a town switched off is now listed below the cards, pointing at the questions that enable it. Listed, not toggled: a switch there would enable a capability with no credentials behind it.

## Contrast

Five audits. The block handling this computed its ratios against the darkest surface on the page; the panels a clerk reads are lighter, where white text has less contrast. `/25` was 2.1:1, `/35` 2.8:1, `/45` 3.5:1, and `.text-gray-400` was 3.36:1 under a comment claiming 4.6:1. Measured worst case, white needs 0.65 to clear 4.5:1; the floor is 0.68, applied globally rather than scoped to three card classes — that scoping is why it never reached the Spotlight bubbles, the GIS panel or the user table.

## Migrations

Three, all additive and guarded by an inspector check:

- `b8c9d0e1f2a3` — alert state. Without it every alert is treated as never-announced.
- `c9d0e1f2a3b4` — mute state. Without it the mute button silently does nothing.
- `d0e1f2a3b4c5` — settings singleton. Without it the retention fix is half-applied.

## Testing

672 backend tests against a CI-equivalent venv, 145 frontend, clean build, no new typecheck errors.

Verified by mutation throughout rather than by tests passing. Several survived first and were fixed by moving the decision into a pure function CI can reach: escalation clearing a mute, `unverifiable` collapsing back into `failing`, and the proxy probe — where the test grepped the source for a header name that was still present in a detail line above a status that had stopped depending on it.

A smoke test now mounts the setup page, because it had been edited by index across several passes and both a clean typecheck and a clean build pass on JSX that throws on render.

## Known gap, not addressed here

If **email** is the broken connector, the email alert cannot be sent — the send fails, nothing is recorded, and it retries forever. The one thing most likely to fail silently is the one that cannot report itself. A banner on admin login for anything broken and unmuted would close it without needing a second channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_