### PR TITLE
Model discovery that only offers callable models, retention that actually runs, and a compile gate for the frontend

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -1,0 +1,57 @@
+name: Frontend checks
+
+# There was no compile gate on the frontend at all.
+#
+# PR #433 arrived with `modelSearchQuery` used five times and never declared,
+# and every check went green: `vite build` passes because esbuild strips types
+# without resolving identifiers, `pytest` is backend-only, and the
+# accessibility workflow audits the deployed site rather than the branch. The
+# model picker would have thrown a ReferenceError for every town on the first
+# render after deploy.
+on:
+  push:
+    branches: [main]
+    paths: ["frontend/**", ".github/workflows/frontend-checks.yml"]
+  pull_request:
+    paths: ["frontend/**", ".github/workflows/frontend-checks.yml"]
+
+jobs:
+  checks:
+    name: typecheck, tests, build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        # The check that would have caught #433. Pre-existing errors in the
+        # Azure map renderer are excluded by file so this gate can be strict
+        # about everything else today rather than aspirational about all of it
+        # later -- a gate nobody can turn on is not a gate.
+        run: |
+          npx tsc --noEmit -p tsconfig.json > /tmp/tsc.log 2>&1 || true
+          grep "error TS" /tmp/tsc.log \
+            | grep -v "src/maps/providers/azure/renderer.ts" \
+            | grep -v "error TS6133" \
+            | grep -v "error TS5101" > /tmp/new.log || true
+          if [ -s /tmp/new.log ]; then
+            echo "::error::TypeScript errors outside the known baseline:"
+            cat /tmp/new.log
+            exit 1
+          fi
+          echo "No TypeScript errors outside the known baseline."
+
+      - name: Tests
+        run: npx vitest run
+
+      - name: Build
+        run: npx vite build

--- a/backend/alembic/versions/20260801_0400_e1f2a3b4c5d6_retention_scrub_fields.py
+++ b/backend/alembic/versions/20260801_0400_e1f2a3b4c5d6_retention_scrub_fields.py
@@ -1,0 +1,69 @@
+"""Let a town choose what a retention run removes.
+
+The list was fixed in code -- names, email, phone, description, staff notes and
+photos, always. A town's retention obligations come from its own counsel and its
+state's records law, and this decided for them.
+
+NULL means never configured, which is read as the old fixed list, so the first
+run after this migration removes exactly what the last run before it did.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "system_settings"
+COLUMN = "retention_scrub_fields"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in set(inspector.get_table_names()):
+        return  # fresh install: created from the models, already complete
+    if COLUMN in {c["name"] for c in inspector.get_columns(TABLE)}:
+        return
+    op.add_column(TABLE, sa.Column(COLUMN, sa.JSON(), nullable=True))
+
+    # `anonymize` is not what this does. It clears the description and the
+    # staff notes, which is redaction; anonymising means removing what ties
+    # data to a person, and the difference matters when it is what a town tells
+    # a judge. The value is migrated rather than only relabelled so that the
+    # database and the screen agree.
+    #
+    # The code still reads `anonymize` for anyone who skips this.
+    if COLUMN in {c["name"] for c in inspector.get_columns(TABLE)} or True:
+        cols = {c["name"] for c in inspector.get_columns(TABLE)}
+        if "retention_mode" in cols:
+            op.execute(
+                sa.text(
+                    f'UPDATE "{TABLE}" SET retention_mode = :new '  # nosec B608 - fixed identifier
+                    f"WHERE retention_mode = :old"
+                ).bindparams(new="redact", old="anonymize")
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in set(inspector.get_table_names()):
+        return
+    cols = {c["name"] for c in inspector.get_columns(TABLE)}
+    if "retention_mode" in cols:
+        op.execute(
+            sa.text(
+                f'UPDATE "{TABLE}" SET retention_mode = :old '  # nosec B608 - fixed identifier
+                f"WHERE retention_mode = :new"
+            ).bindparams(new="redact", old="anonymize")
+        )
+    if COLUMN in cols:
+        op.drop_column(TABLE, COLUMN)

--- a/backend/alembic/versions/20260801_0600_f2a3b4c5d6e7_ai_columns_and_town_timezone.py
+++ b/backend/alembic/versions/20260801_0600_f2a3b4c5d6e7_ai_columns_and_town_timezone.py
@@ -1,0 +1,64 @@
+"""Drop a vendor's name from provider-agnostic columns, and record the town's timezone.
+
+`vertex_ai_summary`, `vertex_ai_classification` and `vertex_ai_analyzed_at`
+were named after Google Vertex AI, which is one of five providers a town can
+pick. A deployment running Azure OpenAI stored its summaries in a column
+claiming otherwise -- the same mistake as the old `google_kms`, which was
+renamed to `kms` for the same reason.
+
+The timezone column is the other half of the timestamp work. Everything is
+stored in UTC, which is right; showing it in UTC is not. "Closed at 02:14"
+means nothing to a clerk looking at a report closed just before ten the
+previous night.
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+REQUESTS = "service_requests"
+SETTINGS = "system_settings"
+RENAMES = [
+    ("vertex_ai_summary", "ai_summary"),
+    ("vertex_ai_classification", "ai_classification"),
+    ("vertex_ai_analyzed_at", "ai_analyzed_at"),
+]
+
+
+def _columns(table: str) -> set:
+    inspector = sa.inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    # Renamed rather than added-and-copied: these hold a model's summary of a
+    # resident's report, so two columns holding the same text while something
+    # backfills is two places for it to be missed by the retention scrub.
+    existing = _columns(REQUESTS)
+    for old, new in RENAMES:
+        if old in existing and new not in existing:
+            op.alter_column(REQUESTS, old, new_column_name=new)
+
+    settings = _columns(SETTINGS)
+    if settings and "timezone" not in settings:
+        op.add_column(SETTINGS, sa.Column("timezone", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    existing = _columns(REQUESTS)
+    for old, new in RENAMES:
+        if new in existing and old not in existing:
+            op.alter_column(REQUESTS, new, new_column_name=old)
+    if "timezone" in _columns(SETTINGS):
+        op.drop_column(SETTINGS, "timezone")

--- a/backend/alembic/versions/20260801_0800_a3b4c5d6e7f8_retire_hard_delete.py
+++ b/backend/alembic/versions/20260801_0800_a3b4c5d6e7f8_retire_hard_delete.py
@@ -1,0 +1,63 @@
+"""Retire hard deletion; the strongest retention mode clears every field.
+
+`delete` called `db.delete(record)` while `request_audit_logs` and
+`request_comments` hold NOT NULL foreign keys back to it with no cascade. The
+flush failed on every record -- submitting a request writes an audit entry, so
+every record has one -- and each failure was caught per record, leaving the run
+to report success with nothing archived. A town on a delete policy was told
+retention was running, and nothing was ever removed.
+
+Making it succeed meant deleting the audit rows, and those form a hash chain
+the compliance page advertises as tamper-evident. Removing rows from the middle
+makes the verify endpoint report tampering, correctly, for a deletion that was
+entirely legitimate.
+
+`purge` clears every field instead. The personal data is gone, the row survives
+as a shell that still counts in statistics, and the audit chain stays whole.
+
+Revision ID: a3b4c5d6e7f8
+Revises: f2a3b4c5d6e7
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a3b4c5d6e7f8"
+down_revision: Union[str, None] = "f2a3b4c5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "system_settings"
+
+
+def _has(column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in set(inspector.get_table_names()):
+        return False
+    return column in {c["name"] for c in inspector.get_columns(TABLE)}
+
+
+def upgrade() -> None:
+    if not _has("retention_mode"):
+        return
+    # A town set to `delete` asked for the strongest available option, and gets
+    # it. What changes is that it now works.
+    op.execute(
+        sa.text(
+            f'UPDATE "{TABLE}" SET retention_mode = :new '  # nosec B608 - fixed identifier
+            f"WHERE retention_mode = :old"
+        ).bindparams(new="purge", old="delete")
+    )
+
+
+def downgrade() -> None:
+    if not _has("retention_mode"):
+        return
+    op.execute(
+        sa.text(
+            f'UPDATE "{TABLE}" SET retention_mode = :old '  # nosec B608 - fixed identifier
+            f"WHERE retention_mode = :new"
+        ).bindparams(new="purge", old="delete")
+    )

--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -8,7 +8,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_, desc
 from typing import Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import io
 import csv
 
@@ -50,14 +50,14 @@ async def get_audit_logs(
             conditions.append(AuditLog.timestamp < end_dt)
         except ValueError:
             # Invalid date format, fall back to days
-            since = datetime.utcnow() - timedelta(days=days or 7)
+            since = datetime.now(timezone.utc) - timedelta(days=days or 7)
             conditions.append(AuditLog.timestamp >= since)
     elif days:
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         conditions.append(AuditLog.timestamp >= since)
     else:
         # Default to last 7 days
-        since = datetime.utcnow() - timedelta(days=7)
+        since = datetime.now(timezone.utc) - timedelta(days=7)
         conditions.append(AuditLog.timestamp >= since)
     
     # Event type filter
@@ -137,7 +137,7 @@ async def get_audit_stats(
     
     Admin only endpoint.
     """
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
     
     # Total events
     total_result = await db.execute(
@@ -197,7 +197,7 @@ async def get_audit_stats(
     unique_users = unique_result.scalar() or 0
     
     # Recent failures (last 24 hours)
-    recent_since = datetime.utcnow() - timedelta(hours=24)
+    recent_since = datetime.now(timezone.utc) - timedelta(hours=24)
     recent_failures_result = await db.execute(
         select(func.count(AuditLog.id))
         .where(
@@ -248,13 +248,13 @@ async def export_audit_logs(
             conditions.append(AuditLog.timestamp >= start_dt)
             conditions.append(AuditLog.timestamp < end_dt)
         except ValueError:
-            since = datetime.utcnow() - timedelta(days=days or 30)
+            since = datetime.now(timezone.utc) - timedelta(days=days or 30)
             conditions.append(AuditLog.timestamp >= since)
     elif days:
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         conditions.append(AuditLog.timestamp >= since)
     else:
-        since = datetime.utcnow() - timedelta(days=30)
+        since = datetime.now(timezone.utc) - timedelta(days=30)
         conditions.append(AuditLog.timestamp >= since)
     
     if event_type and event_type != "all":
@@ -314,7 +314,7 @@ async def export_audit_logs(
         iter([output.getvalue()]),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=audit_logs_{datetime.utcnow().strftime('%Y%m%d')}.csv"
+            "Content-Disposition": f"attachment; filename=audit_logs_{datetime.now(timezone.utc).strftime('%Y%m%d')}.csv"
         }
     )
 
@@ -337,7 +337,7 @@ async def verify_audit_log_integrity(
     return {
         "integrity_valid": is_valid,
         "message": "Audit log chain is intact" if is_valid else "WARNING: Tampering detected in audit logs",
-        "timestamp": datetime.utcnow().isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat()
     }
 
 

--- a/backend/app/api/data_export.py
+++ b/backend/app/api/data_export.py
@@ -9,7 +9,7 @@ import csv
 import io
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List
 from fastapi import APIRouter, Depends, Query, HTTPException
 from fastapi.responses import StreamingResponse
@@ -129,7 +129,7 @@ async def export_requests(
     settings = settings_result.scalar_one_or_none()
     township_name = settings.township_name.replace(" ", "_") if settings else "township"
     
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     
     # Staff exports use the SAME analytical schema as the research export (one
     # shared row builder, so the two can never drift apart), plus the operational
@@ -180,7 +180,7 @@ async def export_requests(
         data = {
             "export_info": {
                 "township": settings.township_name if settings else "Unknown",
-                "exported_at": datetime.utcnow().isoformat(),
+                "exported_at": datetime.now(timezone.utc).isoformat(),
                 "exported_by": current_user.full_name,
                 "total_records": len(requests),
                 "filters": {
@@ -210,7 +210,7 @@ async def export_requests(
             "type": "FeatureCollection",
             "properties": {
                 "township": settings.township_name if settings else "Unknown",
-                "exported_at": datetime.utcnow().isoformat(),
+                "exported_at": datetime.now(timezone.utc).isoformat(),
                 "total_features": len(requests)
             },
             "features": [
@@ -312,7 +312,7 @@ async def export_statistics(
     stats = {
         "export_info": {
             "township": settings.township_name if settings else "Unknown",
-            "exported_at": datetime.utcnow().isoformat(),
+            "exported_at": datetime.now(timezone.utc).isoformat(),
             "exported_by": current_user.full_name,
             "date_range": {
                 "start": start_date.isoformat() if start_date else "all time",
@@ -329,7 +329,7 @@ async def export_statistics(
         "by_department": by_department
     }
     
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     
     if format.lower() == "json":
         json_str = json.dumps(stats, indent=2)
@@ -348,7 +348,7 @@ async def export_statistics(
         # Summary section
         writer.writerow(["Pinpoint 311 Statistics Export"])
         writer.writerow(["Township", settings.township_name if settings else "Unknown"])
-        writer.writerow(["Exported At", datetime.utcnow().isoformat()])
+        writer.writerow(["Exported At", datetime.now(timezone.utc).isoformat()])
         writer.writerow(["Date Range", f"{start_date or 'All time'} to {end_date or 'Present'}"])
         writer.writerow([])
         

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -453,7 +453,7 @@ async def version_info(db: AsyncSession = Depends(get_db)):
 
 # ==================== UPTIME MONITORING ====================
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import desc
 from app.models import UptimeRecord
 
@@ -471,7 +471,7 @@ async def get_uptime_history(
         hours: Number of hours to look back (default 24, max 168 = 7 days)
     """
     hours = min(hours, 168)  # Cap at 7 days
-    since = datetime.utcnow() - timedelta(hours=hours)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
     
     result = await db.execute(
         select(UptimeRecord)
@@ -515,7 +515,7 @@ async def get_uptime_stats(
     periods = {"24h": 24, "7d": 168, "30d": 720}
     
     for period_name, hours in periods.items():
-        since = datetime.utcnow() - timedelta(hours=hours)
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
         
         # Get total checks and healthy checks per service
         result = await db.execute(

--- a/backend/app/api/integrations.py
+++ b/backend/app/api/integrations.py
@@ -5,7 +5,7 @@ create and update requests in Pinpoint."""
 import logging
 import secrets as pysecrets
 import uuid as uuid_module
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -202,7 +202,7 @@ async def update_integration(
             merged.update(stored)
             integration.credentials = merged
 
-    integration.updated_at = datetime.utcnow()
+    integration.updated_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(integration)
     from app.core.sanitize import sanitize_for_log
@@ -474,9 +474,9 @@ async def integration_webhook(
             if payload.status and payload.status != sr.status:
                 old_status = sr.status
                 sr.status = payload.status
-                sr.updated_datetime = datetime.utcnow()
+                sr.updated_datetime = datetime.now(timezone.utc)
                 if payload.status == "closed":
-                    sr.closed_datetime = datetime.utcnow()
+                    sr.closed_datetime = datetime.now(timezone.utc)
                 db.add(RequestAuditLog(
                     service_request_id=sr.id,
                     action="status_change",
@@ -545,7 +545,7 @@ async def integration_webhook(
         external_id=payload.external_id,
         external_status=payload.status,
         direction="pulled",
-        last_pulled_at=datetime.utcnow(),
+        last_pulled_at=datetime.now(timezone.utc),
     ))
     db.add(RequestAuditLog(
         service_request_id=sr.id,

--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
 from sqlalchemy.orm import selectinload
 from typing import List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import uuid
 import logging
 
@@ -951,7 +951,7 @@ async def update_request_status(
             if field == "status":
                 value = value.value
                 if value == "closed" and request.status != "closed":
-                    request.closed_datetime = datetime.utcnow()
+                    request.closed_datetime = datetime.now(timezone.utc)
             elif field == "closed_substatus":
                 value = value.value  # Convert enum to string
             # Special handling for boolean flagged field
@@ -959,7 +959,7 @@ async def update_request_status(
                 logger.debug(f"[LEGAL HOLD] Setting flagged from {request.flagged} to {value} for request {request.service_request_id}")
             setattr(request, field, value)
     
-    request.updated_datetime = datetime.utcnow()
+    request.updated_datetime = datetime.now(timezone.utc)
     
     # Force flush to ensure changes are written
     await db.flush()
@@ -1189,10 +1189,10 @@ async def delete_request(
         raise HTTPException(status_code=400, detail="Request already deleted")
     
     # Soft delete
-    request.deleted_at = datetime.utcnow()
+    request.deleted_at = datetime.now(timezone.utc)
     request.deleted_by = current_user.username
     request.delete_justification = delete_data.justification
-    request.updated_datetime = datetime.utcnow()
+    request.updated_datetime = datetime.now(timezone.utc)
     
     # Add audit log entry
     audit_entry = RequestAuditLog(
@@ -1232,7 +1232,7 @@ async def restore_request(
     request.deleted_at = None
     request.deleted_by = None
     request.delete_justification = None
-    request.updated_datetime = datetime.utcnow()
+    request.updated_datetime = datetime.now(timezone.utc)
     
     # Add audit log entry
     audit_entry = RequestAuditLog(
@@ -1275,7 +1275,7 @@ async def accept_ai_priority(
     
     # Set the manual priority score to the AI suggestion
     request.manual_priority_score = float(ai_priority)
-    request.updated_datetime = datetime.utcnow()
+    request.updated_datetime = datetime.now(timezone.utc)
     
     # Add audit log entry
     audit_entry = RequestAuditLog(

--- a/backend/app/api/research.py
+++ b/backend/app/api/research.py
@@ -1337,7 +1337,7 @@ async def export_csv(
             
             # AI analysis data
             # AI priority is now in ai_analysis JSON, not a separate column
-            ai_summary = sanitize_description(req.vertex_ai_summary) if req.vertex_ai_summary else None
+            ai_summary = sanitize_description(req.ai_summary) if req.ai_summary else None
             ai_priority = req.ai_analysis.get('priority_score') if req.ai_analysis else None
             ai_priority_diff = None
             if ai_priority and req.manual_priority_score:
@@ -1419,7 +1419,7 @@ async def export_csv(
                 req.flag_reason,
                 ai_priority,  # Now from ai_analysis.priority_score
                 ai_summary,
-                bool(req.vertex_ai_analyzed_at),
+                bool(req.ai_analyzed_at),
                 ai_priority_diff,
                 req.status,
                 req.closed_substatus,
@@ -1568,7 +1568,7 @@ async def export_geojson(
             asset_type = req.matched_asset.get('asset_type') or req.matched_asset.get('layer_name')
         
         # AI priority is now in ai_analysis JSON, not a separate column
-        ai_summary = sanitize_description(req.vertex_ai_summary) if req.vertex_ai_summary else None
+        ai_summary = sanitize_description(req.ai_summary) if req.ai_summary else None
         ai_priority = req.ai_analysis.get('priority_score') if req.ai_analysis else None
         ai_priority_diff = None
         if ai_priority and req.manual_priority_score:
@@ -1665,7 +1665,7 @@ async def export_geojson(
                 "moderation_flag_reason": req.flag_reason,
                 "ai_priority_score": ai_priority,  # Now from ai_analysis.priority_score
                 "ai_summary_sanitized": ai_summary,
-                "ai_analyzed": bool(req.vertex_ai_analyzed_at),
+                "ai_analyzed": bool(req.ai_analyzed_at),
                 "ai_vs_manual_priority_diff": ai_priority_diff,
                 
                 # Status & Resolution
@@ -2824,7 +2824,7 @@ def build_dataset_row(req, _eq, privacy_mode, *, operational=False, include_pii=
     days_to_first_update = days_to_first_staff_action(req)
     ai_analysis = req.ai_analysis if isinstance(req.ai_analysis, dict) else {}
     ai_priority = ai_analysis.get("priority_score")
-    ai_summary = sanitize_description(req.vertex_ai_summary) if req.vertex_ai_summary else None
+    ai_summary = sanitize_description(req.ai_summary) if req.ai_summary else None
     ai_priority_diff = (
         round(req.manual_priority_score - ai_priority, 2)
         if (ai_priority is not None and req.manual_priority_score is not None) else None
@@ -2860,7 +2860,7 @@ def build_dataset_row(req, _eq, privacy_mode, *, operational=False, include_pii=
         "moderation_flag_reason": req.flag_reason,
         "ai_priority_score": ai_priority,
         "ai_summary_sanitized": ai_summary,
-        "ai_analyzed": bool(req.vertex_ai_analyzed_at),
+        "ai_analyzed": bool(req.ai_analyzed_at),
         "ai_vs_manual_priority_diff": ai_priority_diff,
         "status": req.status,
         "closed_substatus": req.closed_substatus,

--- a/backend/app/api/services.py
+++ b/backend/app/api/services.py
@@ -153,11 +153,11 @@ async def sla_performance(
     are listed separately so admins can see what isn't covered yet, but they are
     never counted as failing.
     """
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
     from app.models import ServiceRequest
     from app.services.sla import summarize_category, overall_summary
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     since = now - timedelta(days=max(1, min(days, 730)))
 
     services_result = await db.execute(select(ServiceDefinition))

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -180,7 +180,16 @@ async def _configured_map(providers: List[Dict[str, Any]]) -> Dict[str, bool]:
         present = True
         for key in required:
             try:
-                if not await get_secret(key):
+                # `.strip()`, so that a value of " " is absent here as well as
+                # everywhere else.
+                #
+                # Two definitions of empty had drifted apart. This one counted
+                # any truthy string, and the live test stripped before checking
+                # -- so a whitespace credential made a provider "configured"
+                # and simultaneously untestable, and the card said "Set up.
+                # There is no way to test this one from here" about a service
+                # nobody had entered anything for.
+                if not (await get_secret(key) or "").strip():
                     present = False
                     break
             except Exception:
@@ -848,7 +857,19 @@ async def _test_delivery(capability: str) -> dict:
         missing = [k for k in required_keys(entry) if not (await get_secret(k) or "").strip()]
         if not missing:
             return None
-        return {"ok": False, "detail": describe_missing(entry, missing), "recorded": False}
+        # `configured: False` rather than only `recorded: False`.
+        #
+        # These are different facts and the frontend was collapsing them: it
+        # read "not recorded" as "this provider cannot be tested", which is
+        # true of an HTTP gateway in general and wrong about a town that has
+        # entered nothing. Saying which it is lets the card correct itself even
+        # when the catalog disagrees.
+        return {
+            "ok": False,
+            "detail": describe_missing(entry, missing),
+            "recorded": False,
+            "configured": False,
+        }
 
     if capability == "email":
         provider = (await get_secret("EMAIL_PROVIDER")) or "smtp"

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1694,6 +1694,49 @@ async def update_retention_policy(
     }
 
 
+@router.get("/timezone")
+async def get_town_timezone(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+):
+    """Which clock the console shows times on.
+
+    Storage does not move. Every timestamp column is timestamptz and stays in
+    UTC; this only decides what a screen converts it into.
+    """
+    from app.services.town_time import COMMON_TIMEZONES, normalise_timezone, offset_label
+
+    settings = await read_settings_row(db)
+    current = normalise_timezone(getattr(settings, "timezone", None) if settings else None)
+    return {
+        "timezone": current,
+        "offset": offset_label(current),
+        "configured": bool(getattr(settings, "timezone", None)) if settings else False,
+        "common": [{"id": z, "offset": offset_label(z)} for z in COMMON_TIMEZONES],
+    }
+
+
+@router.post("/timezone")
+async def set_town_timezone(
+    payload: Dict[str, Any] = Body(default_factory=dict),
+    db: AsyncSession = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    from app.services.town_time import is_valid_timezone, offset_label
+
+    name = str(payload.get("timezone", "")).strip()
+    if not is_valid_timezone(name):
+        # Rejected rather than quietly falling back to UTC. Silently storing
+        # something other than what was chosen is how a town ends up certain
+        # its times are local when they are not.
+        raise HTTPException(status_code=400, detail=f"Not a timezone this server recognises: {name or '(empty)'}")
+
+    settings = await read_settings_row(db, create=True)
+    settings.timezone = name
+    await db.commit()
+    return {"timezone": name, "offset": offset_label(name)}
+
+
 @router.get("/retention/preview")
 async def preview_retention_run(
     db: AsyncSession = Depends(get_db),
@@ -1840,7 +1883,7 @@ async def export_for_public_records(
     """
     from app.services.retention_service import get_retention_policy
     from app.models import ServiceRequest
-    from datetime import datetime
+    from datetime import datetime, timezone
     import csv
     import io
     from fastapi.responses import StreamingResponse
@@ -1870,7 +1913,7 @@ async def export_for_public_records(
     # Write header with public records law info
     output.write(f"# {policy['public_records_law']} EXPORT\n")
     output.write(f"# State: {policy['name']} ({state_code})\n")
-    output.write(f"# Generated: {datetime.utcnow().isoformat()}Z\n")
+    output.write(f"# Generated: {datetime.now(timezone.utc).isoformat()}Z\n")
     output.write(f"# Total Records: {len(records)}\n")
     output.write(f"# Exported by: {current_user.username}\n")
     output.write("#\n")
@@ -1902,7 +1945,7 @@ async def export_for_public_records(
     
     # Create filename with law name
     law_abbrev = policy['public_records_law'].split('(')[0].strip().replace(' ', '_')
-    filename = f"{law_abbrev}_export_{datetime.utcnow().strftime('%Y%m%d')}.csv"
+    filename = f"{law_abbrev}_export_{datetime.now(timezone.utc).strftime('%Y%m%d')}.csv"
     
     return StreamingResponse(
         iter([output.getvalue()]),
@@ -2007,8 +2050,8 @@ async def get_advanced_statistics(
     except Exception:
         pass  # Redis unavailable
 
-    from datetime import datetime
-    now = datetime.utcnow()
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
     
     # ========== Basic Counts ==========
     
@@ -2535,7 +2578,7 @@ async def get_advanced_statistics(
     if peak_month:
         # Extract month name from YYYY-MM format
         try:
-            from datetime import datetime as dt
+            from datetime import datetime as dt, timezone
             peak_month = dt.strptime(peak_month, "%Y-%m").strftime("%B")
         except Exception:
             pass  # Month format conversion failed, keep original
@@ -3049,10 +3092,10 @@ async def switch_version(
     from app.core.managed import ensure_not_managed
     ensure_not_managed("Upgrading")
     import httpx
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     project_root = os.environ.get("PROJECT_ROOT", "/project")
-    deployment_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    deployment_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     backup_dir = "/project/backups"
     
     # Auto-detect the Docker Compose project name from running containers
@@ -3100,7 +3143,7 @@ async def switch_version(
             "step": step,
             "success": success,
             "detail": detail,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         })
         if not success:
             state["errors"].append(f"{step}: {detail}")
@@ -3904,10 +3947,10 @@ async def get_health_dashboard(
     Comprehensive system health dashboard for non-technical administrators.
     Returns status of all services, database metrics, and last backup info.
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
     
     health = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "services": {},
         "database": {},
         "cache": {},
@@ -4095,12 +4138,12 @@ async def execute_runbook(
     """
     from app.core.managed import ensure_not_managed
     ensure_not_managed("Infrastructure runbook execution")
-    from datetime import datetime
+    from datetime import datetime, timezone
     
     result = {
         "action": action,
         "executed_by": current_user.email,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "status": "success",
         "details": {}
     }
@@ -4248,10 +4291,10 @@ async def analytics_chat(
     Gathers comprehensive context from across the platform (excluding resident PII)
     and uses Gemini 3.1 Flash-Lite to answer questions.
     """
-    from datetime import datetime
+    from datetime import datetime, timezone
     
     context_used = []
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     
     # ========== 1. System Settings (Township Identity) ==========
     settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
@@ -4346,13 +4389,13 @@ async def analytics_chat(
     ai_summaries = []
     flagged_requests = []
     for r in all_requests:
-        if r.vertex_ai_summary:
+        if r.ai_summary:
             ai_summaries.append({
                 "id": r.service_request_id,
                 "category": r.service_name,
                 "address": r.address or "Unknown",
-                "summary": r.vertex_ai_summary[:200],
-                "classification": r.vertex_ai_classification,
+                "summary": r.ai_summary[:200],
+                "classification": r.ai_classification,
                 "priority": (r.ai_analysis or {}).get("priority_score") if isinstance(r.ai_analysis, dict) else None
             })
         if r.flagged:
@@ -4583,7 +4626,7 @@ async def analytics_chat(
         }
         if r.ai_analysis and isinstance(r.ai_analysis, dict):
             detail["ai_priority"] = r.ai_analysis.get("priority_score")
-            detail["ai_category"] = r.vertex_ai_classification
+            detail["ai_category"] = r.ai_classification
         if r.flagged:
             detail["flagged"] = True
             detail["flag_reason"] = r.flag_reason

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -21,6 +21,7 @@ from app.schemas import (
     StatisticsResponse
 )
 from app.core.auth import get_current_admin, get_current_staff
+from app.services.system_settings import get_settings as read_settings_row
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -1673,20 +1674,92 @@ async def update_retention_policy(
     }
 
 
+@router.get("/retention/preview")
+async def preview_retention_run(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+):
+    """What pressing "Run now" would actually do.
+
+    The button had no preview and no confirmation. In `delete` mode it
+    permanently destroys resident records on one click, and the response came
+    back before the task had touched anything, so nothing on screen could say
+    what happened. Somebody deserves to see the number and the mode before
+    that, not after.
+    """
+    from app.models import ServiceRequest
+    from app.services.retention_service import get_retention_policy, get_retention_stats
+
+    settings = await read_settings_row(db)
+    if settings is not None and getattr(settings, "legal_hold", False):
+        return {
+            "eligible": 0,
+            "on_legal_hold": 0,
+            "mode": getattr(settings, "retention_mode", None) or "anonymize",
+            "blocked": "legal_hold",
+        }
+
+    state_code = (settings.retention_state_code if settings else None) or "NJ"
+    override_days = settings.retention_days_override if settings else None
+    mode = (settings.retention_mode if settings else None) or "anonymize"
+    policy = get_retention_policy(state_code)
+    stats = await get_retention_stats(db, state_code, override_days)
+
+    # Flagged records are past their date and must not be touched. They are
+    # counted separately rather than hidden, because "142 eligible" and "142
+    # eligible, 3 of which will be skipped" are different sentences to somebody
+    # approving a deletion.
+    held = (await db.execute(
+        select(func.count(ServiceRequest.id)).where(
+            and_(ServiceRequest.status == "closed", ServiceRequest.flagged.is_(True))
+        )
+    )).scalar() or 0
+
+    eligible = stats.get("eligible_for_archival", 0) if isinstance(stats, dict) else 0
+    return {
+        "eligible": eligible,
+        "on_legal_hold": held,
+        "will_act_on": max(0, eligible - held),
+        "mode": mode,
+        "state_code": state_code,
+        "policy_name": policy.get("name"),
+        "retention_days": override_days or policy.get("retention_days"),
+        "cutoff_date": stats.get("cutoff_date") if isinstance(stats, dict) else None,
+        # The word the caller has to send back. Deleting resident records on a
+        # single click is not something to make easy.
+        "confirmation_required": "DELETE" if mode == "delete" else None,
+    }
+
+
 @router.post("/retention/run")
 async def run_retention_now(
+    payload: Dict[str, Any] = Body(default_factory=dict),
     db: AsyncSession = Depends(get_db),
     _: User = Depends(get_current_admin)
 ):
-    """Manually trigger retention enforcement (admin only)"""
+    """Run retention enforcement now.
+
+    In `delete` mode this permanently destroys records, so it requires the
+    caller to echo back a confirmation word. A modal alone is a client-side
+    courtesy; anything that can be done by a stray fetch should not be able to
+    delete resident data.
+    """
     from app.tasks.service_requests import enforce_retention_policy
-    
-    # Trigger async task
+
+    settings = await read_settings_row(db)
+    mode = (settings.retention_mode if settings else None) or "anonymize"
+    if mode == "delete" and str(payload.get("confirm", "")).strip() != "DELETE":
+        raise HTTPException(
+            status_code=400,
+            detail='This policy deletes records permanently. Send confirm="DELETE" to proceed.',
+        )
+
     task = enforce_retention_policy.delay()
     return {
         "status": "triggered",
         "task_id": task.id,
-        "message": "Retention enforcement task started"
+        "mode": mode,
+        "message": "Retention enforcement started. It works through every eligible record.",
     }
 
 

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1667,10 +1667,10 @@ async def update_retention_policy(
             settings.retention_days_override = override_days
     
     if mode:
-        from app.services.retention_scrub import DELETE, REDACT, normalise_mode
+        from app.services.retention_scrub import MODES, normalise_mode
         resolved = normalise_mode(mode)
-        if resolved not in (REDACT, DELETE):
-            raise HTTPException(400, f"Mode must be '{REDACT}' or '{DELETE}'")
+        if resolved not in MODES:
+            raise HTTPException(400, f"Mode must be one of: {', '.join(MODES)}")
         settings.retention_mode = resolved
 
     if scrub_fields is not None:
@@ -1791,7 +1791,9 @@ async def preview_retention_run(
         "cutoff_date": stats.get("cutoff_date") if isinstance(stats, dict) else None,
         # The word the caller has to send back. Deleting resident records on a
         # single click is not something to make easy.
-        "confirmation_required": "DELETE" if mode == "delete" else None,
+        # Purge clears every field on every eligible record and cannot be
+        # undone, so it is typed out rather than clicked.
+        "confirmation_required": "PURGE" if mode == "purge" else None,
         "scrub_fields": [
             f["label"] for f in describe_selection(
                 getattr(settings, "retention_scrub_fields", None) if settings else None
@@ -1819,10 +1821,11 @@ async def run_retention_now(
 
     settings = await read_settings_row(db)
     mode = normalise_mode(settings.retention_mode if settings else None)
-    if mode == "delete" and str(payload.get("confirm", "")).strip() != "DELETE":
+    if mode == "purge" and str(payload.get("confirm", "")).strip() != "PURGE":
         raise HTTPException(
             status_code=400,
-            detail='This policy deletes records permanently. Send confirm="DELETE" to proceed.',
+            detail='This policy clears every field on every eligible record and cannot be '
+                   'undone. Send confirm="PURGE" to proceed.',
         )
 
     task = enforce_retention_policy.delay()

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1604,12 +1604,19 @@ async def get_current_retention_policy(
     policy = get_retention_policy(state_code)
     stats = await get_retention_stats(db, state_code, override_days)
     
+    from app.services.retention_scrub import describe_selection, normalise_mode
+
     return {
         "state_code": state_code,
         "policy": policy,
         "override_days": override_days,
         "effective_days": override_days if override_days else policy["retention_days"],
-        "mode": mode,
+        "mode": normalise_mode(mode),
+        # The catalog and this town's choice in one object, so the screen never
+        # has to hold its own copy of what the fields are called.
+        "scrub_fields": describe_selection(
+            getattr(settings, "retention_scrub_fields", None) if settings else None
+        ),
         "stats": stats
     }
 
@@ -1619,6 +1626,7 @@ async def update_retention_policy(
     state_code: str = None,
     override_days: int = None,
     mode: str = None,
+    scrub_fields: Optional[List[str]] = Query(None),
     db: AsyncSession = Depends(get_db),
     _: User = Depends(get_current_admin)
 ):
@@ -1659,9 +1667,20 @@ async def update_retention_policy(
             settings.retention_days_override = override_days
     
     if mode:
-        if mode not in ["anonymize", "delete"]:
-            raise HTTPException(400, "Mode must be 'anonymize' or 'delete'")
-        settings.retention_mode = mode
+        from app.services.retention_scrub import DELETE, REDACT, normalise_mode
+        resolved = normalise_mode(mode)
+        if resolved not in (REDACT, DELETE):
+            raise HTTPException(400, f"Mode must be '{REDACT}' or '{DELETE}'")
+        settings.retention_mode = resolved
+
+    if scrub_fields is not None:
+        from app.services.retention_scrub import FIELD_IDS, normalise_fields
+        unknown = [f for f in scrub_fields if f not in FIELD_IDS]
+        if unknown:
+            # Rejected rather than quietly dropped. A field silently ignored is
+            # a town believing it removes something it does not.
+            raise HTTPException(400, f"Unknown fields to scrub: {', '.join(sorted(unknown))}")
+        settings.retention_scrub_fields = normalise_fields(scrub_fields)
     
     await db.commit()
     await db.refresh(settings)
@@ -1670,7 +1689,8 @@ async def update_retention_policy(
         "status": "updated",
         "state_code": settings.retention_state_code,
         "override_days": settings.retention_days_override,
-        "mode": settings.retention_mode
+        "mode": settings.retention_mode,
+        "scrub_fields": settings.retention_scrub_fields,
     }
 
 
@@ -1688,6 +1708,7 @@ async def preview_retention_run(
     that, not after.
     """
     from app.models import ServiceRequest
+    from app.services.retention_scrub import describe_selection, normalise_mode
     from app.services.retention_service import get_retention_policy, get_retention_stats
 
     settings = await read_settings_row(db)
@@ -1701,7 +1722,7 @@ async def preview_retention_run(
 
     state_code = (settings.retention_state_code if settings else None) or "NJ"
     override_days = settings.retention_days_override if settings else None
-    mode = (settings.retention_mode if settings else None) or "anonymize"
+    mode = normalise_mode(settings.retention_mode if settings else None)
     policy = get_retention_policy(state_code)
     stats = await get_retention_stats(db, state_code, override_days)
 
@@ -1728,6 +1749,11 @@ async def preview_retention_run(
         # The word the caller has to send back. Deleting resident records on a
         # single click is not something to make easy.
         "confirmation_required": "DELETE" if mode == "delete" else None,
+        "scrub_fields": [
+            f["label"] for f in describe_selection(
+                getattr(settings, "retention_scrub_fields", None) if settings else None
+            ) if f["selected"]
+        ],
     }
 
 
@@ -1746,8 +1772,10 @@ async def run_retention_now(
     """
     from app.tasks.service_requests import enforce_retention_policy
 
+    from app.services.retention_scrub import normalise_mode
+
     settings = await read_settings_row(db)
-    mode = (settings.retention_mode if settings else None) or "anonymize"
+    mode = normalise_mode(settings.retention_mode if settings else None)
     if mode == "delete" and str(payload.get("confirm", "")).strip() != "DELETE":
         raise HTTPException(
             status_code=400,

--- a/backend/app/api/telemetry.py
+++ b/backend/app/api/telemetry.py
@@ -10,7 +10,7 @@ PII-shaped may originate here.
 import hmac
 import time
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import func, select, text
@@ -59,7 +59,7 @@ async def get_telemetry(
     # error bodies can echo request contents).
     integration_health: dict[str, str] = {}
     try:
-        since = datetime.utcnow() - timedelta(hours=24)
+        since = datetime.now(timezone.utc) - timedelta(hours=24)
         result = await db.execute(
             select(UptimeRecord.service_name, UptimeRecord.status)
             .where(UptimeRecord.checked_at >= since)
@@ -74,7 +74,7 @@ async def get_telemetry(
     # only counters, never request contents.
     api_usage: dict[str, dict[str, int]] = {}
     try:
-        since = datetime.utcnow() - timedelta(days=30)
+        since = datetime.now(timezone.utc) - timedelta(days=30)
         result = await db.execute(
             select(
                 ApiUsageRecord.service_name,
@@ -105,5 +105,5 @@ async def get_telemetry(
         "request_counts": dict(request_counts),
         "integration_health": integration_health,
         "api_usage": api_usage,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -499,6 +499,11 @@ class SystemSettings(Base):
     retention_state_code = Column(String(2), default="NJ")  # State for retention rules
     retention_days_override = Column(Integer)  # Custom override (null = use state default)
     retention_mode = Column(String(20), default="anonymize")  # "anonymize" or "delete"
+    # Which fields a retention run clears. NULL means never configured, which
+    # is read as the defaults rather than as "nothing": a town upgrading into
+    # this keeps the behaviour it already had. An empty list is a deliberate
+    # choice and is honoured.
+    retention_scrub_fields = Column(JSON)
 
     # Instance-wide legal / litigation hold. When true, ALL retention purging is
     # suspended (nothing is deleted or anonymized) until it is lifted. Either the

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import func
 from geoalchemy2 import Geometry
-from datetime import datetime
+from datetime import datetime, timezone
 from app.db.session import Base
 # encryption is imported lazily in hybrid properties to avoid circular imports
 
@@ -286,12 +286,12 @@ class ServiceRequest(Base):
     delete_justification = Column(Text)
     
     # Vertex AI Analysis
-    vertex_ai_summary = Column(Text)  # AI-generated summary
-    vertex_ai_classification = Column(String(100))  # AI category classification
+    ai_summary = Column(Text)  # AI-generated summary
+    ai_classification = Column(String(100))  # AI category classification
     # NOTE: AI priority score is stored ONLY in ai_analysis JSON, not as a separate column
     # This ensures staff must explicitly accept AI suggestions before they take effect
     manual_priority_score = Column(Float)  # Human-approved priority (1-10), required for prioritization
-    vertex_ai_analyzed_at = Column(DateTime(timezone=True))
+    ai_analyzed_at = Column(DateTime(timezone=True))
     
     # Document retention / archival
     archived_at = Column(DateTime(timezone=True), index=True)  # When record was archived
@@ -345,7 +345,12 @@ class RequestAuditLog(Base):
     actor_name = Column(String(100))  # Username or "Resident"
     
     # When (Python-side default so the value is present at insert time for hashing)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), default=datetime.utcnow)
+    # `lambda` rather than `datetime.utcnow`, which is a *reference* and so
+    # survived the sweep that fixed the calls. SQLAlchemy invokes it at insert
+    # and gets a naive value for a timestamptz column -- and this one is hashed
+    # into the audit chain, so the offset would be baked into the entry.
+    created_at = Column(DateTime(timezone=True), server_default=func.now(),
+                        default=lambda: datetime.now(timezone.utc))
 
     # Additional context (JSON for flexibility)
     extra_data = Column(JSON)  # { substatus, completion_message, etc. }
@@ -374,7 +379,12 @@ class AuditAnchor(Base):
     __tablename__ = "audit_anchors"
 
     id = Column(Integer, primary_key=True, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), default=datetime.utcnow)
+    # `lambda` rather than `datetime.utcnow`, which is a *reference* and so
+    # survived the sweep that fixed the calls. SQLAlchemy invokes it at insert
+    # and gets a naive value for a timestamptz column -- and this one is hashed
+    # into the audit chain, so the offset would be baked into the entry.
+    created_at = Column(DateTime(timezone=True), server_default=func.now(),
+                        default=lambda: datetime.now(timezone.utc))
     head_hash = Column(String(64))   # latest RequestAuditLog.entry_hash at anchor time
     entry_count = Column(Integer)    # number of hashed entries at anchor time
 
@@ -462,7 +472,7 @@ def _request_audit_hash_chain(session, flush_context, instances):
     ).scalar()
     for row in pending:
         if row.created_at is None:
-            row.created_at = datetime.utcnow()
+            row.created_at = datetime.now(timezone.utc)
         row.previous_hash = running
         row.entry_hash = compute_request_audit_hash(row, running)
         running = row.entry_hash
@@ -504,6 +514,10 @@ class SystemSettings(Base):
     # this keeps the behaviour it already had. An empty list is a deliberate
     # choice and is honoured.
     retention_scrub_fields = Column(JSON)
+
+    # The town's own clock, for display only. Everything is stored in UTC and
+    # stays that way; this is what a clerk's screen converts into.
+    timezone = Column(String(64))
 
     # Instance-wide legal / litigation hold. When true, ALL retention purging is
     # suspended (nothing is deleted or anonymized) until it is lifted. Either the

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -314,10 +314,10 @@ class ServiceRequestDetailResponse(ServiceRequestResponse):
     delete_justification: Optional[str] = None
     custom_fields: Optional[Dict[str, Any]] = {}
     # Vertex AI Analysis (priority_score is in ai_analysis JSON only)
-    vertex_ai_summary: Optional[str] = None
-    vertex_ai_classification: Optional[str] = None
+    ai_summary: Optional[str] = None
+    ai_classification: Optional[str] = None
     manual_priority_score: Optional[float] = None  # Human-approved priority
-    vertex_ai_analyzed_at: Optional[datetime] = None
+    ai_analyzed_at: Optional[datetime] = None
 
 
 # ============ Manual Intake ============

--- a/backend/app/services/ai/azure_openai.py
+++ b/backend/app/services/ai/azure_openai.py
@@ -21,7 +21,10 @@ from app.services.ai.base import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_VERSION = "2024-06-01"
-DEFAULT_DEPLOYMENT = "gpt-4o-mini"
+# Kept in step with the catalog's default_model in registry.py; a test fails
+# if they drift. Two defaults for the same thing is how a town ends up on a
+# deployment the picker never offered.
+DEFAULT_DEPLOYMENT = "gpt-4.1-mini"
 
 
 class AzureOpenAIProvider(AIProvider):

--- a/backend/app/services/ai/model_discovery.py
+++ b/backend/app/services/ai/model_discovery.py
@@ -71,58 +71,89 @@ def model_is_available(models: List[Dict[str, str]], model_id: Optional[str]) ->
 # --------------------------- per-provider discovery --------------------------
 
 async def _discover_vertex(creds: Dict[str, str]) -> Optional[List[Dict[str, str]]]:
+    """List Vertex models, across the publishers we can actually call.
+
+    Model Garden carries Anthropic, Meta, Mistral and more alongside Gemini,
+    and a town on Vertex should be able to choose them. But only the ones with
+    a handler are offered: listing a publisher the caller cannot speak to gives
+    a clerk a model they can select, save, and watch fail at triage.
+    """
     project = creds.get("VERTEX_AI_PROJECT")
     if not project:
         return None
+    # Honoured, not hardcoded. A town that set a region did so for a reason,
+    # and this product is sold on compliance boundaries.
     location = creds.get("VERTEX_AI_LOCATION") or "global"
     sa_json = creds.get("VERTEX_AI_SERVICE_ACCOUNT_KEY")
 
     def _sync() -> Optional[List[Dict[str, str]]]:
         import json
+
         import google.auth
+        import httpx
         from google.auth.transport.requests import Request
         from google.oauth2 import service_account
-        import httpx
+
+        from app.services.ai.vertex_publishers import ANTHROPIC, GOOGLE, SUPPORTED_PUBLISHERS
 
         scopes = ["https://www.googleapis.com/auth/cloud-platform"]
         if sa_json:
-            info = json.loads(sa_json)
-            credentials = service_account.Credentials.from_service_account_info(info, scopes=scopes)
+            credentials = service_account.Credentials.from_service_account_info(
+                json.loads(sa_json), scopes=scopes)
         else:
             credentials, _ = google.auth.default(scopes=scopes)
         credentials.refresh(Request())
+        headers = {"Authorization": f"Bearer {credentials.token}"}
 
-        host = "aiplatform.googleapis.com" if location == "global" else f"{location}-aiplatform.googleapis.com"
-        url = f"https://{host}/v1/publishers/google/models"
         out: List[Dict[str, str]] = []
-        page_token = None
-        for _ in range(5):  # bound pagination
-            params = {"pageSize": 200}
-            if page_token:
-                params["pageToken"] = page_token
-            resp = httpx.get(url, params=params,
-                             headers={"Authorization": f"Bearer {credentials.token}"}, timeout=15.0)
-            resp.raise_for_status()
-            data = resp.json()
-            for m in data.get("publisherModels", []) or data.get("models", []):
-                name = m.get("name", "")
-                mid = name.split("/")[-1] if name else m.get("modelId", "")
-                # Gemini text-generation models only; drop embeddings/vision-only variants.
-                if not mid or "gemini" not in mid.lower():
-                    continue
-                if any(x in mid.lower() for x in ("embedding", "vision", "aqa")):
-                    continue
-                out.append({"id": mid, "label": mid})
-            page_token = data.get("nextPageToken")
-            if not page_token:
-                break
-        # de-dupe, stable
-        seen, uniq = set(), []
-        for m in out:
-            if m["id"] not in seen:
-                seen.add(m["id"])
-                uniq.append(m)
-        return uniq or None
+        seen = set()
+        failures = []
+        for publisher in SUPPORTED_PUBLISHERS:
+            # Anthropic models are not listed from the global endpoint.
+            region = location
+            if publisher == ANTHROPIC and region in ("", "global"):
+                region = "us-east5"
+            host = ("aiplatform.googleapis.com" if region in ("", "global")
+                    else f"{region}-aiplatform.googleapis.com")
+            url = f"https://{host}/v1/publishers/{publisher}/models"
+            page_token = None
+            try:
+                for _ in range(5):  # bound pagination
+                    params = {"pageSize": 200}
+                    if page_token:
+                        params["pageToken"] = page_token
+                    resp = httpx.get(url, params=params, headers=headers, timeout=15.0)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    for m in data.get("publisherModels", []) or data.get("models", []):
+                        name = m.get("name", "")
+                        mid = name.split("/")[-1] if name else m.get("modelId", "")
+                        if not mid or mid in seen:
+                            continue
+                        # Text generation only. An embedding or image model in
+                        # a triage picker is a choice that fails at request
+                        # time rather than at selection.
+                        if any(x in mid.lower() for x in ("embedding", "aqa", "imagen", "veo")):
+                            continue
+                        seen.add(mid)
+                        label = m.get("displayName") or mid
+                        prefix = "" if publisher == GOOGLE else f"{publisher.capitalize()} "
+                        out.append({
+                            "id": mid,
+                            "label": f"{prefix}{label}" if label == mid else f"{prefix}{label} ({mid})",
+                        })
+                    page_token = data.get("nextPageToken")
+                    if not page_token:
+                        break
+            except Exception as e:
+                # Recorded rather than swallowed. One publisher being
+                # unavailable is normal; all of them failing silently while the
+                # picker shows a short list is how a town concludes the product
+                # only supports Gemini.
+                failures.append(f"{publisher}: {type(e).__name__}")
+        if failures:
+            logger.info("[AI models] some Vertex publishers did not list: %s", ", ".join(failures))
+        return out or None
 
     return await asyncio.get_event_loop().run_in_executor(None, _sync)
 

--- a/backend/app/services/ai/registry.py
+++ b/backend/app/services/ai/registry.py
@@ -40,11 +40,18 @@ AI_CATALOG: Dict[str, Dict[str, Any]] = {
         "name": "Azure Government AI",
         "boundary": "Azure Government / GCC High (FedRAMP High / DoD)",
         "description": "Azure OpenAI (GPT models) in US government regions. Best for Microsoft/M365 states.",
+        # Azure addresses a model by the *deployment name* the town chose, not
+        # by the model name -- which is why discovery lists deployments. These
+        # are the conventional names, and they resolve only where a deployment
+        # was named to match; the moment credentials are saved, discovery
+        # replaces them with what the town actually has.
         "models": [
-            {"id": "gpt-4o-mini", "label": "GPT-4o mini (fast, cheap)"},
-            {"id": "gpt-4o", "label": "GPT-4o (higher quality)"},
+            {"id": "gpt-4.1-mini", "label": "GPT-4.1 mini (fast, cheap)"},
+            {"id": "gpt-4.1", "label": "GPT-4.1 (higher quality, long context)"},
+            {"id": "gpt-4o-mini", "label": "GPT-4o mini"},
+            {"id": "gpt-4o", "label": "GPT-4o"},
         ],
-        "default_model": "gpt-4o-mini",
+        "default_model": "gpt-4.1-mini",
         "credential_fields": [
             {"key": "AZURE_OPENAI_ENDPOINT", "label": "Azure OpenAI Endpoint", "secret": False},
             {"key": "AZURE_OPENAI_API_KEY", "label": "API Key", "secret": True},

--- a/backend/app/services/ai/vertex_publishers.py
+++ b/backend/app/services/ai/vertex_publishers.py
@@ -1,0 +1,149 @@
+"""Vertex serves more than Gemini, and each publisher speaks differently.
+
+Model Garden offers Anthropic, Meta, Mistral and others alongside Google's own
+models, and a town on Vertex should be able to pick them. They are not
+interchangeable at the wire, though: Gemini takes `:generateContent` with
+`contents`/`parts`, Anthropic takes `:rawPredict` with an Anthropic-shaped body
+and its own `anthropic_version`, and the responses come back in different
+shapes too.
+
+The rule this module exists to enforce: **only offer what we can call.**
+
+Listing every publisher in the picker while the caller only speaks Gemini gives
+a clerk a model they can select, save, and watch fail at triage time with a 404
+-- the same silent-failure shape this console keeps being fixed for. So
+discovery asks here which publishers are supported, and adding one means adding
+a handler rather than adding a string to a list.
+
+Pure: builds URLs and payloads and parses responses. No network, no
+credentials, so all of it runs in CI.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+GOOGLE = "google"
+ANTHROPIC = "anthropic"
+
+# Publishers with a request/response handler below. Meta, Mistral, AI21, Cohere
+# and xAI are real on Vertex and deliberately absent: they are served through
+# the OpenAI-compatible MaaS endpoint, which is a third shape, and listing them
+# before that shape is implemented and tested would be offering models that
+# cannot be called.
+SUPPORTED_PUBLISHERS: Tuple[str, ...] = (GOOGLE, ANTHROPIC)
+
+# How a model id announces its publisher.
+#
+# Vertex does not return the publisher alongside the id in a form that survives
+# being stored as a single `AI_MODEL` string, so it is inferred from the id --
+# `gemini-3.5-flash` is Google's, `claude-sonnet-4@20250514` is Anthropic's.
+# Unknown prefixes fall back to Google, which is where every id came from
+# before this existed.
+_PREFIXES = {
+    "gemini": GOOGLE,
+    "gemma": GOOGLE,
+    "medlm": GOOGLE,
+    "claude": ANTHROPIC,
+}
+
+
+def publisher_for(model_id: Optional[str]) -> str:
+    name = (model_id or "").strip().lower().lstrip("/")
+    # An explicitly qualified id wins over the prefix guess.
+    if "/" in name:
+        head = name.split("/", 1)[0]
+        if head in SUPPORTED_PUBLISHERS:
+            return head
+    for prefix, publisher in _PREFIXES.items():
+        if name.startswith(prefix):
+            return publisher
+    return GOOGLE
+
+
+def bare_model_id(model_id: str) -> str:
+    """`anthropic/claude-x` -> `claude-x`. The URL carries the publisher."""
+    return model_id.split("/", 1)[1] if "/" in model_id else model_id
+
+
+def is_supported(model_id: Optional[str]) -> bool:
+    return publisher_for(model_id) in SUPPORTED_PUBLISHERS
+
+
+def endpoint_for(model_id: str, project: str, location: str = "global") -> str:
+    """Where to POST.
+
+    Anthropic models are not served from the `global` endpoint, so a request
+    built for `global` fails with a 404 that reads like a wrong model name. The
+    location falls back to a real region for those.
+    """
+    publisher = publisher_for(model_id)
+    model = bare_model_id(model_id)
+    if publisher == ANTHROPIC:
+        region = location if location and location != "global" else "us-east5"
+        host = f"{region}-aiplatform.googleapis.com"
+        return (f"https://{host}/v1/projects/{project}/locations/{region}"
+                f"/publishers/anthropic/models/{model}:rawPredict")
+    host = "aiplatform.googleapis.com" if location in ("", "global", None) else f"{location}-aiplatform.googleapis.com"
+    loc = location or "global"
+    return (f"https://{host}/v1/projects/{project}/locations/{loc}"
+            f"/publishers/google/models/{model}:generateContent")
+
+
+def _image_parts_google(images: Optional[List[Dict[str, str]]]) -> List[Dict[str, Any]]:
+    return [{"inline_data": {"mime_type": i["mime_type"], "data": i["data"]}} for i in images or []]
+
+
+def _image_parts_anthropic(images: Optional[List[Dict[str, str]]]) -> List[Dict[str, Any]]:
+    return [{"type": "image", "source": {"type": "base64",
+                                         "media_type": i["mime_type"], "data": i["data"]}}
+            for i in images or []]
+
+
+def build_payload(model_id: str, prompt: str,
+                  images: Optional[List[Dict[str, str]]] = None,
+                  max_tokens: int = 4096) -> Dict[str, Any]:
+    """The body each publisher expects. Same prompt, different envelope."""
+    if publisher_for(model_id) == ANTHROPIC:
+        content: List[Dict[str, Any]] = _image_parts_anthropic(images)
+        content.append({"type": "text", "text": prompt})
+        return {
+            # Required by Vertex's Anthropic endpoint, and not the model
+            # version -- it is the shape of the request.
+            "anthropic_version": "vertex-2023-10-16",
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": max_tokens,
+            "temperature": 0.2,
+        }
+    parts: List[Dict[str, Any]] = _image_parts_google(images)
+    parts.append({"text": prompt})
+    return {
+        "contents": [{"role": "user", "parts": parts}],
+        "generationConfig": {
+            "temperature": 0.2,
+            "topP": 0.8,
+            "maxOutputTokens": max_tokens,
+            "thinkingConfig": {"includeThoughts": True, "thinkingLevel": "HIGH"},
+        },
+        "safetySettings": [
+            {"category": c, "threshold": "BLOCK_NONE"} for c in (
+                "HARM_CATEGORY_HARASSMENT", "HARM_CATEGORY_HATE_SPEECH",
+                "HARM_CATEGORY_SEXUALLY_EXPLICIT", "HARM_CATEGORY_DANGEROUS_CONTENT",
+            )
+        ],
+    }
+
+
+def extract_text(model_id: str, result: Dict[str, Any]) -> str:
+    """Pull the answer out, whatever shape it arrived in."""
+    if publisher_for(model_id) == ANTHROPIC:
+        return "".join(
+            block.get("text", "")
+            for block in (result.get("content") or [])
+            if block.get("type") == "text"
+        )
+    text = ""
+    for candidate in (result.get("candidates") or [])[:1]:
+        for part in candidate.get("content", {}).get("parts", []):
+            # Skip "thought" parts -- only the answer carries the JSON.
+            if "text" in part and not part.get("thought"):
+                text += part["text"]
+    return text

--- a/backend/app/services/api_usage.py
+++ b/backend/app/services/api_usage.py
@@ -11,7 +11,7 @@ Supports:
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any, List
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -186,7 +186,7 @@ async def get_usage_summary(
     """
     from app.models import ApiUsageRecord
     
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
     
     query = (
         select(
@@ -292,7 +292,7 @@ async def get_daily_usage(
     """
     from app.models import ApiUsageRecord
     
-    since = datetime.utcnow() - timedelta(days=days)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
     
     query = (
         select(

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -5,7 +5,7 @@ Implements NIST 800-53 AU-2, AU-3, AU-6, AU-9, AU-12 controls.
 
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy import select, desc
@@ -77,7 +77,7 @@ class AuditService:
             "username": username,
             "user_id": user_id,
             "ip_address": ip_address,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "session_id": session_id,
             "details": details or {}
         }

--- a/backend/app/services/backup_service.py
+++ b/backend/app/services/backup_service.py
@@ -9,7 +9,7 @@ import os
 import logging
 import tempfile
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 import boto3
 from botocore.config import Config as BotoConfig
@@ -191,7 +191,7 @@ async def create_backup() -> Dict[str, Any]:
     if not config:
         return {"status": "error", "message": "Backup not configured - add S3 credentials in Admin Console → Secrets"}
     
-    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     backup_name = f"{BACKUP_PREFIX}{timestamp}{BACKUP_EXTENSION}"
     
     try:
@@ -226,7 +226,7 @@ async def create_backup() -> Dict[str, Any]:
                         'ContentType': 'application/octet-stream',
                         'Metadata': {
                             'unencrypted-size': str(dump_size),
-                            'created-at': datetime.utcnow().isoformat()
+                            'created-at': datetime.now(timezone.utc).isoformat()
                         }
                     }
                 )
@@ -238,7 +238,7 @@ async def create_backup() -> Dict[str, Any]:
                 "backup_name": backup_name,
                 "size_bytes": encrypted_size,
                 "unencrypted_size_bytes": dump_size,
-                "created_at": datetime.utcnow().isoformat(),
+                "created_at": datetime.now(timezone.utc).isoformat(),
                 "bucket": config["BACKUP_S3_BUCKET"]
             }
             
@@ -271,13 +271,13 @@ async def list_backups() -> Dict[str, Any]:
                     ts_str = name.replace(BACKUP_PREFIX, "").replace(BACKUP_EXTENSION, "")
                     created_at = datetime.strptime(ts_str, "%Y%m%d_%H%M%S")
                 except Exception:
-                    created_at = obj.get('LastModified', datetime.utcnow())
+                    created_at = obj.get('LastModified', datetime.now(timezone.utc))
                 
                 backups.append({
                     "name": name,
                     "size_bytes": obj['Size'],
                     "created_at": created_at.isoformat() if isinstance(created_at, datetime) else str(created_at),
-                    "age_days": (datetime.utcnow() - created_at).days if isinstance(created_at, datetime) else 0
+                    "age_days": (datetime.now(timezone.utc) - created_at).days if isinstance(created_at, datetime) else 0
                 })
         
         # Sort by date, newest first
@@ -342,7 +342,7 @@ async def cleanup_old_backups(retention_days: int = None) -> Dict[str, Any]:
             logger.warning(f"Could not get retention policy, using 7 years: {e}")
             retention_days = 7 * 365  # Default to 7 years
     
-    cutoff = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     
     try:
         result = await list_backups()
@@ -531,7 +531,7 @@ async def restore_backup(backup_name: str) -> Dict[str, Any]:
                 "backup_name": backup_name,
                 "encrypted_size_bytes": encrypted_size,
                 "decrypted_size_bytes": decrypted_size,
-                "restored_at": datetime.utcnow().isoformat(),
+                "restored_at": datetime.now(timezone.utc).isoformat(),
                 "warning": "Database has been restored. You may need to restart the application."
             }
             

--- a/backend/app/services/proactive_health.py
+++ b/backend/app/services/proactive_health.py
@@ -161,7 +161,7 @@ async def _db_connection_check(db) -> Dict[str, Any]:
 
 async def _backup_age_check() -> Dict[str, Any]:
     try:
-        from datetime import datetime
+        from datetime import datetime, timezone
         from app.services.backup_service import get_backup_status
         status_info = await get_backup_status()
         last = status_info.get("last_backup") if isinstance(status_info, dict) else None
@@ -174,7 +174,7 @@ async def _backup_age_check() -> Dict[str, Any]:
         created = last["created_at"]
         if isinstance(created, str):
             created = datetime.fromisoformat(created.replace("Z", "").replace("+00:00", ""))
-        hours = (datetime.utcnow() - created).total_seconds() / 3600
+        hours = (datetime.now(timezone.utc) - created).total_seconds() / 3600
         status = classify_metric(round(hours, 1), warn=36, crit=72)
         return _check(
             "backup", "Backup freshness", status, round(hours, 1),
@@ -343,12 +343,12 @@ async def collect_checks(db) -> List[Dict[str, Any]]:
 
 async def evaluate(db) -> Dict[str, Any]:
     """Full proactive-health evaluation for the API/alerting layers."""
-    from datetime import datetime
+    from datetime import datetime, timezone
     checks = await collect_checks(db)
     overall = rollup_status(checks)
     return {
         "overall_status": overall,
         "summary": clerk_summary(overall),
         "checks": checks,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/app/services/retention_scrub.py
+++ b/backend/app/services/retention_scrub.py
@@ -1,0 +1,220 @@
+"""What a retention run removes, and what it is honest to call that.
+
+Two things were wrong with the old behaviour beyond the AI leak.
+
+The list was fixed in code. A town's retention obligations are set by its own
+counsel and its state's records law, and this decided for them: names, email,
+phone, description, staff notes and photos, always, with no say. A town that
+must keep descriptions for a public-records index had no way to say so, and one
+that must also remove resident comments had no way to ask.
+
+And it was called anonymisation. Anonymising means removing what ties data to a
+person. Blanking the description of a pothole report is not that -- it is
+redaction, and the two are not interchangeable words when the difference is
+what a town tells a judge. The mode is `redact` now; `anonymize` is still
+accepted on the way in, because it is written in databases that already exist.
+
+Pure, and free of SQLAlchemy, so CI runs it. The comment tables are handled by
+the caller, which needs a session; everything decidable without one is here.
+"""
+
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+REDACT = "redact"
+DELETE = "delete"
+
+# What towns already have stored. Read, never written.
+LEGACY_MODES = {"anonymize": REDACT}
+
+
+def normalise_mode(mode: Optional[str]) -> str:
+    """Accept what is in the database, return what things are now called."""
+    if not mode:
+        return REDACT
+    mode = str(mode).strip().lower()
+    return LEGACY_MODES.get(mode, mode)
+
+
+# ---------------------------------------------------------------------------
+# The catalog
+# ---------------------------------------------------------------------------
+#
+# `default` reproduces exactly what the old fixed list did, so upgrading changes
+# nothing about what a town's next run removes. A retention policy that quietly
+# starts keeping or destroying more than it did yesterday is the one change this
+# module must never make on its own.
+
+SCRUB_FIELDS: List[Dict[str, Any]] = [
+    {
+        "id": "name",
+        "label": "Reporter's name",
+        "detail": "First and last name are replaced with [ARCHIVED].",
+        "default": True,
+    },
+    {
+        "id": "email",
+        "label": "Reporter's email address",
+        "detail": "Replaced with a placeholder that cannot receive mail.",
+        "default": True,
+    },
+    {
+        "id": "phone",
+        "label": "Reporter's phone number",
+        "detail": "Removed.",
+        "default": True,
+    },
+    {
+        "id": "description",
+        "label": "What the resident wrote",
+        "detail": "The free-text description. Residents often put names, phone "
+                  "numbers and neighbours' details in here.",
+        "default": True,
+    },
+    {
+        "id": "staff_notes",
+        "label": "Internal staff notes",
+        "detail": "Notes staff added to the request.",
+        "default": True,
+    },
+    {
+        "id": "media",
+        "label": "Photos",
+        "detail": "Photo links are cleared. The files themselves are removed by "
+                  "the storage cleanup that follows.",
+        "default": True,
+    },
+    {
+        "id": "ai_analysis",
+        "label": "AI analysis and summary",
+        "detail": "The model's writing about the report, which quotes it. The "
+                  "category and priority score are kept so the record still counts.",
+        "default": True,
+    },
+    {
+        "id": "comments",
+        "label": "Comments on the request",
+        "detail": "Both resident and staff comments. Off by default because "
+                  "this was never removed before.",
+        "default": False,
+    },
+    {
+        "id": "address",
+        "label": "Street address",
+        "detail": "The address text. The map pin is a separate choice below.",
+        "default": False,
+    },
+    {
+        "id": "coordinates",
+        "label": "Map location",
+        "detail": "Removes the pin entirely. The request disappears from maps "
+                  "and from anything counted by area.",
+        "default": False,
+    },
+]
+
+FIELD_IDS: Set[str] = {f["id"] for f in SCRUB_FIELDS}
+DEFAULT_FIELDS: List[str] = [f["id"] for f in SCRUB_FIELDS if f["default"]]
+
+# Keys in `ai_analysis` that hold no resident text.
+#
+# An allow-list rather than a list of things to strip, because the failure
+# directions are not symmetric: a new key nobody remembers to add here is
+# dropped from an archived record, which costs a statistic. A new key nobody
+# remembers to add to a strip-list is retained forever, which is the thing the
+# retention policy exists to prevent.
+AI_ANALYSIS_KEEP = frozenset({
+    "priority_score",
+    "quantitative_metrics",
+    "recommended_response_time",
+})
+
+
+def normalise_fields(fields: Optional[Iterable[str]]) -> List[str]:
+    """Validate a stored or submitted selection.
+
+    `None` means "never configured", which is the defaults rather than nothing:
+    a town upgrading into this feature keeps the behaviour it already had. An
+    empty list is a deliberate choice and is honoured -- it means redact nothing,
+    which is a legitimate thing to want alongside a delete-mode policy.
+    """
+    if fields is None:
+        return list(DEFAULT_FIELDS)
+    return [f for f in dict.fromkeys(fields) if f in FIELD_IDS]
+
+
+def scrub_ai_analysis(record: Any) -> None:
+    """Take the model's writing about a report out with the report.
+
+    The summary is the description in different words, and where a resident put
+    their name or a phone number in the description the model repeated it.
+    `priority_justification` and `qualitative_analysis` quote the report;
+    `_error` carries whatever the provider said, which has included the prompt.
+    """
+    analysis = getattr(record, "ai_analysis", None)
+    if isinstance(analysis, dict):
+        record.ai_analysis = {k: v for k, v in analysis.items() if k in AI_ANALYSIS_KEEP}
+    elif analysis is not None:
+        # Not a dict, so nothing inside it can be judged safe.
+        record.ai_analysis = None
+    for attr in ("ai_summary", "vertex_ai_summary"):
+        if hasattr(record, attr):
+            setattr(record, attr, None)
+
+
+def apply_scrub(record: Any, fields: Optional[Iterable[str]] = None) -> List[str]:
+    """Clear the chosen fields on one record. Returns what was actually cleared.
+
+    Only the fields asked for. The temptation is to remove "a bit more, to be
+    safe", and that is how a town loses the public-records index it is legally
+    obliged to keep.
+    """
+    chosen = set(normalise_fields(fields))
+    done: List[str] = []
+
+    if "name" in chosen:
+        record.first_name = "[ARCHIVED]"
+        record.last_name = "[ARCHIVED]"
+        done.append("name")
+    if "email" in chosen:
+        record.email = f"archived-{getattr(record, 'id', 0)}@retention.local"
+        done.append("email")
+    if "phone" in chosen:
+        record.phone = None
+        done.append("phone")
+    if "description" in chosen:
+        record.description = "[Content archived per retention policy]"
+        done.append("description")
+    if "staff_notes" in chosen:
+        record.staff_notes = None
+        done.append("staff_notes")
+    if "media" in chosen:
+        record.media_urls = []
+        done.append("media")
+    if "ai_analysis" in chosen:
+        scrub_ai_analysis(record)
+        done.append("ai_analysis")
+    if "address" in chosen:
+        record.address = None
+        done.append("address")
+    if "coordinates" in chosen:
+        record.lat = None
+        record.long = None
+        # PostGIS geometry, kept in step with the columns beside it.
+        if hasattr(record, "location"):
+            record.location = None
+        done.append("coordinates")
+
+    # `comments` is deliberately absent: they live in another table and need a
+    # session. The caller handles it, and `describe_selection` still lists it so
+    # the admin sees one coherent choice.
+    return done
+
+
+def describe_selection(fields: Optional[Iterable[str]] = None) -> List[Dict[str, Any]]:
+    """The catalog with the current choice marked, for the settings screen."""
+    chosen = set(normalise_fields(fields))
+    return [{**f, "selected": f["id"] in chosen} for f in SCRUB_FIELDS]

--- a/backend/app/services/retention_scrub.py
+++ b/backend/app/services/retention_scrub.py
@@ -25,10 +25,29 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 # ---------------------------------------------------------------------------
 
 REDACT = "redact"
-DELETE = "delete"
+PURGE = "purge"
+
+# Hard deletion is gone, and this is why.
+#
+# `delete` called `db.delete(record)` while `request_audit_logs` and
+# `request_comments` hold NOT NULL foreign keys back to it with no cascade, so
+# SQLAlchemy tried to disown the children and the flush failed -- on every
+# record, because submitting one writes an audit entry. Each failure was caught
+# per record and the run reported success with nothing archived. A town on a
+# delete policy was told retention was running and nothing was ever removed.
+#
+# Making it succeed meant deleting the audit rows, and those are a hash chain
+# the compliance page advertises as tamper-evident. Removing rows from the
+# middle makes the verify endpoint report tampering -- correctly -- for a
+# deletion that was entirely legitimate.
+#
+# So the strongest mode clears every field instead. The row survives as a shell
+# that still counts in statistics, the personal data is gone, and the audit
+# chain stays whole and honest.
+MODES = (REDACT, PURGE)
 
 # What towns already have stored. Read, never written.
-LEGACY_MODES = {"anonymize": REDACT}
+LEGACY_MODES = {"anonymize": REDACT, "delete": PURGE}
 
 
 def normalise_mode(mode: Optional[str]) -> str:
@@ -117,6 +136,7 @@ SCRUB_FIELDS: List[Dict[str, Any]] = [
 ]
 
 FIELD_IDS: Set[str] = {f["id"] for f in SCRUB_FIELDS}
+FIELD_IDS_ORDERED: List[str] = [f["id"] for f in SCRUB_FIELDS]
 DEFAULT_FIELDS: List[str] = [f["id"] for f in SCRUB_FIELDS if f["default"]]
 
 # Keys in `ai_analysis` that hold no resident text.
@@ -165,6 +185,17 @@ def scrub_ai_analysis(record: Any) -> None:
     for attr in ("ai_summary", "vertex_ai_summary"):
         if hasattr(record, attr):
             setattr(record, attr, None)
+
+
+def fields_for_mode(mode: Optional[str], fields: Optional[Iterable[str]] = None) -> List[str]:
+    """Purge means everything. Redact means what the town chose.
+
+    One place to ask, so a caller cannot apply a purge with a redact-sized list
+    and report it as a purge.
+    """
+    if normalise_mode(mode) == PURGE:
+        return list(FIELD_IDS_ORDERED)
+    return normalise_fields(fields)
 
 
 def apply_scrub(record: Any, fields: Optional[Iterable[str]] = None) -> List[str]:

--- a/backend/app/services/retention_scrub.py
+++ b/backend/app/services/retention_scrub.py
@@ -160,6 +160,8 @@ def scrub_ai_analysis(record: Any) -> None:
     elif analysis is not None:
         # Not a dict, so nothing inside it can be judged safe.
         record.ai_analysis = None
+    # The legacy name is still listed so this keeps working against an ORM
+    # object from a deployment that has not run the rename migration yet.
     for attr in ("ai_summary", "vertex_ai_summary"):
         if hasattr(record, attr):
             setattr(record, attr, None)

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -12,9 +12,8 @@ Key features:
 
 import logging
 
-from app.services.retention_scrub import (  # noqa: F401
-    AI_ANALYSIS_KEEP, PURGE, REDACT, apply_scrub, fields_for_mode,
-    normalise_mode, scrub_ai_analysis,
+from app.services.retention_scrub import (
+    REDACT, apply_scrub, fields_for_mode, normalise_mode,
 )
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict, Any

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -232,7 +232,7 @@ async def get_records_for_archival(
     
     policy = get_retention_policy(state_code)
     retention_days = override_days if override_days else policy["retention_days"]
-    cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
     
     # Query closed records older than retention period, not already archived,
     # not deleted, and not under legal hold
@@ -392,7 +392,7 @@ async def get_retention_stats(
     
     policy = get_retention_policy(state_code)
     retention_days = override_days if override_days else policy["retention_days"]
-    cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
     
     # Count records eligible for archival
     eligible_query = select(func.count(ServiceRequest.id)).where(

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -13,7 +13,7 @@ Key features:
 import logging
 
 from app.services.retention_scrub import (  # noqa: F401
-    AI_ANALYSIS_KEEP, DELETE, REDACT, apply_scrub, normalise_fields,
+    AI_ANALYSIS_KEEP, PURGE, REDACT, apply_scrub, fields_for_mode,
     normalise_mode, scrub_ai_analysis,
 )
 from datetime import datetime, timedelta, timezone
@@ -269,7 +269,10 @@ async def record_archival(db: AsyncSession, record: Any, action: str,
 
         db.add(RequestAuditLog(
             service_request_id=record.id,
-            action="retention_archived" if action == "anonymized" else "retention_deleted",
+            # The mode is in the action, so the trail distinguishes a
+            # targeted redaction from a full purge without anyone reading
+            # extra_data to find out which happened.
+            action=f"retention_{action}",
             new_value=action,
             actor_type="staff",
             actor_name="Retention policy",
@@ -331,44 +334,34 @@ async def archive_record(
             "record_id": record_id
         }
     
-    if normalise_mode(archive_mode) == DELETE:
-        # Hard delete - remove from database entirely.
-        #
-        # The timeline entry goes in first and is deliberately left behind: it
-        # records that a request existed and was destroyed under policy, which
-        # is the only trace an auditor can be shown afterwards. See the note in
-        # record_archival about the audit chain.
-        await record_archival(db, record, "deleted")
-        await db.flush()
-        await db.delete(record)
-        await db.commit()
-        return {
-            "status": "deleted",
-            "record_id": record_id,
-            "service_request_id": record.service_request_id
-        }
-    else:
-        # Redact -- clear the fields this town chose, and nothing else.
-        cleared = apply_scrub(record, scrub_fields)
-        if "comments" in set(normalise_fields(scrub_fields)):
-            await scrub_comments(db, record.id)
-            cleared.append("comments")
-        record.archived_at = datetime.now(timezone.utc)
+    # Redact clears the fields this town chose. Purge clears all of them and
+    # leaves the row as a shell that still counts. Neither removes the record:
+    # see the note in retention_scrub about why hard deletion is gone.
+    chosen = fields_for_mode(archive_mode, scrub_fields)
+    cleared = apply_scrub(record, chosen)
+    if "comments" in set(chosen):
+        await scrub_comments(db, record.id)
+        cleared.append("comments")
+    record.archived_at = datetime.now(timezone.utc)
 
-        await db.flush()
-        await record_archival(db, record, "anonymized", cleared)
-        await db.commit()
-        
-        return {
-            # Kept as "anonymized" in the return value on purpose: callers
-            # count on this string, and renaming what the run *is* called is a
-            # separate change from renaming what it *did*.
-            "status": "anonymized",
-            "record_id": record_id,
-            "service_request_id": record.service_request_id,
-            "archived_at": record.archived_at.isoformat(),
-            "cleared": cleared,
-        }
+    await db.flush()
+    # Into the hash chain, via the insert listener on RequestAuditLog. A
+    # redaction that leaves no trace is indistinguishable from data loss, and
+    # this is the trail an auditor is shown when asked what happened to a
+    # record that is now mostly blank.
+    await record_archival(db, record, normalise_mode(archive_mode), cleared)
+    await db.commit()
+
+    return {
+        # Callers count on this string; renaming what the run is *called* is a
+        # separate change from renaming what it *did*.
+        "status": "anonymized",
+        "mode": normalise_mode(archive_mode),
+        "record_id": record_id,
+        "service_request_id": record.service_request_id,
+        "archived_at": record.archived_at.isoformat(),
+        "cleared": cleared,
+    }
 
 
 async def get_retention_stats(

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -11,7 +11,12 @@ Key features:
 """
 
 import logging
-from datetime import datetime, timedelta
+
+from app.services.retention_scrub import (  # noqa: F401
+    AI_ANALYSIS_KEEP, DELETE, REDACT, apply_scrub, normalise_fields,
+    normalise_mode, scrub_ai_analysis,
+)
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict, Any
 from sqlalchemy import select, and_
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -247,10 +252,55 @@ async def get_records_for_archival(
     return result.scalars().all()
 
 
+
+async def record_archival(db: AsyncSession, record: Any, action: str,
+                          cleared: Optional[List[str]] = None) -> None:
+    """Leave the archival itself on the request's timeline.
+
+    A record whose contents changed with nothing saying why reads like data
+    loss rather than policy. It is also the answer to "did this actually run",
+    which until now could only be inferred from a field going blank.
+
+    Best-effort: the timeline entry is bookkeeping and must never be the reason
+    a retention run fails to archive.
+    """
+    try:
+        from app.models import RequestAuditLog
+
+        db.add(RequestAuditLog(
+            service_request_id=record.id,
+            action="retention_archived" if action == "anonymized" else "retention_deleted",
+            new_value=action,
+            actor_type="staff",
+            actor_name="Retention policy",
+            extra_data={"mode": action, "cleared": cleared or []},
+        ))
+    except Exception:  # pragma: no cover - bookkeeping only
+        logger.warning("[Retention] could not write the timeline entry for %s", record.id)
+
+
+async def scrub_comments(db: AsyncSession, record_id: int) -> int:
+    """Clear the text of every comment on a request.
+
+    The rows stay. A deleted comment leaves a gap in a conversation that staff
+    and residents both remember having, and the count is part of the record.
+    Only the words go.
+    """
+    from app.models import RequestComment
+
+    rows = (await db.execute(
+        select(RequestComment).where(RequestComment.service_request_id == record_id)
+    )).scalars().all()
+    for row in rows:
+        row.content = "[Comment archived per retention policy]"
+    return len(rows)
+
+
 async def archive_record(
     db: AsyncSession,
     record_id: int,
-    archive_mode: str = "anonymize"
+    archive_mode: str = REDACT,
+    scrub_fields: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Archive a record by anonymizing PII or marking for deletion.
@@ -281,8 +331,15 @@ async def archive_record(
             "record_id": record_id
         }
     
-    if archive_mode == "delete":
-        # Hard delete - remove from database entirely
+    if normalise_mode(archive_mode) == DELETE:
+        # Hard delete - remove from database entirely.
+        #
+        # The timeline entry goes in first and is deliberately left behind: it
+        # records that a request existed and was destroyed under policy, which
+        # is the only trace an auditor can be shown afterwards. See the note in
+        # record_archival about the audit chain.
+        await record_archival(db, record, "deleted")
+        await db.flush()
         await db.delete(record)
         await db.commit()
         return {
@@ -291,23 +348,26 @@ async def archive_record(
             "service_request_id": record.service_request_id
         }
     else:
-        # Anonymize - remove PII but keep statistical data
-        record.first_name = "[ARCHIVED]"
-        record.last_name = "[ARCHIVED]"
-        record.email = f"archived-{record.id}@retention.local"
-        record.phone = None
-        record.description = "[Content archived per retention policy]"
-        record.staff_notes = None
-        record.media_urls = []
-        record.archived_at = datetime.utcnow()
-        
+        # Redact -- clear the fields this town chose, and nothing else.
+        cleared = apply_scrub(record, scrub_fields)
+        if "comments" in set(normalise_fields(scrub_fields)):
+            await scrub_comments(db, record.id)
+            cleared.append("comments")
+        record.archived_at = datetime.now(timezone.utc)
+
+        await db.flush()
+        await record_archival(db, record, "anonymized", cleared)
         await db.commit()
         
         return {
+            # Kept as "anonymized" in the return value on purpose: callers
+            # count on this string, and renaming what the run *is* called is a
+            # separate change from renaming what it *did*.
             "status": "anonymized",
             "record_id": record_id,
             "service_request_id": record.service_request_id,
-            "archived_at": record.archived_at.isoformat()
+            "archived_at": record.archived_at.isoformat(),
+            "cleared": cleared,
         }
 
 

--- a/backend/app/services/sla.py
+++ b/backend/app/services/sla.py
@@ -66,7 +66,7 @@ def classify(
         return "met" if elapsed <= sla_hours else "breached"
 
     # Still open — measure against the clock.
-    reference = now or datetime.utcnow()
+    reference = now or datetime.now(timezone.utc)
     age = hours_between(requested_at, reference)
     if age is None:
         return "no_sla"

--- a/backend/app/services/town_time.py
+++ b/backend/app/services/town_time.py
@@ -1,0 +1,116 @@
+"""The town's clock, without moving what is stored.
+
+Every timestamp column in this schema is `timestamptz`, so the database hands
+back aware datetimes in UTC. The Python side was building naive ones with
+`datetime.utcnow()` -- 73 of them -- and psycopg interprets a naive value in the
+*session's* timezone. On a database that is not set to UTC, every timestamp
+written was silently offset by hours, and nothing would have said so: the
+numbers all look plausible.
+
+That is fixed by storing aware UTC everywhere. This module is the other half:
+UTC is right for storage and wrong for a person. "Closed at 02:14" means
+nothing to a clerk in New Jersey looking at a report closed just before ten
+last night, and an SLA that turns over at midnight UTC turns over at 7pm local,
+which is the sort of thing that is only noticed during an audit.
+
+So: store UTC, show the town's time. The town says which zone it is in; this
+validates that answer and converts for display.
+
+Pure, and dependency-free apart from the standard library's own zone database.
+"""
+
+from datetime import datetime, timezone, tzinfo
+from typing import Optional
+
+try:  # pragma: no cover - available on every supported Python
+    from zoneinfo import ZoneInfo, available_timezones
+except ImportError:  # pragma: no cover
+    ZoneInfo = None  # type: ignore
+    available_timezones = None  # type: ignore
+
+# Not a guess about where any particular town is. UTC is the honest default for
+# a deployment that has not said, because it is what is stored -- showing a time
+# that matches the database is better than showing one confidently shifted into
+# a zone nobody chose.
+DEFAULT_TIMEZONE = "UTC"
+
+# Offered first in the picker. Not a restriction: every zone the platform's
+# Python knows about is accepted, because a town that needs Guam should not be
+# told it is unsupported.
+COMMON_TIMEZONES = [
+    "America/New_York",
+    "America/Chicago",
+    "America/Denver",
+    "America/Phoenix",
+    "America/Los_Angeles",
+    "America/Anchorage",
+    "Pacific/Honolulu",
+    "America/Puerto_Rico",
+    "UTC",
+]
+
+
+def is_valid_timezone(name: Optional[str]) -> bool:
+    if not name or not isinstance(name, str):
+        return False
+    if ZoneInfo is None:  # pragma: no cover
+        return name == "UTC"
+    try:
+        ZoneInfo(name)
+        return True
+    except Exception:
+        return False
+
+
+def normalise_timezone(name: Optional[str]) -> str:
+    """What to store. An unrecognised zone falls back rather than raising.
+
+    A bad value in the database must not be able to take the whole console
+    down; it should show UTC and let somebody fix it.
+    """
+    return name if is_valid_timezone(name) else DEFAULT_TIMEZONE
+
+
+def town_tz(name: Optional[str]) -> tzinfo:
+    if ZoneInfo is None:  # pragma: no cover
+        return timezone.utc
+    try:
+        return ZoneInfo(normalise_timezone(name))
+    except Exception:  # pragma: no cover
+        return timezone.utc
+
+
+def to_town(moment: Optional[datetime], name: Optional[str]) -> Optional[datetime]:
+    """Convert a stored instant into the town's wall clock.
+
+    A naive input is assumed to be UTC, which is what everything in this
+    codebase means by a naive datetime -- and saying so here beats each caller
+    guessing differently.
+    """
+    if moment is None:
+        return None
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(town_tz(name))
+
+
+def format_town(moment: Optional[datetime], name: Optional[str],
+                fmt: str = "%d %b %Y, %H:%M %Z") -> str:
+    local = to_town(moment, name)
+    return local.strftime(fmt) if local else ""
+
+
+def offset_label(name: Optional[str], at: Optional[datetime] = None) -> str:
+    """"UTC-04:00" for the settings screen, computed at a real instant.
+
+    Not from a table: half the zones this matters for observe daylight saving,
+    so the offset depends on when you ask.
+    """
+    moment = (at or datetime.now(timezone.utc)).astimezone(town_tz(name))
+    delta = moment.utcoffset()
+    if delta is None:  # pragma: no cover
+        return "UTC"
+    total = int(delta.total_seconds())
+    sign = "+" if total >= 0 else "-"
+    total = abs(total)
+    return f"UTC{sign}{total // 3600:02d}:{(total % 3600) // 60:02d}"

--- a/backend/app/services/vertex_ai_service.py
+++ b/backend/app/services/vertex_ai_service.py
@@ -9,6 +9,7 @@ This service analyzes service requests using Google's Gemini model to provide:
 """
 
 import json
+import os
 import re
 import logging
 from datetime import datetime
@@ -263,62 +264,30 @@ async def analyze_with_gemini(
         # Refresh the credentials
         credentials.refresh(Request())
         
-        # Build the API endpoint
-        # Gemini 3 models are currently available on global endpoints
+        # Which publisher, and therefore which protocol.
+        #
+        # Model Garden serves Anthropic alongside Google, and they are not
+        # interchangeable at the wire: different path, different verb,
+        # different body, different response shape. Building a Gemini request
+        # for a Claude model produces a 404 that reads like a wrong model name.
+        from app.services.ai import vertex_publishers as vp
+
         model_id = model or "gemini-3.1-flash-lite"
-        endpoint = f"https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/global/publishers/google/models/{model_id}:generateContent"
-        
-        # Build the request payload
-        contents = []
-        parts = []
-        
-        # Add images if provided (for multimodal analysis)
-        if image_data:
-            for i, img_b64 in enumerate(image_data[:3]):  # Max 3 images
-                # Handle data URLs
-                if img_b64.startswith('data:'):
-                    # Extract base64 part from data URL
-                    match = re.match(r'data:image/(\w+);base64,(.+)', img_b64)
-                    if match:
-                        mime_type = f"image/{match.group(1)}"
-                        b64_data = match.group(2)
-                    else:
-                        continue
-                else:
-                    mime_type = "image/jpeg"
-                    b64_data = img_b64
-                
-                parts.append({
-                    "inline_data": {
-                        "mime_type": mime_type,
-                        "data": b64_data
-                    }
-                })
-        
-        # Add text prompt
-        parts.append({"text": prompt})
-        
-        contents.append({"role": "user", "parts": parts})
-        
-        payload = {
-            "contents": contents,
-            "generationConfig": {
-                "temperature": 0.2,
-                "topP": 0.8,
-                "maxOutputTokens": 4096,  # Larger for thinking responses
-                "thinkingConfig": {
-                    "includeThoughts": True,
-                    "thinkingLevel": "HIGH"  # Enable deep reasoning as requested
-                }
-            },
-            "safetySettings": [
-                {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
-                {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"},
-                {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "BLOCK_NONE"},
-                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"},
-            ]
-        }
-        
+        location = os.getenv("VERTEX_AI_LOCATION") or "global"
+        endpoint = vp.endpoint_for(model_id, project_id, location)
+
+        images: List[Dict[str, str]] = []
+        for img_b64 in (image_data or [])[:3]:
+            if img_b64.startswith('data:'):
+                match = re.match(r'data:image/(\w+);base64,(.+)', img_b64)
+                if not match:
+                    continue
+                images.append({"mime_type": f"image/{match.group(1)}", "data": match.group(2)})
+            else:
+                images.append({"mime_type": "image/jpeg", "data": img_b64})
+
+        payload = vp.build_payload(model_id, prompt, images)
+
         # Make the API call
         async with aiohttp.ClientSession() as session:
             async with session.post(
@@ -341,13 +310,7 @@ async def analyze_with_gemini(
         # budget went to "thinking"), still report the call as REACHABLE so
         # connectivity checks don't false-negative on a working configuration.
         try:
-            candidates = result.get('candidates') or []
-            text_response = ""
-            if candidates:
-                for part in candidates[0].get('content', {}).get('parts', []):
-                    # Skip "thought" parts — only the answer text carries the JSON.
-                    if 'text' in part and not part.get('thought'):
-                        text_response += part['text']
+            text_response = vp.extract_text(model_id, result)
             json_match = re.search(r'```json\s*(.*?)\s*```', text_response, re.DOTALL)
             json_str = json_match.group(1) if json_match else text_response.strip()
             if not json_str:

--- a/backend/app/tasks/integrations.py
+++ b/backend/app/tasks/integrations.py
@@ -16,7 +16,7 @@ import base64
 import hashlib
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import select
@@ -271,7 +271,7 @@ async def _import_external_record(db, integration, record):
         external_id=record.external_id,
         external_status=record.raw_status,
         direction="pulled",
-        last_pulled_at=datetime.utcnow(),
+        last_pulled_at=datetime.now(timezone.utc),
     ))
     db.add(RequestAuditLog(
         service_request_id=sr.id,
@@ -353,7 +353,7 @@ def push_request_to_integrations(self, request_id: int):
                         external_id=record.external_id,
                         external_status=record.raw_status,
                         direction="pushed",
-                        last_pushed_at=datetime.utcnow(),
+                        last_pushed_at=datetime.now(timezone.utc),
                     )
                     db.add(link)
                     await _log(db, integration.id, "push", "success",
@@ -405,7 +405,7 @@ def push_status_to_integrations(self, request_id: int, notes: str = None):
                         provider=integration.platform,
                     )
                     link.external_status = connector.map_status_out(sr.status)
-                    link.last_pushed_at = datetime.utcnow()
+                    link.last_pushed_at = datetime.now(timezone.utc)
                     link.sync_error = None
                     await _log(db, integration.id, "push_status", "success",
                                f"{sr.service_request_id} -> {sr.status}", 1)
@@ -458,7 +458,7 @@ def pull_integration_updates():
                                 if new_sr:
                                     imported += 1
                             continue
-                        link.last_pulled_at = datetime.utcnow()
+                        link.last_pulled_at = datetime.now(timezone.utc)
                         if record.raw_status and record.raw_status != link.external_status:
                             link.external_status = record.raw_status
                         sr = (await db.execute(
@@ -478,9 +478,9 @@ def pull_integration_updates():
                             continue
                         old_status = sr.status
                         sr.status = record.status
-                        sr.updated_datetime = datetime.utcnow()
+                        sr.updated_datetime = datetime.now(timezone.utc)
                         if record.status == "closed":
-                            sr.closed_datetime = datetime.utcnow()
+                            sr.closed_datetime = datetime.now(timezone.utc)
                             if record.resolution and not sr.completion_message:
                                 sr.completion_message = record.resolution
                             elif record.status_notes:
@@ -497,7 +497,7 @@ def pull_integration_updates():
                         ))
                         updated += 1
 
-                    integration.last_sync_at = datetime.utcnow()
+                    integration.last_sync_at = datetime.now(timezone.utc)
                     integration.last_sync_status = "success"
                     integration.last_sync_error = None
                     await _log(db, integration.id, "pull", "success",
@@ -508,7 +508,7 @@ def pull_integration_updates():
                     # Clear any pending-rollback state before writing the error
                     # log, so one bad record can't poison the whole beat cycle.
                     await db.rollback()
-                    integration.last_sync_at = datetime.utcnow()
+                    integration.last_sync_at = datetime.now(timezone.utc)
                     integration.last_sync_status = "error"
                     integration.last_sync_error = str(e)[:1000]
                     await _log(db, integration.id, "pull", "error", str(e))
@@ -554,15 +554,15 @@ def refresh_request_from_integrations(self, request_id: int):
                         continue
                     if record.raw_status and record.raw_status != link.external_status:
                         link.external_status = record.raw_status
-                    link.last_pulled_at = datetime.utcnow()
+                    link.last_pulled_at = datetime.now(timezone.utc)
                     if await _apply_work_order_fields(db, sr, record, integration):
                         applied += 1
                     if record.status and record.status != sr.status:
                         old = sr.status
                         sr.status = record.status
-                        sr.updated_datetime = datetime.utcnow()
+                        sr.updated_datetime = datetime.now(timezone.utc)
                         if record.status == "closed":
-                            sr.closed_datetime = datetime.utcnow()
+                            sr.closed_datetime = datetime.now(timezone.utc)
                             if record.resolution and not sr.completion_message:
                                 sr.completion_message = record.resolution
                             if not sr.closed_substatus:
@@ -688,7 +688,7 @@ def pull_integration_comments():
                                 external_ref=ref,
                             ))
                             imported += 1
-                        link.last_pulled_at = datetime.utcnow()
+                        link.last_pulled_at = datetime.now(timezone.utc)
 
                     if imported or links:
                         await _log(db, integration.id, "pull_comments", "success",
@@ -741,7 +741,7 @@ def sync_integration_assets():
                         )).scalar_one_or_none()
                     if layer:
                         layer.geojson = geojson
-                        layer.updated_at = datetime.utcnow()
+                        layer.updated_at = datetime.now(timezone.utc)
                     else:
                         layer = MapLayer(
                             name=f"{integration.display_name} Assets"[:100],

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -133,7 +133,7 @@ def analyze_request(self, request_id: int):
             analyze_with_gemini,
             strip_pii
         )
-        from datetime import datetime
+        from datetime import datetime, timezone
         
         async with SessionLocal() as db:
             settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
@@ -248,8 +248,8 @@ def analyze_request(self, request_id: int):
                         else:
                             analysis.update(ai_result)
                             ai_ran = True
-                            request.vertex_ai_summary = ai_result.get("qualitative_analysis", "")
-                            request.vertex_ai_analyzed_at = datetime.utcnow()
+                            request.ai_summary = ai_result.get("qualitative_analysis", "")
+                            request.ai_analyzed_at = datetime.now(timezone.utc)
                     # Keep the computed similar_reports even if the AI result omitted them.
                     if historical_context.get("similar_reports"):
                         analysis["similar_reports"] = historical_context["similar_reports"]
@@ -1151,7 +1151,7 @@ def send_weekly_digest():
     Respects individual staff notification preferences.
     """
     import logging
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
     from sqlalchemy import func, and_
     logger = logging.getLogger(__name__)
     
@@ -1224,7 +1224,7 @@ def send_weekly_digest():
                         func.sum(case((ServiceRequest.status == 'in_progress', 1), else_=0)).label('in_progress'),
                         func.sum(case((and_(
                             ServiceRequest.status.in_(['open', 'in_progress']),
-                            ServiceRequest.requested_datetime < datetime.utcnow() - timedelta(days=7)
+                            ServiceRequest.requested_datetime < datetime.now(timezone.utc) - timedelta(days=7)
                         ), 1), else_=0)).label('overdue')
                     ).where(
                         and_(
@@ -1239,7 +1239,7 @@ def send_weekly_digest():
                         func.sum(case((ServiceRequest.status == 'in_progress', 1), else_=0)).label('in_progress'),
                         func.sum(case((and_(
                             ServiceRequest.status.in_(['open', 'in_progress']),
-                            ServiceRequest.requested_datetime < datetime.utcnow() - timedelta(days=7)
+                            ServiceRequest.requested_datetime < datetime.now(timezone.utc) - timedelta(days=7)
                         ), 1), else_=0)).label('overdue')
                     ).where(
                         and_(
@@ -1279,7 +1279,7 @@ def send_weekly_digest():
                 # Build request list HTML
                 requests_html = ""
                 for req in oldest_requests:
-                    age_days = (datetime.utcnow() - req.requested_datetime).days if req.requested_datetime else 0
+                    age_days = (datetime.now(timezone.utc) - req.requested_datetime).days if req.requested_datetime else 0
                     age_str = f"{age_days}d" if age_days > 0 else "Today"
                     status_color = "#22c55e" if req.status == "in_progress" else "#f59e0b"
                     requests_html += f"""

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -951,6 +951,15 @@ def purge_old_ip_addresses():
         return {"status": "error", "error": str(e)}
 
 
+# How many records one query pulls, and how many such queries one run makes.
+#
+# The batch keeps transactions short; the ceiling is a runaway guard rather than
+# a policy, and at 200,000 records it is far above any town's real backlog. A
+# run that reaches it says so in its result instead of reporting success.
+BATCH_SIZE = 200
+MAX_BATCHES = 1000
+
+
 @celery_app.task
 def enforce_retention_policy():
     """
@@ -992,38 +1001,75 @@ def enforce_retention_policy():
             policy = get_retention_policy(state_code)
             logger.info(f"[Retention] Enforcing policy: {policy['name']} ({policy['retention_years']} years)")
             
-            # Get records eligible for archival (limit 100 per run to avoid overwhelming)
-            records = await get_records_for_archival(db, state_code, override_days, limit=100)
-            
-            if not records:
-                logger.info("[Retention] No records eligible for archival")
-                return {"status": "success", "archived": 0, "policy": policy}
-            
-            logger.info(f"[Retention] Found {len(records)} records eligible for archival")
-            
+            # Everything eligible, in batches.
+            #
+            # This used to take the first hundred and stop, with no sign on
+            # screen that it had. A town with five thousand expired records
+            # needed fifty presses of a button that looked like it had finished,
+            # or fifty nights -- and the retention policy it publishes says the
+            # records are gone, so the gap between the claim and the database
+            # widened every day.
+            #
+            # Batched rather than one query, because the whole point is that
+            # this set can be large: a single transaction over five thousand
+            # rows holds locks for the duration and fails all-or-nothing.
+            #
+            # `skipped` is what stops this looping forever. Records under legal
+            # hold stay eligible by design -- they are past their date and must
+            # not be touched -- so a batch of nothing but held records would be
+            # fetched again for ever. Once a pass archives none of what it was
+            # given, there is nothing left this run can act on.
             archived_count = 0
             skipped_count = 0
             errors = []
-            
-            for record in records:
-                try:
-                    result = await archive_record(db, record.id, archive_mode)
-                    if result["status"] in ["anonymized", "deleted"]:
-                        archived_count += 1
-                        logger.info(f"[Retention] Archived record {record.service_request_id}")
-                    else:
-                        skipped_count += 1
-                        logger.info(f"[Retention] Skipped record {record.service_request_id}: {result.get('message')}")
-                except Exception as e:
-                    errors.append({"record_id": record.id, "error": str(e)})
-                    logger.error(f"[Retention] Error archiving {record.id}: {e}")
-            
+            batches = 0
+
+            while True:
+                records = await get_records_for_archival(db, state_code, override_days, limit=BATCH_SIZE)
+                if not records:
+                    break
+                batches += 1
+                archived_this_batch = 0
+                for record in records:
+                    try:
+                        result = await archive_record(db, record.id, archive_mode)
+                        if result["status"] in ["anonymized", "deleted"]:
+                            archived_count += 1
+                            archived_this_batch += 1
+                        else:
+                            skipped_count += 1
+                            logger.info(
+                                "[Retention] Skipped %s: %s",
+                                record.service_request_id, result.get("message"),
+                            )
+                    except Exception as e:
+                        errors.append({"record_id": record.id, "error": str(e)})
+                        logger.error("[Retention] Error archiving %s: %s", record.id, e)
+                if archived_this_batch == 0:
+                    # Nothing in that batch could be acted on, and the query is
+                    # deterministic, so the next one would return the same rows.
+                    break
+                if batches >= MAX_BATCHES:
+                    logger.warning(
+                        "[Retention] Stopped after %s batches with records still eligible. "
+                        "Run again to continue.", batches,
+                    )
+                    break
+
+            logger.info(
+                "[Retention] %s archived, %s skipped, %s errors across %s batches",
+                archived_count, skipped_count, len(errors), batches,
+            )
             return {
                 "status": "success",
                 "policy": policy,
                 "archived": archived_count,
                 "skipped": skipped_count,
-                "errors": len(errors)
+                "errors": len(errors),
+                "batches": batches,
+                # True when the cap stopped it early, so a caller can say so
+                # rather than reporting a finished job that is not finished.
+                "more_remaining": batches >= MAX_BATCHES,
             }
     
     try:

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -973,6 +973,7 @@ def enforce_retention_policy():
 
     async def _enforce():
         from app.models import SystemSettings
+        from app.services.retention_scrub import REDACT, normalise_fields, normalise_mode
         from app.services.retention_service import (
             get_records_for_archival,
             archive_record,
@@ -988,7 +989,8 @@ def enforce_retention_policy():
                 logger.warning("[Retention] No system settings found, using defaults")
                 state_code = "NJ"
                 override_days = None
-                archive_mode = "anonymize"
+                archive_mode = REDACT
+                scrub_fields = normalise_fields(None)
             else:
                 # Instance-wide legal hold: freeze ALL purging until it is lifted.
                 if getattr(settings, "legal_hold", False):
@@ -996,7 +998,8 @@ def enforce_retention_policy():
                     return {"status": "skipped_legal_hold", "archived": 0}
                 state_code = settings.retention_state_code or "NJ"
                 override_days = settings.retention_days_override
-                archive_mode = settings.retention_mode or "anonymize"
+                archive_mode = normalise_mode(settings.retention_mode)
+                scrub_fields = normalise_fields(getattr(settings, "retention_scrub_fields", None))
             
             policy = get_retention_policy(state_code)
             logger.info(f"[Retention] Enforcing policy: {policy['name']} ({policy['retention_years']} years)")
@@ -1032,7 +1035,7 @@ def enforce_retention_policy():
                 archived_this_batch = 0
                 for record in records:
                     try:
-                        result = await archive_record(db, record.id, archive_mode)
+                        result = await archive_record(db, record.id, archive_mode, scrub_fields)
                         if result["status"] in ["anonymized", "deleted"]:
                             archived_count += 1
                             archived_this_batch += 1

--- a/backend/tests/test_connector_alerts.py
+++ b/backend/tests/test_connector_alerts.py
@@ -596,3 +596,29 @@ def test_the_card_can_tell_that_alerts_are_muted():
     """A mute that silenced the email and left no trace on screen would be
     indistinguishable from the alerting being broken."""
     assert '"alerts_muted_until"' in _system_api()
+
+
+def test_the_mute_button_appears_exactly_where_an_alert_exists():
+    """The frontend decides whether to offer "Mute alerts" from a list of
+    statuses. If that list drifts from `alert_level`, the button either offers
+    to silence something that was never going to make a sound, or hides on a
+    connector that is emailing every day.
+
+    `stale` is why this is pinned rather than eyeballed: it displays as "not
+    checked yet" and it alerts, so neither the raw status nor what the card
+    shows answers the question on its own.
+    """
+    import re
+    from pathlib import Path
+
+    ui = (Path(__file__).resolve().parents[2] / "frontend/src/components/capabilityUI.tsx").read_text()
+    m = re.search(r"ALERTING_STATUSES = \[(.*?)\]", ui, re.S)
+    assert m, "the frontend no longer declares which statuses alert"
+    frontend = set(re.findall(r"'([a-z]+)'", m.group(1)))
+
+    backend = {s for s in ("down", "failing", "stale", "working", "unknown")
+               if A.alert_level(s) != A.HEALTHY}
+    assert frontend == backend, (
+        f"the mute button and the alerting rules disagree: "
+        f"frontend={sorted(frontend)} backend={sorted(backend)}"
+    )

--- a/backend/tests/test_retention_run_is_deliberate.py
+++ b/backend/tests/test_retention_run_is_deliberate.py
@@ -83,15 +83,18 @@ class TestItAsksFirst:
         block = API[API.index("async def run_retention_now"):]
         block = block[:block.index("\n@router")]
         assert 'confirm' in block
-        assert '"DELETE"' in block
+        assert '"PURGE"' in block
         assert "status_code=400" in block
 
-    def test_anonymising_does_not_demand_the_word(self):
-        """Reversible enough not to need ceremony; asking for a password every
-        time is how people learn to type it without reading."""
+    def test_redacting_does_not_demand_the_word(self):
+        """Targeted enough not to need ceremony; asking for a password every
+        time is how people learn to type it without reading.
+
+        Purge still does: it clears every field on every eligible record and
+        cannot be undone."""
         block = API[API.index("async def run_retention_now"):]
         block = block[:block.index("\n@router")]
-        assert 'mode == "delete"' in block
+        assert 'mode == "purge"' in block
 
     def test_a_legal_hold_is_reported_before_anything_is_offered(self):
         assert '"blocked": "legal_hold"' in API
@@ -143,3 +146,29 @@ class TestTheWordItUses:
         assert "retention_mode = :new" in migration
         assert 'old="anonymize"' in migration
         assert 'new="redact"' in migration
+
+
+def test_the_word_asked_for_is_the_word_checked():
+    """The preview said PURGE and the endpoint checked for DELETE, so typing
+    what you were told would have been rejected. A confirmation that cannot be
+    satisfied is worse than none: it teaches people the button is broken."""
+    required = re.search(r'"confirmation_required": "(\w+)"', API).group(1)
+    checked = re.search(r'strip\(\) != "(\w+)"', API).group(1)
+    assert required == checked, f"asked for {required}, checks for {checked}"
+
+
+def test_hard_deletion_is_gone_from_the_service():
+    """It could never have worked: NOT NULL foreign keys from the audit log and
+    the comments with no cascade, so the flush failed on every record."""
+    service = (ROOT / "app/services/retention_service.py").read_text()
+    assert "db.delete(" not in service
+
+
+def test_the_redaction_lands_in_the_tamper_evident_trail():
+    """The chain hashes any RequestAuditLog insert, so writing the row is what
+    puts a redaction in it. A redaction that leaves no trace is
+    indistinguishable from data loss."""
+    service = (ROOT / "app/services/retention_service.py").read_text()
+    assert "RequestAuditLog(" in service
+    assert 'action=f"retention_{action}"' in service
+    assert '"cleared"' in service

--- a/backend/tests/test_retention_run_is_deliberate.py
+++ b/backend/tests/test_retention_run_is_deliberate.py
@@ -1,0 +1,97 @@
+"""Running retention is destructive, unbounded, and was one click away.
+
+Two separate problems, reported together.
+
+It stopped after a hundred records with nothing on screen saying so, which for
+a town with five thousand expired records meant fifty presses of a button that
+looked finished each time -- while the retention policy the town publishes says
+those records are gone. The gap between the claim and the database widened
+every day nobody noticed.
+
+And in `delete` mode it destroys resident records permanently, with no preview,
+no confirmation, and a response that returned before the task had touched
+anything.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TASK = (ROOT / "app/tasks/service_requests.py").read_text()
+API = (ROOT / "app/api/system.py").read_text()
+BLOCK = TASK[TASK.index("def enforce_retention_policy"):]
+BLOCK = BLOCK[:BLOCK.index("\n@celery_app.task")]
+
+
+def _const(name: str) -> int:
+    """Read a module constant without importing the module.
+
+    `app.tasks.service_requests` imports Celery, which CI does not install, so
+    importing it here would skip these tests in exactly the environment that is
+    supposed to enforce them.
+    """
+    m = re.search(rf"^{name} = (\d+)$", TASK, re.M)
+    assert m, f"{name} is gone"
+    return int(m.group(1))
+
+
+class TestItProcessesEverything:
+    def test_it_no_longer_stops_at_a_hundred(self):
+        assert "limit=100" not in BLOCK, "the hundred-record cap is back"
+
+    def test_it_keeps_going_until_there_is_nothing_left(self):
+        assert "while True:" in BLOCK
+        assert "limit=BATCH_SIZE" in BLOCK
+
+    def test_it_still_works_in_batches(self):
+        """Not one transaction over five thousand rows: that holds locks for
+        the duration and fails all-or-nothing."""
+        assert 1 <= _const("BATCH_SIZE") <= 1000
+
+    def test_a_batch_of_untouchable_records_does_not_loop_for_ever(self):
+        """Records under legal hold stay eligible by design -- they are past
+        their date and must not be archived -- so a batch of nothing but held
+        records would be re-fetched for ever."""
+        assert "archived_this_batch == 0" in BLOCK
+
+    def test_the_runaway_guard_is_far_above_any_real_backlog(self):
+        assert _const("BATCH_SIZE") * _const("MAX_BATCHES") >= 100_000
+
+    def test_hitting_the_guard_is_reported_rather_than_called_success(self):
+        assert "more_remaining" in BLOCK
+
+
+class TestItAsksFirst:
+    def test_there_is_a_preview(self):
+        assert '"/retention/preview"' in API
+        assert "async def preview_retention_now" in API or "async def preview_retention_run" in API
+
+    def test_the_preview_separates_what_will_be_skipped(self):
+        """"142 eligible" and "142 eligible, 3 of which will be skipped" are
+        different sentences to somebody approving a deletion."""
+        for field in ('"eligible"', '"on_legal_hold"', '"will_act_on"'):
+            assert field in API
+
+    def test_the_preview_says_which_mode_is_in_force(self):
+        """Anonymise and delete are not the same act and the button never said
+        which one it was about to perform."""
+        assert '"mode": mode' in API
+
+    def test_deleting_requires_the_word_back(self):
+        """A modal is a client-side courtesy. Anything a stray fetch can do
+        should not include destroying resident records."""
+        block = API[API.index("async def run_retention_now"):]
+        block = block[:block.index("\n@router")]
+        assert 'confirm' in block
+        assert '"DELETE"' in block
+        assert "status_code=400" in block
+
+    def test_anonymising_does_not_demand_the_word(self):
+        """Reversible enough not to need ceremony; asking for a password every
+        time is how people learn to type it without reading."""
+        block = API[API.index("async def run_retention_now"):]
+        block = block[:block.index("\n@router")]
+        assert 'mode == "delete"' in block
+
+    def test_a_legal_hold_is_reported_before_anything_is_offered(self):
+        assert '"blocked": "legal_hold"' in API

--- a/backend/tests/test_retention_run_is_deliberate.py
+++ b/backend/tests/test_retention_run_is_deliberate.py
@@ -95,3 +95,51 @@ class TestItAsksFirst:
 
     def test_a_legal_hold_is_reported_before_anything_is_offered(self):
         assert '"blocked": "legal_hold"' in API
+
+
+class TestTheTownChoosesWhatIsRemoved:
+    """The list of what a retention run clears was fixed in code."""
+
+    def test_the_setting_is_stored(self):
+        models = (ROOT / "app/models.py").read_text()
+        assert "retention_scrub_fields" in models
+
+    def test_the_api_returns_the_catalog_with_the_choice_marked(self):
+        assert "describe_selection" in API
+
+    def test_an_unknown_field_is_rejected_rather_than_dropped(self):
+        """Silently ignoring one leaves a town believing it removes something
+        it does not."""
+        assert "Unknown fields to scrub" in API
+
+    def test_the_task_reads_the_choice(self):
+        assert "retention_scrub_fields" in TASK
+        assert "scrub_fields" in TASK
+
+    def test_the_preview_names_what_will_be_cleared(self):
+        """"142 records" without saying what happens to them is not consent."""
+        block = API[API.index("async def preview_retention_run"):]
+        block = block[:block.index("\n@router")]
+        assert "scrub_fields" in block
+
+
+class TestTheWordItUses:
+    def test_the_api_no_longer_demands_the_old_word(self):
+        assert '"anonymize", "delete"' not in API
+
+    def test_what_is_already_stored_still_works(self):
+        """Towns have `anonymize` in their database now. Rejecting it on read
+        would break the policy screen for every one of them."""
+        from app.services.retention_scrub import normalise_mode
+
+        assert normalise_mode("anonymize") == "redact"
+
+    def test_the_migration_moves_the_stored_value_too(self):
+        """So the database and the screen agree, rather than the screen
+        translating forever."""
+        migration = next(
+            (ROOT / "alembic/versions").glob("*retention_scrub_fields*")
+        ).read_text()
+        assert "retention_mode = :new" in migration
+        assert 'old="anonymize"' in migration
+        assert 'new="redact"' in migration

--- a/backend/tests/test_retention_scrubs_ai.py
+++ b/backend/tests/test_retention_scrubs_ai.py
@@ -1,0 +1,167 @@
+"""What a retention run removes, and what it is honest to call it.
+
+Three problems, reported together.
+
+The AI summary is the description in different words, so clearing one and
+keeping the other is redaction that leaves behind the thing it was meant to
+remove -- where a resident put a name or a phone number in the description, the
+model repeated it.
+
+The list of what gets removed was fixed in code, deciding for every town what
+its own counsel and its state's records law are supposed to decide.
+
+And it was called anonymisation. Anonymising means removing what ties data to a
+person; blanking the description of a pothole report is redaction. They are not
+interchangeable words when the difference is what a town tells a judge.
+"""
+
+import pytest
+
+from app.services import retention_scrub as S
+
+
+class Rec:
+    def __init__(self, **kw):
+        self.id = 7
+        self.first_name = "John"; self.last_name = "Smith"
+        self.email = "john@example.com"; self.phone = "555-0143"
+        self.description = "Pothole outside 12 Elm St, call me on 555-0143"
+        self.staff_notes = "Spoke to Mr Smith"
+        self.media_urls = ["a.jpg"]
+        self.address = "12 Elm St"; self.lat = 40.8; self.long = -74.2; self.location = "POINT(...)"
+        self.ai_analysis = None; self.vertex_ai_summary = None
+        self.vertex_ai_classification = "pothole"
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+REAL_ANALYSIS = {
+    "priority_score": 8.0,
+    "priority_justification": "Reported by John Smith, 12 Elm St, reachable on 555-0143.",
+    "qualitative_analysis": "The resident says their child cycles past it.",
+    "quantitative_metrics": {"estimated_severity": "high"},
+    "recommended_response_time": "24h",
+    "safety_flags": ["child_safety"],
+    "_error": "provider rejected prompt: 'John Smith at 12 Elm St reports...'",
+}
+
+
+class TestTheAiLeak:
+    def test_the_free_text_the_model_wrote_is_removed(self):
+        r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+        S.apply_scrub(r, ["ai_analysis"])
+        blob = repr(r.ai_analysis)
+        for leaked in ("John Smith", "12 Elm St", "555-0143", "child"):
+            assert leaked not in blob, f"{leaked!r} survived"
+
+    def test_the_generated_summary_goes_too(self):
+        r = Rec(vertex_ai_summary="John Smith reports a pothole outside 12 Elm St.")
+        S.apply_scrub(r, ["ai_analysis"])
+        assert r.vertex_ai_summary is None
+
+    def test_the_statistics_survive(self):
+        r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+        S.apply_scrub(r, ["ai_analysis"])
+        assert r.ai_analysis["priority_score"] == 8.0
+        assert r.ai_analysis["quantitative_metrics"]["estimated_severity"] == "high"
+        assert r.vertex_ai_classification == "pothole"
+
+    def test_it_is_an_allow_list_not_a_strip_list(self):
+        r = Rec(ai_analysis={"invented_next_year": "John Smith", "priority_score": 1})
+        S.apply_scrub(r, ["ai_analysis"])
+        assert "invented_next_year" not in r.ai_analysis
+
+    def test_a_non_dict_analysis_is_discarded_whole(self):
+        r = Rec(ai_analysis="John Smith reports a pothole")
+        S.apply_scrub(r, ["ai_analysis"])
+        assert r.ai_analysis is None
+
+
+class TestTheTownChooses:
+    def test_only_what_was_asked_for_is_cleared(self):
+        """Removing "a bit more, to be safe" is how a town loses the
+        public-records index it is legally obliged to keep."""
+        r = Rec()
+        S.apply_scrub(r, ["phone"])
+        assert r.phone is None
+        assert r.description.startswith("Pothole")
+        assert r.first_name == "John"
+        assert r.address == "12 Elm St"
+
+    def test_never_configured_means_what_it_did_before(self):
+        """A town upgrading into this feature must not have its next run start
+        removing more, or less, than yesterday's."""
+        r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+        done = S.apply_scrub(r, None)
+        assert set(done) == {"name", "email", "phone", "description", "staff_notes",
+                             "media", "ai_analysis"}
+        assert r.address == "12 Elm St"
+        assert r.lat == 40.8
+
+    def test_an_empty_choice_is_honoured_rather_than_defaulted(self):
+        """Deliberately empty is a real answer -- it goes with a delete-mode
+        policy -- and quietly substituting the defaults would destroy data
+        somebody had chosen to keep."""
+        r = Rec()
+        assert S.apply_scrub(r, []) == []
+        assert r.first_name == "John"
+
+    def test_location_is_two_choices_not_one(self):
+        r = Rec()
+        S.apply_scrub(r, ["address"])
+        assert r.address is None and r.lat == 40.8
+
+    def test_clearing_the_pin_clears_the_geometry_with_it(self):
+        """Leaving PostGIS holding the point after the columns are blank puts
+        the record back on a map drawn from geometry."""
+        r = Rec()
+        S.apply_scrub(r, ["coordinates"])
+        assert r.lat is None and r.long is None and r.location is None
+
+    def test_a_made_up_field_is_ignored(self):
+        r = Rec()
+        assert S.apply_scrub(r, ["not_a_field", "phone"]) == ["phone"]
+
+    def test_duplicates_do_not_double_report(self):
+        assert S.normalise_fields(["phone", "phone"]) == ["phone"]
+
+    def test_every_catalog_entry_is_actionable(self):
+        """A checkbox that changes nothing when ticked is worse than no
+        checkbox: it reads as a promise. `comments` is the one exception --
+        another table, handled by the caller."""
+        for field in S.SCRUB_FIELDS:
+            if field["id"] == "comments":
+                continue
+            r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+            assert S.apply_scrub(r, [field["id"]]) == [field["id"]], field["id"]
+
+    def test_the_defaults_are_what_the_fixed_list_used_to_be(self):
+        assert set(S.DEFAULT_FIELDS) == {"name", "email", "phone", "description",
+                                         "staff_notes", "media", "ai_analysis"}
+
+
+class TestTheWord:
+    def test_the_mode_is_no_longer_called_anonymising(self):
+        assert S.REDACT == "redact"
+
+    def test_what_towns_already_have_stored_still_reads(self):
+        assert S.normalise_mode("anonymize") == "redact"
+
+    def test_delete_is_untouched(self):
+        assert S.normalise_mode("delete") == "delete"
+
+    def test_nothing_stored_means_redact(self):
+        assert S.normalise_mode(None) == "redact"
+        assert S.normalise_mode("") == "redact"
+
+    def test_case_and_spacing_do_not_change_the_meaning(self):
+        assert S.normalise_mode("  Anonymize ") == "redact"
+
+
+def test_the_settings_screen_can_show_the_current_choice():
+    shown = S.describe_selection(["phone", "address"])
+    chosen = {f["id"] for f in shown if f["selected"]}
+    assert chosen == {"phone", "address"}
+    assert len(shown) == len(S.SCRUB_FIELDS)
+    for field in shown:
+        assert field["label"] and field["detail"], field["id"]

--- a/backend/tests/test_retention_scrubs_ai.py
+++ b/backend/tests/test_retention_scrubs_ai.py
@@ -140,6 +140,52 @@ class TestTheTownChooses:
                                          "staff_notes", "media", "ai_analysis"}
 
 
+class TestHardDeleteIsGone:
+    """`delete` could never have worked, and making it work would have broken
+    something else.
+
+    It called db.delete(record) while request_audit_logs and request_comments
+    hold NOT NULL foreign keys back to it with no cascade, so the flush failed
+    on every record -- and every record has an audit entry, because submitting
+    one writes it. Each failure was caught per record, so the run reported
+    success with nothing archived.
+
+    Making it succeed meant deleting the audit rows, which form a hash chain
+    the compliance page advertises as tamper-evident.
+    """
+
+    def test_purge_clears_every_field(self):
+        r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+        cleared = S.apply_scrub(r, S.fields_for_mode("purge"))
+        # Everything except comments, which lives in another table.
+        assert set(cleared) == set(S.FIELD_IDS) - {"comments"}
+        assert r.first_name == "[ARCHIVED]" and r.phone is None
+        assert r.address is None and r.lat is None and r.location is None
+
+    def test_purge_ignores_a_narrower_selection(self):
+        """A caller must not be able to apply a redact-sized list and report it
+        as a purge."""
+        assert set(S.fields_for_mode("purge", ["phone"])) == set(S.FIELD_IDS)
+
+    def test_a_town_set_to_delete_gets_the_strongest_option_that_works(self):
+        assert S.normalise_mode("delete") == "purge"
+
+    def test_redact_still_honours_the_choice(self):
+        assert S.fields_for_mode("redact", ["phone"]) == ["phone"]
+
+    def test_delete_is_no_longer_an_accepted_mode(self):
+        assert "delete" not in S.MODES
+        assert set(S.MODES) == {"redact", "purge"}
+
+    def test_the_row_survives_so_it_still_counts(self):
+        """The point of keeping a shell: a town's own history of how many
+        reports it handled must not be a casualty of retention."""
+        r = Rec(ai_analysis=dict(REAL_ANALYSIS))
+        S.apply_scrub(r, S.fields_for_mode("purge"))
+        assert r.id == 7
+        assert r.ai_analysis == {} or "priority_score" in r.ai_analysis
+
+
 class TestTheWord:
     def test_the_mode_is_no_longer_called_anonymising(self):
         assert S.REDACT == "redact"
@@ -147,8 +193,10 @@ class TestTheWord:
     def test_what_towns_already_have_stored_still_reads(self):
         assert S.normalise_mode("anonymize") == "redact"
 
-    def test_delete_is_untouched(self):
-        assert S.normalise_mode("delete") == "delete"
+    def test_a_stored_delete_now_means_purge(self):
+        """It is the strongest option a town could pick, and it is still the
+        strongest option -- the difference is that it works."""
+        assert S.normalise_mode("delete") == "purge"
 
     def test_nothing_stored_means_redact(self):
         assert S.normalise_mode(None) == "redact"

--- a/backend/tests/test_retention_scrubs_ai.py
+++ b/backend/tests/test_retention_scrubs_ai.py
@@ -15,7 +15,6 @@ person; blanking the description of a pothole report is redaction. They are not
 interchangeable words when the difference is what a town tells a judge.
 """
 
-import pytest
 
 from app.services import retention_scrub as S
 

--- a/backend/tests/test_town_time.py
+++ b/backend/tests/test_town_time.py
@@ -9,7 +9,7 @@ The other half is display. "Closed at 02:14" means nothing to a clerk in New
 Jersey looking at a report closed just before ten the previous night.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from app.services import town_time as T
 

--- a/backend/tests/test_town_time.py
+++ b/backend/tests/test_town_time.py
@@ -1,0 +1,100 @@
+"""Store UTC, show the town's time.
+
+Every timestamp column here is `timestamptz`, so the database returns aware
+UTC. The Python side was building naive datetimes, which psycopg interprets in
+the database session's timezone -- so on a database not set to UTC, every
+written timestamp was silently offset and every number still looked plausible.
+
+The other half is display. "Closed at 02:14" means nothing to a clerk in New
+Jersey looking at a report closed just before ten the previous night.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services import town_time as T
+
+JAN = datetime(2026, 1, 15, 15, 30, tzinfo=timezone.utc)   # EST, UTC-5
+JUL = datetime(2026, 7, 15, 15, 30, tzinfo=timezone.utc)   # EDT, UTC-4
+
+
+class TestValidation:
+    def test_a_real_zone_is_accepted(self):
+        assert T.is_valid_timezone("America/New_York")
+
+    def test_nonsense_is_not(self):
+        for bad in ("", None, "Mars/Olympus", "EST5EDT_typo", 42):
+            assert not T.is_valid_timezone(bad)
+
+    def test_a_bad_stored_value_falls_back_rather_than_raising(self):
+        """A bad row must not be able to take the console down. It should show
+        UTC and let somebody fix it."""
+        assert T.normalise_timezone("Mars/Olympus") == "UTC"
+        assert T.normalise_timezone(None) == "UTC"
+
+    def test_the_default_is_what_is_stored_rather_than_a_guess(self):
+        """Showing a time that matches the database beats one confidently
+        shifted into a zone nobody chose."""
+        assert T.DEFAULT_TIMEZONE == "UTC"
+
+    def test_the_shortlist_is_a_shortlist_not_a_restriction(self):
+        """A town that needs Guam should not be told it is unsupported."""
+        assert T.is_valid_timezone("Pacific/Guam")
+        assert "Pacific/Guam" not in T.COMMON_TIMEZONES
+
+
+class TestConversion:
+    def test_it_converts_to_the_town_clock(self):
+        assert T.to_town(JAN, "America/New_York").hour == 10
+
+    def test_daylight_saving_is_not_a_fixed_offset(self):
+        """The same UTC hour is 10am in January and 11am in July. A stored
+        offset would be wrong for half the year."""
+        assert T.to_town(JAN, "America/New_York").hour == 10
+        assert T.to_town(JUL, "America/New_York").hour == 11
+
+    def test_a_naive_input_is_read_as_utc(self):
+        """Which is what a naive datetime means everywhere in this codebase.
+        Saying so once beats each caller guessing."""
+        assert T.to_town(JAN.replace(tzinfo=None), "America/New_York").hour == 10
+
+    def test_nothing_converts_to_nothing(self):
+        assert T.to_town(None, "America/New_York") is None
+        assert T.format_town(None, "America/New_York") == ""
+
+    def test_the_instant_itself_does_not_move(self):
+        """Converting for display must not change what moment it is."""
+        assert T.to_town(JAN, "America/Los_Angeles").timestamp() == JAN.timestamp()
+
+    def test_an_unknown_zone_shows_utc_rather_than_failing(self):
+        assert T.to_town(JAN, "Mars/Olympus").hour == 15
+
+
+class TestOffsetLabel:
+    def test_it_is_computed_at_an_instant_not_looked_up(self):
+        assert T.offset_label("America/New_York", JAN) == "UTC-05:00"
+        assert T.offset_label("America/New_York", JUL) == "UTC-04:00"
+
+    def test_utc_is_zero(self):
+        assert T.offset_label("UTC", JAN) == "UTC+00:00"
+
+    def test_a_half_hour_zone_is_not_rounded_away(self):
+        assert T.offset_label("Asia/Kolkata", JAN) == "UTC+05:30"
+
+
+def test_the_codebase_no_longer_builds_naive_timestamps():
+    """`datetime.utcnow()` returns a naive value. Written to a `timestamptz`
+    column, psycopg interprets it in the session's timezone -- so on a database
+    not set to UTC, every timestamp was silently hours out."""
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "app"
+    offenders = []
+    for path in root.rglob("*.py"):
+        # Parsed rather than grepped. The first version of this searched the
+        # text and tripped over its own explanation of the bug sitting in a
+        # docstring two files away.
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Attribute) and node.attr == "utcnow":
+                offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert not offenders, "naive timestamps are back:\n  " + "\n  ".join(offenders)

--- a/backend/tests/test_vertex_publishers.py
+++ b/backend/tests/test_vertex_publishers.py
@@ -10,7 +10,28 @@ The answer is not to hide them. It is to speak their protocol, and to offer
 exactly the publishers we have a handler for.
 """
 
+import re
+from urllib.parse import urlparse
+
 from app.services.ai import vertex_publishers as V
+
+# Vertex hosts are `aiplatform.googleapis.com` or `{region}-aiplatform...` --
+# a hyphen, not a dot. That hyphen is why a substring check was tempting and
+# why `endswith(".aiplatform.googleapis.com")` is wrong; matching the whole
+# host is the only form that is both correct and unambiguous.
+VERTEX_HOST = re.compile(r"^(?:[a-z0-9-]+-)?aiplatform\.googleapis\.com$")
+
+
+def host_of(url: str) -> str:
+    """The actual host, not a substring of the URL.
+
+    CodeQL rates `"-aiplatform.googleapis.com" in url` as a high-severity
+    finding and it is right to: that assertion also passes for
+    `evil-aiplatform.googleapis.com.attacker.com`. In production that pattern
+    is an SSRF bypass, and in a test it is an assertion that does not check
+    what it claims to.
+    """
+    return urlparse(url).hostname or ""
 
 
 class TestWhoseModelIsThis:
@@ -66,14 +87,22 @@ class TestTheEndpoint:
         """Anthropic models are not served there, and the 404 reads like a
         wrong model name rather than a wrong host."""
         url = V.endpoint_for("claude-sonnet-4", "town-311", "global")
-        assert "global" not in url
-        assert "-aiplatform.googleapis.com" in url
+        assert "/locations/global/" not in url
+        assert VERTEX_HOST.match(host_of(url))
+
+    def test_every_request_goes_to_google(self):
+        """The host is asserted rather than searched for. A model id is
+        town-supplied, and it is interpolated into this URL."""
+        for model in ("gemini-3.5-flash", "claude-sonnet-4"):
+            for location in ("", "global", "europe-west4"):
+                host = host_of(V.endpoint_for(model, "p", location))
+                assert VERTEX_HOST.match(host), host
 
     def test_a_configured_region_is_honoured(self):
         """PR #433 hardcoded us-central1 and dropped VERTEX_AI_LOCATION, which
         is the wrong direction for a product sold on compliance boundaries."""
-        assert "europe-west4" in V.endpoint_for("gemini-3.5-flash", "p", "europe-west4")
-        assert "us-east5" in V.endpoint_for("claude-sonnet-4", "p", "us-east5")
+        assert host_of(V.endpoint_for("gemini-3.5-flash", "p", "europe-west4")).startswith("europe-west4-")
+        assert host_of(V.endpoint_for("claude-sonnet-4", "p", "us-east5")).startswith("us-east5-")
 
     def test_a_qualified_id_does_not_leak_into_the_path(self):
         url = V.endpoint_for("anthropic/claude-sonnet-4", "p")

--- a/backend/tests/test_vertex_publishers.py
+++ b/backend/tests/test_vertex_publishers.py
@@ -1,0 +1,196 @@
+"""Vertex serves more than Gemini, and the picker must only offer what we call.
+
+PR #433 listed eight publishers from Model Garden while the caller still built
+`publishers/google/.../:generateContent` for every one of them. A clerk could
+select Claude on Vertex, save it, and watch triage 404 -- a setting that stores
+fine and silently does nothing, which is the shape this console keeps being
+fixed for.
+
+The answer is not to hide them. It is to speak their protocol, and to offer
+exactly the publishers we have a handler for.
+"""
+
+from app.services.ai import vertex_publishers as V
+
+
+class TestWhoseModelIsThis:
+    def test_gemini_is_google(self):
+        assert V.publisher_for("gemini-3.5-flash") == V.GOOGLE
+
+    def test_claude_is_anthropic(self):
+        assert V.publisher_for("claude-sonnet-4@20250514") == V.ANTHROPIC
+
+    def test_an_explicit_prefix_wins(self):
+        assert V.publisher_for("anthropic/claude-x") == V.ANTHROPIC
+
+    def test_an_unknown_id_falls_back_to_google(self):
+        """Which is where every stored id came from before this existed, so an
+        upgrade cannot reroute a town's working model somewhere else."""
+        assert V.publisher_for("some-new-google-thing") == V.GOOGLE
+        assert V.publisher_for(None) == V.GOOGLE
+        assert V.publisher_for("") == V.GOOGLE
+
+    def test_case_and_stray_slashes_do_not_change_the_answer(self):
+        assert V.publisher_for("  Claude-Opus-4  ") == V.ANTHROPIC
+        assert V.publisher_for("/gemini-3.5-flash") == V.GOOGLE
+
+
+class TestOnlyOfferWhatWeCanCall:
+    def test_the_supported_list_is_what_has_a_handler(self):
+        for publisher in V.SUPPORTED_PUBLISHERS:
+            model = "gemini-3.5-flash" if publisher == V.GOOGLE else "claude-sonnet-4"
+            assert V.publisher_for(model) == publisher
+            assert V.build_payload(model, "hi")
+            assert V.endpoint_for(model, "proj")
+
+    def test_meta_and_mistral_are_not_offered_yet(self):
+        """They are real on Vertex and served through a third shape, the
+        OpenAI-compatible MaaS endpoint. Listing them before that is
+        implemented would be offering models that cannot be called."""
+        assert "meta" not in V.SUPPORTED_PUBLISHERS
+        assert "mistral" not in V.SUPPORTED_PUBLISHERS
+
+
+class TestTheEndpoint:
+    def test_gemini_uses_generate_content(self):
+        url = V.endpoint_for("gemini-3.5-flash", "town-311")
+        assert url.endswith(":generateContent")
+        assert "publishers/google" in url
+
+    def test_claude_uses_raw_predict(self):
+        url = V.endpoint_for("claude-sonnet-4", "town-311")
+        assert url.endswith(":rawPredict")
+        assert "publishers/anthropic" in url
+
+    def test_claude_is_not_asked_for_from_the_global_endpoint(self):
+        """Anthropic models are not served there, and the 404 reads like a
+        wrong model name rather than a wrong host."""
+        url = V.endpoint_for("claude-sonnet-4", "town-311", "global")
+        assert "global" not in url
+        assert "-aiplatform.googleapis.com" in url
+
+    def test_a_configured_region_is_honoured(self):
+        """PR #433 hardcoded us-central1 and dropped VERTEX_AI_LOCATION, which
+        is the wrong direction for a product sold on compliance boundaries."""
+        assert "europe-west4" in V.endpoint_for("gemini-3.5-flash", "p", "europe-west4")
+        assert "us-east5" in V.endpoint_for("claude-sonnet-4", "p", "us-east5")
+
+    def test_a_qualified_id_does_not_leak_into_the_path(self):
+        url = V.endpoint_for("anthropic/claude-sonnet-4", "p")
+        assert "models/claude-sonnet-4:" in url
+        assert "anthropic/claude" not in url.split("publishers/")[1]
+
+
+class TestTheEnvelope:
+    def test_gemini_gets_contents_and_parts(self):
+        body = V.build_payload("gemini-3.5-flash", "describe this")
+        assert body["contents"][0]["parts"][-1]["text"] == "describe this"
+        assert "anthropic_version" not in body
+
+    def test_claude_gets_messages_and_the_version_marker(self):
+        body = V.build_payload("claude-sonnet-4", "describe this")
+        assert body["anthropic_version"] == "vertex-2023-10-16"
+        assert body["messages"][0]["content"][-1]["text"] == "describe this"
+        assert "contents" not in body
+
+    def test_claude_requires_max_tokens(self):
+        """Anthropic's API rejects a request without it, so a missing default
+        would fail every call rather than degrade."""
+        assert V.build_payload("claude-sonnet-4", "x")["max_tokens"] > 0
+
+    def test_images_ride_in_each_publisher_own_shape(self):
+        img = [{"mime_type": "image/jpeg", "data": "AAA"}]
+        g = V.build_payload("gemini-3.5-flash", "x", img)
+        assert g["contents"][0]["parts"][0]["inline_data"]["data"] == "AAA"
+        a = V.build_payload("claude-sonnet-4", "x", img)
+        assert a["messages"][0]["content"][0]["source"]["data"] == "AAA"
+
+    def test_the_prompt_comes_last_so_images_precede_it(self):
+        img = [{"mime_type": "image/png", "data": "B"}]
+        for model in ("gemini-3.5-flash", "claude-sonnet-4"):
+            body = V.build_payload(model, "the question", img)
+            blocks = body.get("contents", [{}])[0].get("parts") or body["messages"][0]["content"]
+            assert "text" in blocks[-1]
+
+
+class TestReadingTheAnswer:
+    def test_gemini_text_is_joined_and_thoughts_are_skipped(self):
+        result = {"candidates": [{"content": {"parts": [
+            {"text": "ignore me", "thought": True},
+            {"text": '{"priority'}, {"text": '_score": 5}'},
+        ]}}]}
+        assert V.extract_text("gemini-3.5-flash", result) == '{"priority_score": 5}'
+
+    def test_claude_text_blocks_are_joined(self):
+        result = {"content": [{"type": "text", "text": '{"a":'}, {"type": "text", "text": " 1}"}]}
+        assert V.extract_text("claude-sonnet-4", result) == '{"a": 1}'
+
+    def test_a_non_text_block_is_ignored(self):
+        result = {"content": [{"type": "thinking", "thinking": "hmm"},
+                              {"type": "text", "text": "answer"}]}
+        assert V.extract_text("claude-sonnet-4", result) == "answer"
+
+    def test_an_empty_response_is_empty_rather_than_an_error(self):
+        for model in ("gemini-3.5-flash", "claude-sonnet-4"):
+            assert V.extract_text(model, {}) == ""
+
+
+# ---------------------------------------------------------------------------
+# The rest of what PR #433 changed
+# ---------------------------------------------------------------------------
+
+def _source(rel: str) -> str:
+    from pathlib import Path
+
+    return (Path(__file__).resolve().parents[1] / rel).read_text()
+
+
+class TestDiscoveryOffersOnlyUsableModels:
+    def test_bedrock_still_asks_for_text_and_on_demand(self):
+        """Without these an embedding model, an image model, or one needing
+        provisioned throughput lands in a triage picker and fails at request
+        time rather than at selection."""
+        src = _source("app/services/ai/model_discovery.py")
+        assert 'byOutputModality="TEXT"' in src
+        assert 'byInferenceType="ON_DEMAND"' in src
+
+    def test_vertex_honours_the_configured_region(self):
+        src = _source("app/services/ai/model_discovery.py")
+        assert 'creds.get("VERTEX_AI_LOCATION")' in src
+        assert "us-central1-aiplatform" not in src, "the region is hardcoded again"
+
+    def test_vertex_lists_only_publishers_with_a_handler(self):
+        src = _source("app/services/ai/model_discovery.py")
+        assert "SUPPORTED_PUBLISHERS" in src
+        for unsupported in ('"meta"', '"mistral"', '"cohere"', '"ai21"', '"writer"', '"xai"'):
+            assert unsupported not in src, f"{unsupported} is offered without a handler"
+
+    def test_a_failing_publisher_is_logged_rather_than_swallowed(self):
+        """Eight silent excepts meant all eight could fail while the picker
+        showed a short list and nobody learned why."""
+        src = _source("app/services/ai/model_discovery.py")
+        assert "failures.append" in src
+
+
+class TestTheCallerSpeaksMoreThanGemini:
+    def test_it_dispatches_on_publisher(self):
+        src = _source("app/services/vertex_ai_service.py")
+        assert "vertex_publishers" in src
+        assert "vp.endpoint_for" in src and "vp.build_payload" in src
+
+    def test_the_endpoint_is_no_longer_hardcoded_to_google(self):
+        src = _source("app/services/vertex_ai_service.py")
+        assert "publishers/google/models/{model_id}:generateContent" not in src
+
+
+class TestOneDefaultPerProvider:
+    def test_azure_agrees_with_itself(self):
+        """The catalog's default and the client's fallback are two defaults for
+        the same thing; drift puts a town on a deployment the picker never
+        offered."""
+        registry = _source("app/services/ai/registry.py")
+        client = _source("app/services/ai/azure_openai.py")
+        import re
+        catalog_default = re.search(r'"default_model": "(gpt[^"]+)"', registry).group(1)
+        client_default = re.search(r'DEFAULT_DEPLOYMENT = "([^"]+)"', client).group(1)
+        assert catalog_default == client_default

--- a/frontend/src/__preview__/main.tsx
+++ b/frontend/src/__preview__/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import { Database, Activity } from 'lucide-react';
 
 /**
  * A local harness for looking at admin pages.
@@ -133,7 +134,25 @@ function App() {
             </Section>
 
             <Section id="spotlight" title="Service providers — Spotlight, built for real">
-                <ServiceProviders />
+                <ServiceProviders
+                    plainSettings={[
+                        {
+                            id: 'backups', title: 'Automatic backups',
+                            subtitle: 'Encrypted, on S3-compatible storage',
+                            icon: Database, configured: true,
+                            fields: [{ key: 'BACKUP_S3_BUCKET', label: 'Bucket name' }],
+                        },
+                        {
+                            id: 'errors', title: 'Crash reporting', subtitle: 'Sentry',
+                            icon: Activity, configured: false,
+                            fields: [{ key: 'SENTRY_DSN', label: 'Sentry DSN', secret: true }],
+                        },
+                    ]}
+                    plainSecrets={{
+                        values: {}, onChange: () => {}, onSave: async () => {},
+                        saving: null, isConfigured: () => false, onSaved: () => {},
+                    }}
+                />
             </Section>
 
             <Section id="departments" title="Departments">

--- a/frontend/src/components/DialogProvider.tsx
+++ b/frontend/src/components/DialogProvider.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, createContext, useContext, ReactNode } from 'react';
+import { useState, useCallback, useEffect, createContext, useContext, ReactNode } from 'react';
 import { X, AlertTriangle, Info, CheckCircle2, Rocket, Trash2, Shield, Download } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -13,6 +13,13 @@ interface DialogConfig {
     confirmText?: string;
     cancelText?: string;
     icon?: ReactNode;
+    /** A word the person has to type before Confirm becomes available.
+     *
+     * For the small number of actions that destroy data permanently. A dialog
+     * on its own is a speed bump: it appears where a click was already going,
+     * and Confirm is under the cursor. Typing the word is the difference
+     * between agreeing and noticing. */
+    requireTyped?: string;
 }
 
 interface DialogContextType {
@@ -77,6 +84,11 @@ interface DialogProps {
 }
 
 const Dialog = ({ isOpen, config, onConfirm, onCancel, showCancel = true }: DialogProps) => {
+    /* Cleared whenever the dialog opens, so the word typed to authorise one
+     * deletion is never sitting in the box pre-approving the next. */
+    const [typed, setTyped] = useState('');
+    useEffect(() => { if (isOpen) setTyped(''); }, [isOpen]);
+
     const variant = config.variant || 'default';
     const styles = variantStyles[variant];
 
@@ -138,6 +150,20 @@ const Dialog = ({ isOpen, config, onConfirm, onCancel, showCancel = true }: Dial
                                 <div className="text-slate-300 text-base leading-relaxed whitespace-pre-wrap">
                                     {config.message}
                                 </div>
+                                {config.requireTyped && (
+                                    <div className="mt-5">
+                                        <label className="block text-sm text-slate-300 mb-2">
+                                            Type <code className="px-1.5 py-0.5 rounded bg-slate-700 text-white font-semibold">{config.requireTyped}</code> to continue
+                                        </label>
+                                        <input
+                                            autoFocus
+                                            value={typed}
+                                            onChange={(e) => setTyped(e.target.value)}
+                                            className="w-full rounded-xl bg-slate-900 border border-slate-600 px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-red-400"
+                                            placeholder={config.requireTyped}
+                                        />
+                                    </div>
+                                )}
                             </div>
 
                             {/* Actions */}
@@ -152,7 +178,8 @@ const Dialog = ({ isOpen, config, onConfirm, onCancel, showCancel = true }: Dial
                                 )}
                                 <button
                                     onClick={onConfirm}
-                                    className={`px-8 py-3.5 text-base font-medium text-white rounded-xl transition-all ${styles.confirmBtn}`}
+                                    disabled={!!config.requireTyped && typed.trim() !== config.requireTyped}
+                                    className={`px-8 py-3.5 text-base font-medium text-white rounded-xl transition-all disabled:opacity-40 disabled:cursor-not-allowed ${styles.confirmBtn}`}
                                 >
                                     {config.confirmText || 'Confirm'}
                                 </button>

--- a/frontend/src/components/PrintWorkOrder.tsx
+++ b/frontend/src/components/PrintWorkOrder.tsx
@@ -98,7 +98,7 @@ export default function PrintWorkOrder({ request, auditLog, comments, townshipNa
         ` : '';
 
         // Build AI analysis HTML - use correct field names with improved tag styling
-        const qualitativeText = ai?.qualitative_analysis ?? request.vertex_ai_summary ?? null;
+        const qualitativeText = ai?.qualitative_analysis ?? request.ai_summary ?? null;
         const safetyFlagsHtml = ai?.safety_flags?.length ? `
             <div class="ai-tags safety-tags">
                 <strong>Safety Flags:</strong>
@@ -110,10 +110,10 @@ export default function PrintWorkOrder({ request, auditLog, comments, townshipNa
             <div class="section ai-analysis">
                 <h3>${icons.brain} AI Analysis</h3>
                 ${qualitativeText ? `<p><strong>Summary:</strong> ${qualitativeText}</p>` : ''}
-                ${ai?.classification || request.vertex_ai_classification ? `
+                ${ai?.classification || request.ai_classification ? `
                     <div class="ai-tags">
                         <strong>Classification:</strong>
-                        <span class="tag tag-purple">${ai?.classification || request.vertex_ai_classification}</span>
+                        <span class="tag tag-purple">${ai?.classification || request.ai_classification}</span>
                     </div>
                 ` : ''}
                 ${ai?.root_cause ? `<p><strong>Root Cause:</strong> ${ai.root_cause}</p>` : ''}

--- a/frontend/src/components/ServiceProviders.switchedoff.test.tsx
+++ b/frontend/src/components/ServiceProviders.switchedoff.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Deselecting a feature has to leave a trace.
+ *
+ * Reported: "I deselected some and nothing popped up." Hiding the card is only
+ * half an answer -- the other half is telling a town the capability exists and
+ * where to switch it on, or "we cannot do that" becomes the standing
+ * assumption for anything declined once during a five-minute questionnaire.
+ */
+
+vi.mock('../services/api', () => {
+    const shapes: Record<string, unknown> = {
+        getConnectorHealth: { connectors: [] },
+        getCloudIdentity: null,
+        getProviderCatalog: {
+            capability: 'ai', current_provider: 'vertex',
+            providers: [{ provider: 'vertex', name: 'Google Vertex AI', credential_fields: [] }],
+            configured: { vertex: true },
+        },
+        getCloudProfile: {
+            profile: 'google', managed: false, profiles: [],
+            components: { identity: 'auth0' }, maps: { label: 'Google Maps' },
+        },
+    };
+    const api: any = new Proxy({}, {
+        get: (_t, prop: string) => vi.fn().mockResolvedValue(prop in shapes ? shapes[prop] : {}),
+    });
+    return { default: api, api };
+});
+
+let host: HTMLDivElement; let root: Root;
+beforeEach(() => { host = document.createElement('div'); document.body.appendChild(host); root = createRoot(host); });
+afterEach(() => { act(() => root.unmount()); host.remove(); vi.clearAllMocks(); });
+
+async function mount(show?: Set<string>) {
+    const { default: ServiceProviders } = await import('./ServiceProviders');
+    await act(async () => {
+        root.render(React.createElement(ServiceProviders as any, { show }));
+    });
+    return host.textContent || '';
+}
+
+describe('capabilities the town switched off', () => {
+    it('lists them when a feature is deselected', async () => {
+        // Everything except text messages and translation.
+        const text = await mount(new Set(['ai', 'email', 'kms', 'redaction']));
+        expect(text).toContain('Switched off');
+        expect(text).toContain('Text Messages');
+        expect(text).toContain('Translation');
+    });
+
+    it('points at where they are switched back on', async () => {
+        const text = await mount(new Set(['ai']));
+        expect(text).toMatch(/Setup Instructions/i);
+    });
+
+    it('says nothing when the town asked for everything', async () => {
+        const text = await mount(new Set(['ai', 'translation', 'email', 'sms', 'kms', 'redaction']));
+        expect(text).not.toContain('Switched off');
+    });
+
+    it('never lists sign-in or maps, which cannot be switched off', async () => {
+        const text = await mount(new Set([]));
+        const off = text.slice(text.indexOf('Switched off'));
+        expect(off).not.toContain('Staff Sign-In');
+        expect(off).not.toContain('Maps Provider');
+    });
+});

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -838,7 +838,7 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     );
 }
 
-export default function ServiceProviders({ show, extras, refreshToken = 0, onChanged, publicOrigin = null }: {
+export default function ServiceProviders({ show, extras, extraOff = [], refreshToken = 0, onChanged, publicOrigin = null }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -855,6 +855,14 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
      * across both. Rendered here instead, after the capability cards, so the
      * page has one list. */
     extras?: ReactNode;
+    /* Features the town switched off that are not capabilities.
+     *
+     * Backups and crash reporting have no provider catalog, so they are absent
+     * from CAPS and could never appear in the switched-off list -- which is
+     * exactly the pair somebody is most likely to untick and then wonder where
+     * they went. Passed in rather than hardcoded here, because the
+     * questionnaire owns the feature list. */
+    extraOff?: { id: string; title: string; blurb: string; icon: typeof Sparkles }[];
     /* Bumped by the page when the setup guide above saves something.
      *
      * The guide and these cards are two views of one set of credentials, on the
@@ -926,7 +934,12 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
      * Listed, not offered. Turning one on means going through its setup, and a
      * toggle here that quietly enabled a capability with no credentials behind
      * it would be a switch that appears to work and does nothing. */
-    const notChosen = show ? CAPS.filter(c => !ALWAYS.has(c.key) && !show.has(c.key)) : [];
+    const notChosen = [
+        ...(show ? CAPS.filter(c => !ALWAYS.has(c.key) && !show.has(c.key)) : []).map(c => ({
+            id: c.key as string, title: c.title, blurb: c.blurb, icon: c.icon,
+        })),
+        ...extraOff,
+    ];
 
     /* Order matters, and not only for readability.
      *
@@ -1058,7 +1071,7 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                         {notChosen.map(c => (
                             <div
-                                key={c.key}
+                                key={c.id}
                                 className="relative px-4 py-4 rounded-3xl bg-gradient-to-br from-white/[0.035] via-white/[0.01] to-indigo-950/30 border border-white/[0.08] backdrop-blur-2xl"
                             >
                                 <div className="flex items-center gap-3">

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -15,6 +15,7 @@ import {
 
 import { CollapsibleSection } from './ui';
 import { StatusPill, CapabilityTile, Action, hasAlert, type CapabilityState } from './capabilityUI';
+import { PlainSecrets } from './SetupWizard';
 import { api, ProviderCatalog, ProviderInfo, ProviderModelSpec, CloudIdentity } from '../services/api';
 import type { ConnectorHealth } from '../types';
 
@@ -838,7 +839,122 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     );
 }
 
-export default function ServiceProviders({ show, extras, extraOff = [], refreshToken = 0, onChanged, publicOrigin = null }: {
+
+/**
+ * A setting with no provider behind it, drawn as one of the cards.
+ *
+ * Backups and crash reporting were rendered below the grid in an "Other
+ * settings" block, in a completely different treatment and at a different
+ * size, and they read as a separate class of thing. They are not: they are
+ * something the town either has set up or has not, exactly like the eight
+ * above them. The only real difference is that there is nothing to pick
+ * between and nothing to test, so the card carries no provider name and no
+ * "Test now".
+ *
+ * Same shell, same tile, same expand-to-full-width behaviour, so restyling the
+ * capability cards restyles these too rather than leaving them behind again.
+ */
+export interface PlainSetting {
+    id: string;
+    title: string;
+    subtitle: string;
+    icon: typeof Sparkles;
+    fields: { key: string; label: string; secret?: boolean; help?: string }[];
+    configured: boolean;
+    /** Anything the plain fields cannot express -- the backup passphrase, which
+     *  is generated rather than typed and shown exactly once. */
+    body?: ReactNode;
+    /** Why saving is refused, if it is. */
+    blockedReason?: string | null;
+}
+
+function PlainSettingCard({ setting, expanded, onToggle, secrets }: {
+    setting: PlainSetting;
+    expanded: boolean;
+    onToggle: () => void;
+    secrets: PlainSecretsBridge;
+}) {
+    const { title, subtitle, icon: Icon, fields, configured, body } = setting;
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+            className={!expanded
+                ? 'group relative h-full px-4 py-4 rounded-3xl bg-gradient-to-br from-white/[0.06] via-white/[0.02] to-indigo-950/40 border border-white/10 backdrop-blur-2xl hover:border-primary-400/40 hover:-translate-y-0.5 transition-all duration-300'
+                : 'relative overflow-hidden p-5 sm:p-6 rounded-3xl border backdrop-blur-2xl shadow-[0_14px_40px_rgba(0,0,0,0.4)] bg-gradient-to-br from-white/[0.08] via-white/[0.02] to-indigo-950/40 border-white/15'}
+        >
+            <div className="relative">
+                {!expanded ? (
+                    <button
+                        type="button"
+                        onClick={onToggle}
+                        aria-expanded={false}
+                        className="w-full text-left rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400/60"
+                    >
+                        <div className="flex items-center gap-3">
+                            <CapabilityTile icon={Icon} />
+                            <span className="min-w-0 flex-1">
+                                <span className="block font-semibold text-white text-sm truncate">{title}</span>
+                                <span className="block text-[11px] text-white/50 truncate">
+                                    {configured ? subtitle : 'Not set up'}
+                                </span>
+                            </span>
+                            <span className={`shrink-0 ${configured ? 'text-emerald-300' : 'text-white/30'}`} aria-hidden="true">
+                                {configured ? <Check className="w-4 h-4" /> : <CircleDashed className="w-4 h-4" />}
+                            </span>
+                        </div>
+                        <span className={`block text-[11px] mt-2.5 ${configured ? 'text-white/45' : 'text-amber-200/85'}`}>
+                            {configured
+                                ? 'Set up. Nothing here reports back, so there is nothing to test.'
+                                : 'Add its details in Setup Instructions, above.'}
+                        </span>
+                    </button>
+                ) : (
+                    <>
+                        <div className="flex items-start justify-between gap-4 flex-wrap">
+                            <div className="flex items-start gap-4 min-w-0 flex-1">
+                                <CapabilityTile icon={Icon} size="lg" />
+                                <div className="min-w-0">
+                                    <div className="flex items-center gap-3 flex-wrap">
+                                        <h3 className="font-bold text-lg text-white tracking-tight">{title}</h3>
+                                        <StatusPill state={configured ? 'done' : 'unset'} />
+                                    </div>
+                                    <p className="text-sm text-white/60 mt-1">{subtitle}</p>
+                                </div>
+                            </div>
+                            <Action variant="primary" onClick={onToggle} chevron>Close</Action>
+                        </div>
+                        <div className="mt-4 pt-4 border-t border-white/10">
+                            <PlainSecrets
+                                fields={fields}
+                                values={secrets.values}
+                                onChange={secrets.onChange}
+                                onSave={secrets.onSave}
+                                saving={secrets.saving}
+                                isConfigured={secrets.isConfigured}
+                                onSaved={secrets.onSaved}
+                                blockedReason={setting.blockedReason}
+                            />
+                            {body}
+                        </div>
+                    </>
+                )}
+            </div>
+        </motion.div>
+    );
+}
+
+export interface PlainSecretsBridge {
+    values: Record<string, string>;
+    onChange: (key: string, value: string) => void;
+    onSave: (keys: string[]) => Promise<void>;
+    saving: string | null;
+    isConfigured: (key: string) => boolean;
+    onSaved: () => void;
+}
+
+export default function ServiceProviders({ show, extras, footer, extraOff = [], plainSettings = [], plainSecrets, refreshToken = 0, onChanged, publicOrigin = null }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -855,6 +971,9 @@ export default function ServiceProviders({ show, extras, extraOff = [], refreshT
      * across both. Rendered here instead, after the capability cards, so the
      * page has one list. */
     extras?: ReactNode;
+    /** One quiet line under everything. Not a section: the block this replaced
+     *  had a heading announcing a group that ended up containing one sentence. */
+    footer?: ReactNode;
     /* Features the town switched off that are not capabilities.
      *
      * Backups and crash reporting have no provider catalog, so they are absent
@@ -863,6 +982,11 @@ export default function ServiceProviders({ show, extras, extraOff = [], refreshT
      * they went. Passed in rather than hardcoded here, because the
      * questionnaire owns the feature list. */
     extraOff?: { id: string; title: string; blurb: string; icon: typeof Sparkles }[];
+    /** Settings with no provider behind them, drawn as cards in the same grid.
+     *  They were in a separate block below, in a different treatment at a
+     *  different size, reading as a different class of thing. */
+    plainSettings?: PlainSetting[];
+    plainSecrets?: PlainSecretsBridge;
     /* Bumped by the page when the setup guide above saves something.
      *
      * The guide and these cards are two views of one set of credentials, on the
@@ -969,7 +1093,11 @@ export default function ServiceProviders({ show, extras, extraOff = [], refreshT
 
     /* Which card the clerk has opened in the Spotlight layout. Held here rather
      * than in the card, because opening one has to widen its cell. */
-    const [openCap, setOpenCap] = useState<Capability | null>(null);
+    /* Which card is expanded. A string rather than a Capability, because the
+     * plain settings -- backups, crash reporting -- share this grid and this
+     * behaviour, and giving them a second piece of open-state would let two
+     * cards be open at once. */
+    const [openCap, setOpenCap] = useState<string | null>(null);
     const capState = (cap: Capability) => capabilityState(statuses[cap], health[cap]);
     /* Only what is wrong gets the whole width.
      *
@@ -1060,6 +1188,21 @@ export default function ServiceProviders({ show, extras, extraOff = [], refreshT
                         </div>
                     );
                 })}
+
+                {/* In the grid, not below it. */}
+                {plainSecrets && plainSettings.map(setting => (
+                    <div
+                        key={setting.id}
+                        className={openCap === setting.id ? 'sm:col-span-2 lg:col-span-3' : ''}
+                    >
+                        <PlainSettingCard
+                            setting={setting}
+                            secrets={plainSecrets}
+                            expanded={openCap === setting.id}
+                            onToggle={() => setOpenCap(k => (k === setting.id ? null : setting.id))}
+                        />
+                    </div>
+                ))}
             </div>
 
             {notChosen.length > 0 && (
@@ -1098,6 +1241,8 @@ export default function ServiceProviders({ show, extras, extraOff = [], refreshT
                     </p>
                 </div>
             )}
+
+            {footer && <div className="mt-6">{footer}</div>}
 
             {extras && (
                 <div className="mt-8">

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 
 import { CollapsibleSection } from './ui';
-import { StatusPill, CapabilityTile, Action, type CapabilityState } from './capabilityUI';
+import { StatusPill, CapabilityTile, Action, hasAlert, type CapabilityState } from './capabilityUI';
 import { api, ProviderCatalog, ProviderInfo, ProviderModelSpec, CloudIdentity } from '../services/api';
 import type { ConnectorHealth } from '../types';
 
@@ -266,9 +266,13 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             // test here", not "the test failed". Passing t.ok straight through
             // is what put a red "Not working" on an HTTP SMS gateway whose own
             // message said it could not be checked.
-            onStatus(cap, t.recorded === false
-                ? { verifiable: false, verified: null }
-                : { verifiable: true, verified: t.ok });
+            // `configured: false` beats everything: the test looked for the
+            // credentials and they are not there, whatever the catalog said.
+            onStatus(cap, t.configured === false
+                ? { configured: false, verifiable: undefined, verified: null }
+                : t.recorded === false
+                    ? { verifiable: false, verified: null }
+                    : { verifiable: true, verified: t.ok });
         } catch (e: any) {
             setResult({ ok: false, detail: e?.message || 'Test failed' });
             onStatus(cap, { verified: false });
@@ -433,9 +437,11 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             // Immediately verify
             const t = await api.testProvider(cap);
             setResult(t);
-            onStatus(cap, t.recorded === false
-                ? { verifiable: false, verified: null }
-                : { verifiable: true, verified: t.ok });
+            onStatus(cap, t.configured === false
+                ? { configured: false, verifiable: undefined, verified: null }
+                : t.recorded === false
+                    ? { verifiable: false, verified: null }
+                    : { verifiable: true, verified: t.ok });
         } catch (e: any) {
             setError(e?.message || 'Save failed');
         } finally {
@@ -506,9 +512,22 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                             credentials: the tile already says "Not set up", and
                             "Not checked yet" underneath reads as a second,
                             different problem. */}
-                        {configured && (
+                        {configured ? (
                             <span className="block text-[11px] text-white/45 mt-2.5">
-                                {shown === 'unverifiable' ? 'Set up. There is no way to test this one from here.' : checkedLine}
+                                {shown === 'unverifiable'
+                                    ? 'Set up. There is no way to test this one from here.'
+                                    : checkedLine}
+                            </span>
+                        ) : (
+                            /* Somewhere to go.
+                             *
+                             * A card that says "Not set up" and stops is a dead
+                             * end: the questionnaire and the steps are back up
+                             * the page, and nothing here said so. This is a
+                             * town that asked for the feature, so the useful
+                             * thing is the next action, not the diagnosis. */
+                            <span className="block text-[11px] text-amber-200/85 mt-2.5">
+                                Add its credentials in Setup Instructions, above.
                             </span>
                         )}
                     </button>
@@ -549,7 +568,12 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                                 {/* Only where there is an alert to silence. A
                                     capability nobody is being emailed about
                                     does not need an off switch. */}
-                                {(shown === 'failing' || shown === 'unchecked') && (
+                                {/* Only where something is actually alerting.
+                                    Derived from the health status rather than
+                                    from the pill, because "not checked yet"
+                                    covers both `unknown`, which never alerts,
+                                    and `stale`, which does. */}
+                                {(hasAlert(health?.status) || !!effectiveMute) && (
                                     <Action onClick={toggleMute} busy={muting} disabled={muting}
                                         title={effectiveMute
                                             ? 'Start emailing administrators about this again'
@@ -975,6 +999,16 @@ export default function ServiceProviders({ show, extras, refreshToken = 0, onCha
                     <span>{configuredCount === loaded.length
                         ? `All ${loaded.length} have credentials`
                         : `${loaded.length - configuredCount} of ${loaded.length} still need credentials`}</span>
+                    {/* Named, and pointed somewhere.
+                        A count on its own makes a clerk hunt for which ones,
+                        and the answer to "so what do I do" is up the page in a
+                        panel this section never mentioned. */}
+                    {configuredCount < loaded.length && (
+                        <span className="text-amber-200/85">
+                            {loaded.filter(c => !statuses[c.key]?.configured).map(c => c.title).join(', ')}
+                            {' — set these up in Setup Instructions, above'}
+                        </span>
+                    )}
                     {verifiedCount > 0 && <span className="text-emerald-300/80 inline-flex items-center gap-1"><CheckCircle className="w-3 h-3" />{verifiedCount} verified</span>}
                     {failedCount > 0 && <span className="text-amber-300/90 inline-flex items-center gap-1"><AlertCircle className="w-3 h-3" />{failedCount} not working</span>}
                     {unverifiableCount > 0 && (

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
     Sparkles, Languages, KeyRound, CheckCircle, AlertCircle,
-    Check, CircleDashed, HelpCircle, ShieldCheck, RefreshCw,
+    Check, CircleDashed, HelpCircle, ShieldCheck, RefreshCw, Search,
     Lock, Map as MapIcon,
     Mail, MessageSquare, Image as ImageIcon,
 } from 'lucide-react';
@@ -209,6 +209,13 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     const [liveModels, setLiveModels] = useState<ProviderModelSpec[] | null>(null);
     const [modelsMeta, setModelsMeta] = useState<{ source?: string; fetched_at?: number | null } | null>(null);
     const [staleOverride, setStaleOverride] = useState<boolean | null>(null);
+    /* Filters the model tiles.
+     *
+     * Declared, which the version in #433 was not -- it used the setter and the
+     * value five times with no useState, so opening any AI card threw a
+     * ReferenceError. `vite build` passed anyway, because esbuild strips types
+     * without resolving identifiers, and nothing in CI runs tsc. */
+    const [modelSearch, setModelSearch] = useState('');
     const [warnings, setWarnings] = useState<{ key: string; severity: string; message: string }[]>([]);
     /* Collapsed by default, expanded when something needs attention.
      *
@@ -730,16 +737,49 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                                     {refreshingModels ? 'Checking…' : 'Refresh from provider'}
                                 </button>
                             }>Model</Step>
-                            {/* Tiles, not a <select>. The model list is short, the
-                                choice is consequential, and a dropdown hides every
-                                option but one -- including the "new" markers that
-                                live discovery just added. Same control as the
-                                provider picker above, so the page has one idiom. */}
+                            {/* Tiles, not a <select>. The choice is consequential and
+                                a dropdown hides every option but one -- including the
+                                "new" markers live discovery just added. Same control as
+                                the provider picker above, so the page has one idiom.
+
+                                Searchable once the list is long enough to scroll:
+                                Vertex Model Garden legitimately returns a couple of
+                                hundred entries, and scanning those as tiles is worse
+                                than the dropdown this replaced. */}
+                            {models.length > 8 && (
+                                <div className="relative mb-2">
+                                    <Search className="w-3.5 h-3.5 absolute left-3 top-2.5 text-white/50 pointer-events-none" aria-hidden="true" />
+                                    <input
+                                        type="search"
+                                        id={`model-search-${cap}`}
+                                        value={modelSearch}
+                                        onChange={e => setModelSearch(e.target.value)}
+                                        /* A real label, not just a placeholder: the
+                                           placeholder disappears the moment somebody
+                                           types, and this console is audited for AA. */
+                                        aria-label={`Search the ${models.length} models ${active.name} offers`}
+                                        placeholder={`Search ${models.length} models — try "flash", "claude", "mini"`}
+                                        className="w-full bg-white/[0.04] border border-white/10 rounded-xl pl-9 pr-3 py-1.5 text-xs text-white placeholder-white/50 focus:outline-none focus:border-primary-400/60 transition-colors"
+                                    />
+                                </div>
+                            )}
                             {(() => {
                                 const chosen = model || active.default_model || models[0].id;
+                                const q = modelSearch.trim().toLowerCase();
+                                const filtered = q
+                                    ? models.filter(m => m.id.toLowerCase().includes(q)
+                                        || m.label.toLowerCase().includes(q))
+                                    : models;
+                                if (filtered.length === 0) {
+                                    return (
+                                        <p className="py-4 text-center text-xs text-white/60 bg-white/[0.02] border border-white/10 rounded-xl">
+                                            No model matches “{modelSearch}”.
+                                        </p>
+                                    );
+                                }
                                 return (
-                                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2" role="radiogroup" aria-label="AI model">
-                                        {models.map(m => {
+                                    <div className="max-h-80 overflow-y-auto pr-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2" role="radiogroup" aria-label="AI model">
+                                        {filtered.map(m => {
                                             const isSel = m.id === chosen;
                                             return (
                                                 <button

--- a/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
@@ -83,11 +83,12 @@ describe('the setup page after the Other-settings surgery', () => {
     });
 
     it('still offers crash reporting and backups', async () => {
-        // Both were rewritten to render shared field definitions. If either
-        // vanished during the edit, this is where it shows up.
+        // They are cards in the provider grid now rather than a separate block
+        // below it, so they are collapsed bubbles carrying their title. If
+        // either vanished during the move, this is where it shows up.
         const text = await mount();
         expect(text).toContain('Crash reporting');
-        expect(text).toMatch(/Database Backups/i);
+        expect(text).toContain('Automatic backups');
     });
 
     it('no longer carries a Google Cloud card in Other settings', async () => {
@@ -96,10 +97,12 @@ describe('the setup page after the Other-settings surgery', () => {
         expect(text).not.toContain('GCP Project ID');
     });
 
-    it('asks for the backup bucket by the shared label', async () => {
-        // Proves the shared array is what rendered, not a surviving hand-written
-        // copy that happens to look similar.
+    it('draws them as cards rather than as a separate block', async () => {
+        // The whole point of the move. Collapsed, they say whether they are set
+        // up and where to go, exactly like the eight capabilities beside them --
+        // and the credential fields appear on expand, from the shared array.
         const text = await mount();
-        expect(text).toContain('Bucket name');
+        expect(text).not.toContain('Other settings');
+        expect(text).toMatch(/Not set up|Set up/);
     });
 });

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -2,10 +2,10 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-    Key, Shield, CheckCircle, CircleDashed, Activity,
+    Key, CheckCircle, CircleDashed, Activity,
     AlertCircle, ChevronDown, ChevronUp,
     ExternalLink, Database, BookOpen,
-    ListChecks, HardDrive, Bell,
+    ListChecks, Bell,
 } from 'lucide-react';
 
 import { Card, Button, Badge, CollapsibleSection } from './ui';
@@ -16,8 +16,6 @@ import GovtechIntegrations from './GovtechIntegrations';
 import ServiceProviders from './ServiceProviders';
 import SetupWizard from './SetupWizard';
 import { buildPlan, summarise, nameList, BACKUP_SECRETS, SENTRY_SECRETS } from './setupPlan';
-import { PlainSecrets } from './SetupWizard';
-import { CapabilityTile, StatusPill } from './capabilityUI';
 // Registers every provider's setup steps as a side effect, so the guide can
 // render them inline rather than pointing at the cards that do.
 import './setupStepsContent';
@@ -652,6 +650,77 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         </div>
     );
 
+    /* The backup passphrase, rendered inside the backups card.
+     *
+     * Deliberately not one of the plain credential fields: it is generated
+     * rather than typed, shown exactly once, and gated on somebody confirming
+     * they kept a copy. A generic form would lose all three, and losing it
+     * means a town's backups cannot be restored.
+     */
+    const renderBackupPassphrase = () => (
+        <div className="mt-4 pt-4 border-t border-white/10">
+    <div>
+        <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
+        {!backupKey ? (
+            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                <p className="text-white/50 text-xs mb-2.5">
+                    {isConfigured('BACKUP_ENCRYPTION_KEY')
+                        ? "A passphrase is already set and backups are being encrypted with it. Creating a new one means older backups can only be restored with the old passphrase — so only do this if the current one has been exposed."
+                        : "Backups are encrypted before they leave this server. We'll create the passphrase for you — you don't need to think one up."}
+                </p>
+                <Button
+                    size="sm"
+                    variant="ghost"
+                    className="w-full border border-white/15 hover:bg-white/10"
+                    onClick={async () => {
+                        try {
+                            const { key } = await api.generateBackupKey();
+                            setBackupKey(key);
+                        } catch (err: any) {
+                            setSaveMessage(`❌ ${err.message || 'Could not create a passphrase'}`);
+                        }
+                    }}
+                >
+                    {isConfigured('BACKUP_ENCRYPTION_KEY')
+                        ? 'Replace backup passphrase'
+                        : 'Create backup passphrase'}
+                </Button>
+            </div>
+        ) : (
+            <div className="rounded-xl border border-amber-400/30 bg-amber-500/[0.07] p-3 space-y-2.5">
+                <p className="text-amber-100/90 text-xs leading-relaxed">
+                    This is shown once. Put a copy somewhere that is <strong>not this
+                    server</strong> — a password manager, or a sealed envelope in the
+                    clerk's safe. Without it, a backup cannot be restored, and that is the
+                    one thing we cannot do for you.
+                </p>
+                <div className="flex items-center gap-2">
+                    <code className="flex-1 bg-black/40 rounded-lg px-3 py-2 text-[11px] text-amber-200 break-all select-all">
+                        {backupKey}
+                    </code>
+                    <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => navigator.clipboard?.writeText(backupKey)}
+                    >
+                        Copy
+                    </Button>
+                </div>
+                <label className="flex items-start gap-2 text-xs text-white/70 cursor-pointer">
+                    <input
+                        type="checkbox"
+                        checked={backupKeyAcknowledged}
+                        onChange={(e) => setBackupKeyAcknowledged(e.target.checked)}
+                        className="mt-0.5 accent-amber-400"
+                    />
+                    I have saved a copy of this passphrase somewhere off this server.
+                </label>
+            </div>
+        )}
+    </div>
+        </div>
+    );
+
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -974,6 +1043,38 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                        provider catalog, so they are not in CAPS and could never
                        show up as switched off -- which is the pair somebody is
                        most likely to untick and then wonder about. */
+                    /* In the grid, as cards, alongside the eight capabilities. */
+                    plainSettings={[
+                        ...(wantedFeatures.has('backups') ? [{
+                            id: 'backups',
+                            title: 'Automatic backups',
+                            subtitle: 'Encrypted, on S3-compatible storage',
+                            icon: Database,
+                            fields: BACKUP_SECRETS,
+                            configured: !!backupConfigured,
+                            blockedReason:
+                                (backupKeyAcknowledged || (!backupKey && isConfigured('BACKUP_ENCRYPTION_KEY')))
+                                    ? null
+                                    : 'Create the encryption passphrase below and confirm you have kept a copy first.',
+                            body: renderBackupPassphrase(),
+                        }] : []),
+                        ...(wantedFeatures.has('errors') ? [{
+                            id: 'errors',
+                            title: 'Crash reporting',
+                            subtitle: 'Sentry',
+                            icon: Activity,
+                            fields: SENTRY_SECRETS,
+                            configured: !!isConfigured('SENTRY_DSN'),
+                        }] : []),
+                    ]}
+                    plainSecrets={{
+                        values: secretValues,
+                        onChange: (k, v) => setSecretValues(p => ({ ...p, [k]: v })),
+                        onSave: async (keys) => { for (const k of keys) await handleSave(k); },
+                        saving: savingKey,
+                        isConfigured: (k) => !!isConfigured(k),
+                        onSaved: () => undefined,
+                    }}
                     extraOff={[
                         ...(wantedFeatures.has('backups') ? [] : [{
                             id: 'backups', title: 'Automatic backups', icon: Database,
@@ -987,239 +1088,22 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                     refreshToken={providerRefresh}
                     publicOrigin={publicOrigin}
                     onChanged={() => { onRefresh(); loadProviderStatus(); }}
-                    extras={
-                        <>
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            {/* The Google Cloud card that used to open this
-                                section has gone. Its instructions and its two
-                                boxes now sit together in the setup guide's
-                                Google task, so the walk that says "download
-                                this file" ends where the file is added rather
-                                than pointing thousands of pixels down the page.
-
-                                Nothing replaces it for Azure or AWS, and that
-                                is correct: neither has an account-level
-                                credential to enter. */}
-                            {/* Where the stored data actually lives.
-                              *
-                              * This used to be two buttons -- "Vault Local Secrets to GCP
-                              * Identity" and "Re-encrypt All PII Data (after key rotation)" --
-                              * which asked a clerk to recognise the need for work they had no
-                              * way to know about. Both now run on a schedule, so all that is
-                              * left is one sentence.
-                              *
-                              * Deliberately outside the Google Cloud card. Secret storage and
-                              * key management are pluggable, and anything nested in that card
-                              * is invisible to a town on Azure or AWS -- which is exactly the
-                              * town most likely to want to know where its credentials are. */}
-                            <div className="px-1">
-                                <StorageStatusLine />
-                            </div>
-
-
-                            {/* Crash reporting.
-                                One field, and it was written out by hand here
-                                as well as in setupPlan.ts. Both now render the
-                                same SENTRY_SECRETS array through the same
-                                component the guide uses -- two copies of a
-                                credential form is exactly how the guide and
-                                the cards drifted last time. */}
-                            <div className="premium-card p-5">
-                                <div className="flex items-center gap-3.5 mb-3.5">
-                                    <CapabilityTile icon={Activity} size="sm" />
-                                    <div className="min-w-0 flex-1">
-                                        <h3 className="font-semibold text-white">Crash reporting</h3>
-                                        <p className="text-white/55 text-xs">
-                                            Sends crash reports off this server, so they survive a restart.
-                                        </p>
-                                    </div>
-                                    <StatusPill state={isConfigured('SENTRY_DSN') ? 'done' : 'unset'} />
-                                </div>
-                                <PlainSecrets
-                                    fields={SENTRY_SECRETS}
-                                    values={secretValues}
-                                    onChange={(k, v) => setSecretValues(p => ({ ...p, [k]: v }))}
-                                    onSave={async (keys) => { for (const k of keys) await handleSave(k); }}
-                                    saving={savingKey}
-                                    isConfigured={(k) => !!isConfigured(k)}
-                                    onSaved={() => undefined}
-                                />
-                            </div>
-
-                            {/* Database Backups - Premium Card (locked in managed mode: the state owns backups) */}
-                            {managedMode ? (
-                                <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6">
-                                    <div className="flex items-center gap-4 mb-2">
-                                        <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-white/10">
-                                            <HardDrive className="w-7 h-7 text-white/50" />
-                                        </div>
-                                        <div>
-                                            <h3 className="font-bold text-lg text-white/70">Database Backups</h3>
-                                            <p className="text-white/40 text-sm">Encrypted off-site backups</p>
-                                        </div>
-                                        <span className="ml-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/10 text-white/60 border border-white/15">
-                                            <Shield className="w-3.5 h-3.5" />
-                                            Managed by your state
-                                        </span>
-                                    </div>
-                                    <p className="text-white/50 text-sm">
-                                        Automated encrypted backups run under your state hosting program's disaster-recovery plan. Nothing to configure here.
-                                    </p>
-                                </div>
-                            ) : (
-                            <motion.div
-                                initial={{ opacity: 0, y: 20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                transition={{ delay: 0.5 }}
-                                className={`relative rounded-3xl border p-6 transition-all duration-300 ${backupConfigured
-                                    ? 'bg-gradient-to-br from-amber-500/10 via-yellow-500/5 to-orange-500/10 border-amber-500/30 shadow-lg shadow-amber-500/10'
-                                    : 'setup-panel border-transparent'
-                                    }`}
-                            >
-                                {backupConfigured && (
-                                    <div className="absolute inset-0 bg-gradient-to-r from-amber-500/5 via-transparent to-orange-500/5 pointer-events-none" />
-                                )}
-
-                                <div className="relative">
-                                    <div className="flex items-start justify-between mb-4">
-                                        <div className="flex items-center gap-4">
-                                            <div className={`w-14 h-14 rounded-2xl flex items-center justify-center transition-all duration-300 ${backupConfigured
-                                                ? 'bg-gradient-to-br from-amber-400 to-orange-500 shadow-lg shadow-amber-500/30'
-                                                : 'setup-tile'
-                                                }`}>
-                                                <HardDrive className="w-7 h-7 text-white" />
-                                            </div>
-                                            <div>
-                                                <h3 className="font-bold text-lg text-white">Database Backups</h3>
-                                                <p className="text-white/50 text-sm">Encrypted S3-compatible storage</p>
-                                            </div>
-                                        </div>
-                                        {backupConfigured ? (
-                                            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-300 border border-amber-500/30 shadow-lg shadow-amber-500/10">
-                                                <CheckCircle className="w-3.5 h-3.5" />
-                                                Configured
-                                            </span>
-                                        ) : (
-                                            <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 text-white/50 border border-white/10">
-                                                Optional
-                                            </span>
-                                        )}
-                                    </div>
-
-                                    <p className="text-white/60 text-sm mb-4">
-                                        Backups are encrypted with AES-256 and stored in your S3-compatible bucket. Backup cleanup follows your configured retention policy.
-                                        See the <strong className="text-amber-300">Setup Instructions</strong> above for provider-specific guidance.
-                                    </p>
-
-                                    {/* The five S3 boxes were written by hand
-                                        here and again in setupPlan.ts. Both
-                                        now render BACKUP_SECRETS through the
-                                        same component the guide uses.
-
-                                        The passphrase below is not part of
-                                        that array on purpose: it is generated
-                                        rather than typed, it is shown exactly
-                                        once, and it needs the acknowledgement
-                                        checkbox. Folding it into a generic
-                                        credential form would lose all three,
-                                        and losing it means a town's backups
-                                        cannot be restored. */}
-                                    {!backupConfigured || secretValues['BACKUP_S3_BUCKET'] !== undefined ? (
-                                        <div className="space-y-3">
-                                            <PlainSecrets
-                                                fields={BACKUP_SECRETS}
-                                                values={secretValues}
-                                                onChange={(k, v) => setSecretValues(p => ({ ...p, [k]: v }))}
-                                                onSave={async (keys) => { for (const k of keys) await handleSave(k); }}
-                                                saving={savingKey}
-                                                isConfigured={(k) => !!isConfigured(k)}
-                                                onSaved={() => undefined}
-                                                blockedReason={
-                                                    (backupKeyAcknowledged || (!backupKey && isConfigured('BACKUP_ENCRYPTION_KEY')))
-                                                        ? null
-                                                        : 'Create the encryption passphrase below and confirm you have kept a copy first.'
-                                                }
-                                            />
-
-                                            <div>
-                                                <label className="text-sm text-white/60 mb-1.5 block">Encryption Passphrase</label>
-                                                {!backupKey ? (
-                                                    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
-                                                        <p className="text-white/50 text-xs mb-2.5">
-                                                            {isConfigured('BACKUP_ENCRYPTION_KEY')
-                                                                ? "A passphrase is already set and backups are being encrypted with it. Creating a new one means older backups can only be restored with the old passphrase — so only do this if the current one has been exposed."
-                                                                : "Backups are encrypted before they leave this server. We'll create the passphrase for you — you don't need to think one up."}
-                                                        </p>
-                                                        <Button
-                                                            size="sm"
-                                                            variant="ghost"
-                                                            className="w-full border border-white/15 hover:bg-white/10"
-                                                            onClick={async () => {
-                                                                try {
-                                                                    const { key } = await api.generateBackupKey();
-                                                                    setBackupKey(key);
-                                                                } catch (err: any) {
-                                                                    setSaveMessage(`❌ ${err.message || 'Could not create a passphrase'}`);
-                                                                }
-                                                            }}
-                                                        >
-                                                            {isConfigured('BACKUP_ENCRYPTION_KEY')
-                                                                ? 'Replace backup passphrase'
-                                                                : 'Create backup passphrase'}
-                                                        </Button>
-                                                    </div>
-                                                ) : (
-                                                    <div className="rounded-xl border border-amber-400/30 bg-amber-500/[0.07] p-3 space-y-2.5">
-                                                        <p className="text-amber-100/90 text-xs leading-relaxed">
-                                                            This is shown once. Put a copy somewhere that is <strong>not this
-                                                            server</strong> — a password manager, or a sealed envelope in the
-                                                            clerk's safe. Without it, a backup cannot be restored, and that is the
-                                                            one thing we cannot do for you.
-                                                        </p>
-                                                        <div className="flex items-center gap-2">
-                                                            <code className="flex-1 bg-black/40 rounded-lg px-3 py-2 text-[11px] text-amber-200 break-all select-all">
-                                                                {backupKey}
-                                                            </code>
-                                                            <Button
-                                                                size="sm"
-                                                                variant="ghost"
-                                                                onClick={() => navigator.clipboard?.writeText(backupKey)}
-                                                            >
-                                                                Copy
-                                                            </Button>
-                                                        </div>
-                                                        <label className="flex items-start gap-2 text-xs text-white/70 cursor-pointer">
-                                                            <input
-                                                                type="checkbox"
-                                                                checked={backupKeyAcknowledged}
-                                                                onChange={(e) => setBackupKeyAcknowledged(e.target.checked)}
-                                                                className="mt-0.5 accent-amber-400"
-                                                            />
-                                                            I have saved a copy of this passphrase somewhere off this server.
-                                                        </label>
-                                                    </div>
-                                                )}
-                                            </div>
-
-                                        </div>
-                                    ) : (
-                                        <div className="space-y-3">
-                                            <div className="flex items-center gap-2">
-                                                <div className="flex-1 h-10 rounded-xl bg-amber-500/20 border border-amber-500/30 flex items-center px-4">
-                                                    <CheckCircle className="w-4 h-4 text-amber-400 mr-2" />
-                                                    <span className="text-amber-200 text-sm">Backup storage configured</span>
-                                                </div>
-                                                <Button size="sm" variant="ghost" onClick={() => setSecretValues(p => ({ ...p, 'BACKUP_S3_BUCKET': '' }))}>
-                                                    Change
-                                                </Button>
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                            </motion.div>
-                            )}
+                    /* The "Other settings" block is gone.
+                     *
+                     * Its Google Cloud card moved into the setup guide, and its
+                     * backups and crash-reporting cards moved into the grid, so
+                     * all that was left was one status line under a heading
+                     * announcing a section containing nothing else. */
+                    footer={
+                        <div className="px-1">
+                            {/* Where the stored data actually lives. Deliberately
+                                not nested in any provider's card: secret storage
+                                and key management are pluggable, and anything
+                                inside the Google card is invisible to the town on
+                                Azure or AWS -- which is the town most likely to
+                                want to know where its credentials are. */}
+                            <StorageStatusLine />
                         </div>
-                        </>
                     }
                 />
             </div>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -970,6 +970,20 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             <div id="sec-providers">
                 <ServiceProviders
                     show={wantedCapabilities}
+                    /* Backups and crash reporting are features without a
+                       provider catalog, so they are not in CAPS and could never
+                       show up as switched off -- which is the pair somebody is
+                       most likely to untick and then wonder about. */
+                    extraOff={[
+                        ...(wantedFeatures.has('backups') ? [] : [{
+                            id: 'backups', title: 'Automatic backups', icon: Database,
+                            blurb: 'A nightly copy of everything, kept somewhere other than this server.',
+                        }]),
+                        ...(wantedFeatures.has('errors') ? [] : [{
+                            id: 'errors', title: 'Crash reporting', icon: Activity,
+                            blurb: 'Sends crash reports off this server, so they survive a restart.',
+                        }]),
+                    ]}
                     refreshToken={providerRefresh}
                     publicOrigin={publicOrigin}
                     onChanged={() => { onRefresh(); loadProviderStatus(); }}

--- a/frontend/src/components/capabilityUI.tsx
+++ b/frontend/src/components/capabilityUI.tsx
@@ -18,6 +18,25 @@ import { Check, AlertCircle, CircleDashed, HelpCircle, ChevronDown, Loader2 } fr
  * this file, and there is nowhere else to edit.
  */
 
+/**
+ * The health statuses that actually raise an alert.
+ *
+ * Mirrors `alert_level` in connector_alerts.py, and a backend test fails if the
+ * two lists stop agreeing. Offering "Mute alerts" anywhere else is offering to
+ * silence something that was never going to make a sound: a connector nobody
+ * has checked yet reports `unknown`, which maps to healthy, so the button was
+ * appearing on cards with no alert behind them.
+ *
+ * `stale` is the case that makes this worth deriving rather than eyeballing --
+ * it displays as "not checked yet" but does alert, so neither the raw status
+ * nor the display state answers the question on its own.
+ */
+export const ALERTING_STATUSES = ['down', 'failing', 'stale'] as const;
+
+export function hasAlert(status?: string | null): boolean {
+    return !!status && (ALERTING_STATUSES as readonly string[]).includes(status);
+}
+
 export type CapabilityState =
     | 'working'      // a live check succeeded recently
     | 'failing'      // a live check failed, and we have the provider's words

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -904,11 +904,15 @@ export default function AdminConsole() {
         policy: { name: string; retention_days: number; retention_years: number; source: string; public_records_law: string };
         override_days: number | null;
         effective_days: number;
-        mode: 'anonymize' | 'delete';
+        mode: 'redact' | 'delete';
         stats: { eligible_for_archival: number; under_legal_hold: number; already_archived: number; cutoff_date: string };
     } | null>(null);
     const [selectedStateCode, setSelectedStateCode] = useState<string>('');
-    const [selectedMode, setSelectedMode] = useState<'anonymize' | 'delete'>('anonymize');
+    const [selectedMode, setSelectedMode] = useState<'redact' | 'delete'>('redact');
+    /* Which fields a retention run clears. Null until the server answers --
+     * rendering the catalog from a hardcoded copy here is how the screen and
+     * the thing it configures drift apart. */
+    const [scrubFields, setScrubFields] = useState<import('../services/api').ScrubField[] | null>(null);
     const [overrideDays, setOverrideDays] = useState<string>('');
     const [isSavingRetention, setIsSavingRetention] = useState(false);
     const [isRunningRetention, setIsRunningRetention] = useState(false);
@@ -1037,7 +1041,8 @@ export default function AdminConsole() {
                         setRetentionStates(states);
                         setRetentionPolicy(policy);
                         setSelectedStateCode(policy.state_code);
-                        setSelectedMode(policy.mode);
+                        setSelectedMode(policy.mode === 'delete' ? 'delete' : 'redact');
+                        setScrubFields(policy.scrub_fields || null);
                         // Reflect the saved override in the input (was always blank before)
                         setOverrideDays(policy.override_days ? String(policy.override_days) : '');
                         // Filter for deleted requests only
@@ -2853,7 +2858,7 @@ export default function AdminConsole() {
                                 {retentionPolicy && (
                                     <AccordionSection
                                         title={`Current Policy: ${retentionPolicy.policy.public_records_law}`}
-                                        subtitle={`${retentionPolicy.policy.name} • ${formatYears(retentionPolicy.effective_days)} retention${retentionPolicy.override_days ? ' (custom override)' : ''} • ${retentionPolicy.mode === 'anonymize' ? 'Anonymize mode' : 'Delete mode'}`}
+                                        subtitle={`${retentionPolicy.policy.name} • ${formatYears(retentionPolicy.effective_days)} retention${retentionPolicy.override_days ? ' (custom override)' : ''} • ${retentionPolicy.mode === 'delete' ? 'Delete mode' : 'Redact mode'}`}
                                         icon={Shield}
                                         iconClassName="text-green-400"
                                         badge={<Badge variant="success">Active</Badge>}
@@ -2878,7 +2883,7 @@ export default function AdminConsole() {
                                             <div className="bg-white/5 rounded-lg p-4">
                                                 <div className="text-white/60 text-sm">Mode</div>
                                                 <div className="text-2xl font-bold text-white capitalize">{retentionPolicy.mode}</div>
-                                                <div className="text-white/40 text-sm">{retentionPolicy.mode === 'anonymize' ? 'PII removed, stats kept' : 'Permanent deletion'}</div>
+                                                <div className="text-white/40 text-sm">{retentionPolicy.mode === 'delete' ? 'Permanent deletion' : 'Chosen fields cleared, record kept'}</div>
                                             </div>
                                         </div>
 
@@ -3166,12 +3171,17 @@ export default function AdminConsole() {
                                             <label className="block text-sm font-medium text-white/70 mb-2">Archival Mode</label>
                                             <select
                                                 value={selectedMode}
-                                                onChange={(e) => setSelectedMode(e.target.value as 'anonymize' | 'delete')}
+                                                onChange={(e) => setSelectedMode(e.target.value as 'redact' | 'delete')}
                                                 className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-amber-400"
                                                 aria-label="Select archival mode"
                                             >
-                                                <option value="anonymize" className="bg-slate-800">Anonymize (Remove PII, keep statistics)</option>
-                                                <option value="delete" className="bg-slate-800">Delete (Permanent removal)</option>
+                                                {/* Not "anonymise". Anonymising means removing what
+                                                    ties data to a person; this also clears the
+                                                    description and the staff notes, which is
+                                                    redaction. The two are not interchangeable when
+                                                    the difference is what a town tells a judge. */}
+                                                <option value="redact" className="bg-slate-800">Redact — clear the fields you choose, keep the record</option>
+                                                <option value="delete" className="bg-slate-800">Delete — remove the record entirely</option>
                                             </select>
                                         </div>
 
@@ -3189,6 +3199,48 @@ export default function AdminConsole() {
                                             <p className="text-white/40 text-xs mt-1">Min 365 days. Must be ≥ state requirement.</p>
                                         </div>
                                     </div>
+
+                                    {/* What a run actually clears.
+                                        This was fixed in code -- names, email, phone, description,
+                                        staff notes and photos, always. A town's retention
+                                        obligations come from its own counsel and its state's
+                                        records law, and deciding for them was not ours to do. */}
+                                    {selectedMode !== 'delete' && scrubFields && (
+                                        <div className="mt-6 rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+                                            <h4 className="font-semibold text-white">What gets cleared</h4>
+                                            <p className="text-white/55 text-xs mt-1 mb-4">
+                                                The record stays and still counts in your statistics. Only the
+                                                fields ticked here are emptied.
+                                            </p>
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                                {scrubFields.map(field => (
+                                                    <label
+                                                        key={field.id}
+                                                        className={`flex items-start gap-3 rounded-xl border p-3 cursor-pointer transition-colors ${field.selected
+                                                            ? 'bg-amber-500/10 border-amber-400/30'
+                                                            : 'bg-white/[0.02] border-white/10 hover:border-white/20'}`}
+                                                    >
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={field.selected}
+                                                            onChange={(e) => setScrubFields(prev => (prev || []).map(f =>
+                                                                f.id === field.id ? { ...f, selected: e.target.checked } : f))}
+                                                            className="mt-0.5 accent-amber-400"
+                                                        />
+                                                        <span className="min-w-0">
+                                                            <span className="block text-sm font-medium text-white/90">{field.label}</span>
+                                                            <span className="block text-xs text-white/55 mt-0.5 leading-relaxed">{field.detail}</span>
+                                                        </span>
+                                                    </label>
+                                                ))}
+                                            </div>
+                                            {!scrubFields.some(f => f.selected) && (
+                                                <p className="text-amber-300 text-xs mt-3">
+                                                    Nothing is ticked, so a run would leave every record untouched.
+                                                </p>
+                                            )}
+                                        </div>
+                                    )}
 
                                     {/* Selected State Preview — updates live as state/override change */}
                                     {selectedStateCode && retentionStates.find(s => s.code === selectedStateCode) && (() => {
@@ -3225,6 +3277,8 @@ export default function AdminConsole() {
                                                     await api.updateRetentionPolicy({
                                                         state_code: selectedStateCode,
                                                         mode: selectedMode,
+                                                        scrub_fields: (scrubFields || [])
+                                                            .filter(f => f.selected).map(f => f.id),
                                                         // 0 explicitly clears the override back to the state default;
                                                         // omitting it would leave a previously-set override stuck.
                                                         override_days: overrideDays ? parseInt(overrideDays) : 0

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -904,11 +904,11 @@ export default function AdminConsole() {
         policy: { name: string; retention_days: number; retention_years: number; source: string; public_records_law: string };
         override_days: number | null;
         effective_days: number;
-        mode: 'redact' | 'delete';
+        mode: 'redact' | 'purge';
         stats: { eligible_for_archival: number; under_legal_hold: number; already_archived: number; cutoff_date: string };
     } | null>(null);
     const [selectedStateCode, setSelectedStateCode] = useState<string>('');
-    const [selectedMode, setSelectedMode] = useState<'redact' | 'delete'>('redact');
+    const [selectedMode, setSelectedMode] = useState<'redact' | 'purge'>('redact');
     /* Which fields a retention run clears. Null until the server answers --
      * rendering the catalog from a hardcoded copy here is how the screen and
      * the thing it configures drift apart. */
@@ -1041,7 +1041,7 @@ export default function AdminConsole() {
                         setRetentionStates(states);
                         setRetentionPolicy(policy);
                         setSelectedStateCode(policy.state_code);
-                        setSelectedMode(policy.mode === 'delete' ? 'delete' : 'redact');
+                        setSelectedMode(policy.mode === 'purge' ? 'purge' : 'redact');
                         setScrubFields(policy.scrub_fields || null);
                         // Reflect the saved override in the input (was always blank before)
                         setOverrideDays(policy.override_days ? String(policy.override_days) : '');
@@ -2858,7 +2858,7 @@ export default function AdminConsole() {
                                 {retentionPolicy && (
                                     <AccordionSection
                                         title={`Current Policy: ${retentionPolicy.policy.public_records_law}`}
-                                        subtitle={`${retentionPolicy.policy.name} • ${formatYears(retentionPolicy.effective_days)} retention${retentionPolicy.override_days ? ' (custom override)' : ''} • ${retentionPolicy.mode === 'delete' ? 'Delete mode' : 'Redact mode'}`}
+                                        subtitle={`${retentionPolicy.policy.name} • ${formatYears(retentionPolicy.effective_days)} retention${retentionPolicy.override_days ? ' (custom override)' : ''} • ${retentionPolicy.mode === 'purge' ? 'Purge mode' : 'Redact mode'}`}
                                         icon={Shield}
                                         iconClassName="text-green-400"
                                         badge={<Badge variant="success">Active</Badge>}
@@ -2883,7 +2883,7 @@ export default function AdminConsole() {
                                             <div className="bg-white/5 rounded-lg p-4">
                                                 <div className="text-white/60 text-sm">Mode</div>
                                                 <div className="text-2xl font-bold text-white capitalize">{retentionPolicy.mode}</div>
-                                                <div className="text-white/40 text-sm">{retentionPolicy.mode === 'delete' ? 'Permanent deletion' : 'Chosen fields cleared, record kept'}</div>
+                                                <div className="text-white/40 text-sm">{retentionPolicy.mode === 'purge' ? 'Every field cleared, row kept' : 'Chosen fields cleared, row kept'}</div>
                                             </div>
                                         </div>
 
@@ -3171,7 +3171,7 @@ export default function AdminConsole() {
                                             <label className="block text-sm font-medium text-white/70 mb-2">Archival Mode</label>
                                             <select
                                                 value={selectedMode}
-                                                onChange={(e) => setSelectedMode(e.target.value as 'redact' | 'delete')}
+                                                onChange={(e) => setSelectedMode(e.target.value as 'redact' | 'purge')}
                                                 className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-amber-400"
                                                 aria-label="Select archival mode"
                                             >
@@ -3181,7 +3181,14 @@ export default function AdminConsole() {
                                                     redaction. The two are not interchangeable when
                                                     the difference is what a town tells a judge. */}
                                                 <option value="redact" className="bg-slate-800">Redact — clear the fields you choose, keep the record</option>
-                                                <option value="delete" className="bg-slate-800">Delete — remove the record entirely</option>
+                                                {/* Not deletion. It could never have worked --
+                                                    NOT NULL foreign keys from the audit log and the
+                                                    comments, with no cascade -- and making it work
+                                                    meant deleting audit rows that form the
+                                                    tamper-evident chain. Clearing every field
+                                                    removes the personal data and leaves a row that
+                                                    still counts. */}
+                                                <option value="purge" className="bg-slate-800">Purge — clear every field, keep the row for counting</option>
                                             </select>
                                         </div>
 
@@ -3205,7 +3212,7 @@ export default function AdminConsole() {
                                         staff notes and photos, always. A town's retention
                                         obligations come from its own counsel and its state's
                                         records law, and deciding for them was not ours to do. */}
-                                    {selectedMode !== 'delete' && scrubFields && (
+                                    {selectedMode !== 'purge' && scrubFields && (
                                         <div className="mt-6 rounded-2xl border border-white/10 bg-white/[0.03] p-5">
                                             <h4 className="font-semibold text-white">What gets cleared</h4>
                                             <p className="text-white/55 text-xs mt-1 mb-4">
@@ -3341,11 +3348,11 @@ export default function AdminConsole() {
                                                     return;
                                                 }
 
-                                                const deleting = plan.mode === 'delete';
+                                                const purging = plan.mode === 'purge';
                                                 const ok = await dialog.confirm({
-                                                    title: deleting ? 'Delete records permanently' : 'Anonymise records',
-                                                    variant: deleting ? 'danger' : 'warning',
-                                                    confirmText: deleting ? 'Delete them' : 'Anonymise them',
+                                                    title: purging ? 'Clear every field on these records' : 'Redact these records',
+                                                    variant: purging ? 'danger' : 'warning',
+                                                    confirmText: purging ? 'Clear them' : 'Redact them',
                                                     requireTyped: plan.confirmation_required || undefined,
                                                     message: (
                                                         <div className="space-y-3">
@@ -3355,10 +3362,19 @@ export default function AdminConsole() {
                                                                 the {plan.retention_days}-day retention period for {plan.policy_name || plan.state_code}.
                                                             </p>
                                                             <p>
-                                                                {deleting
-                                                                    ? 'They will be removed from the database entirely. This cannot be undone, and it is not covered by an existing backup taken after they are gone.'
-                                                                    : 'Reporter names, emails and phone numbers will be stripped. The reports themselves stay, so the counts and the map do not change.'}
+                                                                {purging
+                                                                    ? 'Every field is emptied — names, contact details, what the resident wrote, photos, comments and the map pin. The rows stay so your totals do not change, but nothing about the people is recoverable.'
+                                                                    : 'Only the fields you ticked are cleared. The rows stay, so the counts and anything you have not ticked are untouched.'}
                                                             </p>
+                                                            {/* Named, from the server's own list. A
+                                                                clerk approving this should not have
+                                                                to remember which boxes are ticked on
+                                                                a screen they cannot see right now. */}
+                                                            {!!plan.scrub_fields?.length && (
+                                                                <p className="text-white/70 text-sm">
+                                                                    Cleared: {plan.scrub_fields.join(', ')}.
+                                                                </p>
+                                                            )}
                                                             {!!plan.on_legal_hold && (
                                                                 <p className="text-amber-300">
                                                                     {plan.on_legal_hold} flagged {plan.on_legal_hold === 1 ? 'record is' : 'records are'} under

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -3248,9 +3248,80 @@ export default function AdminConsole() {
                                         <Button
                                             variant="secondary"
                                             onClick={async () => {
+                                                /* Show the numbers, then ask.
+                                                 *
+                                                 * This button used to run
+                                                 * immediately. In delete mode
+                                                 * that permanently destroys
+                                                 * resident records, and the
+                                                 * response came back before
+                                                 * the task had touched
+                                                 * anything, so nothing on
+                                                 * screen could say what had
+                                                 * happened. */
+                                                setIsRunningRetention(true);
+                                                let plan;
+                                                try {
+                                                    plan = await api.previewRetentionRun();
+                                                } catch (err) {
+                                                    setIsRunningRetention(false);
+                                                    reportError('Could not work out what this would affect', err);
+                                                    return;
+                                                }
+                                                setIsRunningRetention(false);
+
+                                                if (plan.blocked === 'legal_hold') {
+                                                    await dialog.alert({
+                                                        title: 'Legal hold is on',
+                                                        message: 'Nothing will be archived or deleted while the instance-wide legal hold is active. Lift it first if this run is meant to happen.',
+                                                        variant: 'info',
+                                                    });
+                                                    return;
+                                                }
+                                                if (!plan.eligible) {
+                                                    await dialog.alert({
+                                                        title: 'Nothing is due yet',
+                                                        message: `No closed records have passed the ${plan.retention_days}-day retention period, so this run would do nothing.`,
+                                                        variant: 'info',
+                                                    });
+                                                    return;
+                                                }
+
+                                                const deleting = plan.mode === 'delete';
+                                                const ok = await dialog.confirm({
+                                                    title: deleting ? 'Delete records permanently' : 'Anonymise records',
+                                                    variant: deleting ? 'danger' : 'warning',
+                                                    confirmText: deleting ? 'Delete them' : 'Anonymise them',
+                                                    requireTyped: plan.confirmation_required || undefined,
+                                                    message: (
+                                                        <div className="space-y-3">
+                                                            <p>
+                                                                <strong className="text-white">{plan.will_act_on ?? plan.eligible}</strong>{' '}
+                                                                closed {(plan.will_act_on ?? plan.eligible) === 1 ? 'record has' : 'records have'} passed
+                                                                the {plan.retention_days}-day retention period for {plan.policy_name || plan.state_code}.
+                                                            </p>
+                                                            <p>
+                                                                {deleting
+                                                                    ? 'They will be removed from the database entirely. This cannot be undone, and it is not covered by an existing backup taken after they are gone.'
+                                                                    : 'Reporter names, emails and phone numbers will be stripped. The reports themselves stay, so the counts and the map do not change.'}
+                                                            </p>
+                                                            {!!plan.on_legal_hold && (
+                                                                <p className="text-amber-300">
+                                                                    {plan.on_legal_hold} flagged {plan.on_legal_hold === 1 ? 'record is' : 'records are'} under
+                                                                    legal hold and will be left alone.
+                                                                </p>
+                                                            )}
+                                                            <p className="text-slate-400 text-sm">
+                                                                It works through every eligible record, not the first hundred.
+                                                            </p>
+                                                        </div>
+                                                    ),
+                                                });
+                                                if (!ok) return;
+
                                                 setIsRunningRetention(true);
                                                 try {
-                                                    const result = await api.runRetentionNow();
+                                                    const result = await api.runRetentionNow(plan.confirmation_required || undefined);
                                                     setSaveMessage(`Retention task started: ${result.message}`);
                                                     setTimeout(() => {
                                                         setSaveMessage(null);

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -2199,7 +2199,7 @@ export default function StaffDashboard() {
                                             {(() => {
                                                 const ai = selectedRequest.ai_analysis as any;
                                                 const priorityScore = ai?.priority_score ?? null;
-                                                const qualitativeText = ai?.qualitative_analysis ?? selectedRequest.vertex_ai_summary ?? null;
+                                                const qualitativeText = ai?.qualitative_analysis ?? selectedRequest.ai_summary ?? null;
                                                 const hasError = ai?._error;
 
                                                 // Computed (non-AI) triage facts — populated for every request
@@ -2627,9 +2627,9 @@ export default function StaffDashboard() {
 
                                                                     {/* Footer with timestamp */}
                                                                     <div className="flex items-center justify-between pt-3 border-t border-white/5">
-                                                                        {selectedRequest.vertex_ai_analyzed_at && (
+                                                                        {selectedRequest.ai_analyzed_at && (
                                                                             <p className="text-white/20 text-[9px]">
-                                                                                Analyzed {new Date(selectedRequest.vertex_ai_analyzed_at).toLocaleString()}
+                                                                                Analyzed {new Date(selectedRequest.ai_analyzed_at).toLocaleString()}
                                                                             </p>
                                                                         )}
                                                                         {!hasError && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -631,7 +631,7 @@ class ApiClient {
      *  text. That is not a failure, and the backend deliberately does not write
      *  it to connector health. Dropping the flag here is what made those show
      *  up as "Not working". */
-    async testProvider(capability: string): Promise<{ ok: boolean; detail: string; recorded?: boolean }> {
+    async testProvider(capability: string): Promise<{ ok: boolean; detail: string; recorded?: boolean; configured?: boolean }> {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1088,13 +1088,29 @@ class ApiClient {
     async updateRetentionPolicy(params: {
         state_code?: string;
         override_days?: number;
-        mode?: 'anonymize' | 'delete';
+        mode?: 'redact' | 'delete';
+        scrub_fields?: string[];
     }): Promise<{ status: string; state_code: string; override_days: number | null; mode: string }> {
         const queryParams = new URLSearchParams();
         if (params.state_code) queryParams.append('state_code', params.state_code);
         if (params.override_days !== undefined) queryParams.append('override_days', params.override_days.toString());
         if (params.mode) queryParams.append('mode', params.mode);
+        // Repeated key rather than a joined string: FastAPI reads a list that
+        // way, and an empty selection has to survive the trip as an explicit
+        // "none" rather than vanishing.
+        (params.scrub_fields || []).forEach(f => queryParams.append('scrub_fields', f));
         return this.request(`/system/retention/policy?${queryParams.toString()}`, { method: 'POST' });
+    }
+
+    async getTownTimezone(): Promise<{
+        timezone: string; offset: string; configured: boolean;
+        common: { id: string; offset: string }[];
+    }> {
+        return this.request('/system/timezone');
+    }
+
+    async setTownTimezone(timezone: string): Promise<{ timezone: string; offset: string }> {
+        return this.request('/system/timezone', { method: 'POST', body: JSON.stringify({ timezone }) });
     }
 
     /** What "Run now" would actually do, before it does it. */
@@ -1474,8 +1490,19 @@ export interface RetentionState {
     public_records_law: string;
 }
 
+export interface ScrubField {
+    id: string;
+    label: string;
+    detail: string;
+    default: boolean;
+    selected: boolean;
+}
+
 export interface RetentionPolicyConfig {
     state_code: string;
+    /** The catalog and this town's choice in one object, so the screen never
+     *  holds its own copy of what the fields are called. */
+    scrub_fields?: ScrubField[];
     policy: {
         state_code: string;
         name: string;
@@ -1486,7 +1513,7 @@ export interface RetentionPolicyConfig {
     };
     override_days: number | null;
     effective_days: number;
-    mode: 'anonymize' | 'delete';
+    mode: 'redact' | 'delete';
     stats: {
         retention_policy: object;
         cutoff_date: string;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1088,7 +1088,7 @@ class ApiClient {
     async updateRetentionPolicy(params: {
         state_code?: string;
         override_days?: number;
-        mode?: 'redact' | 'delete';
+        mode?: 'redact' | 'purge';
         scrub_fields?: string[];
     }): Promise<{ status: string; state_code: string; override_days: number | null; mode: string }> {
         const queryParams = new URLSearchParams();
@@ -1116,9 +1116,11 @@ class ApiClient {
     /** What "Run now" would actually do, before it does it. */
     async previewRetentionRun(): Promise<{
         eligible: number; on_legal_hold: number; will_act_on?: number;
-        mode: 'anonymize' | 'delete'; state_code?: string; policy_name?: string;
+        mode: 'redact' | 'purge'; state_code?: string; policy_name?: string;
         retention_days?: number; cutoff_date?: string | null;
         confirmation_required?: string | null; blocked?: string;
+        /** What a run will actually empty, in the words the settings screen uses. */
+        scrub_fields?: string[];
     }> {
         return this.request('/system/retention/preview');
     }
@@ -1513,7 +1515,7 @@ export interface RetentionPolicyConfig {
     };
     override_days: number | null;
     effective_days: number;
-    mode: 'redact' | 'delete';
+    mode: 'redact' | 'purge';
     stats: {
         retention_policy: object;
         cutoff_date: string;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1097,8 +1097,21 @@ class ApiClient {
         return this.request(`/system/retention/policy?${queryParams.toString()}`, { method: 'POST' });
     }
 
-    async runRetentionNow(): Promise<{ status: string; task_id: string; message: string }> {
-        return this.request('/system/retention/run', { method: 'POST' });
+    /** What "Run now" would actually do, before it does it. */
+    async previewRetentionRun(): Promise<{
+        eligible: number; on_legal_hold: number; will_act_on?: number;
+        mode: 'anonymize' | 'delete'; state_code?: string; policy_name?: string;
+        retention_days?: number; cutoff_date?: string | null;
+        confirmation_required?: string | null; blocked?: string;
+    }> {
+        return this.request('/system/retention/preview');
+    }
+
+    async runRetentionNow(confirm?: string): Promise<{ status: string; task_id: string; message: string }> {
+        return this.request('/system/retention/run', {
+            method: 'POST',
+            body: JSON.stringify(confirm ? { confirm } : {}),
+        });
     }
 
     async getLegalHoldRequests(): Promise<{

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -203,10 +203,10 @@ export interface ServiceRequestDetail extends ServiceRequest {
     completion_photo_url: string | null;
     delete_justification: string | null;
     // Vertex AI Analysis (priority_score is in ai_analysis JSON only)
-    vertex_ai_summary: string | null;
-    vertex_ai_classification: string | null;
+    ai_summary: string | null;
+    ai_classification: string | null;
     manual_priority_score: number | null;  // Human-approved priority
-    vertex_ai_analyzed_at: string | null;
+    ai_analyzed_at: string | null;
 }
 
 export interface RequestComment {


### PR DESCRIPTION
Supersedes #433. Takes its direction — more models, searchable — and fixes what it would have shipped, alongside the retention, timezone and setup-page work.

## From #433, kept

Multi-publisher Vertex discovery, a searchable model picker with a scroll cap, wider Azure catalog entries, and a higher `_MAX_MODELS` so a real Model Garden listing is not truncated.

## From #433, fixed

**The picker threw on open.** `modelSearchQuery` and `setModelSearchQuery` were used five times with no `useState`. Every check was green: `vite build` passes because esbuild strips types without resolving identifiers, `pytest` is backend-only, and the accessibility workflow audits the deployed site rather than the branch. The frontend had **no compile gate at all**, so a `ReferenceError` on first render would have reached every town.

There is one now — tsc, vitest and build on any frontend change. It excludes the pre-existing Azure map-renderer errors by file so it can be strict about everything else today rather than aspirational about all of it later.

**Vertex was offering models it could not call.** #433 was right that Model Garden serves more than Gemini, and listed eight publishers — but the caller still built `publishers/google/.../:generateContent` for all of them. Selecting Claude on Vertex would have saved cleanly and 404'd at triage.

Fixed by speaking their protocol rather than hiding them. Anthropic on Vertex uses `:rawPredict`, needs `anthropic_version`, is not served from the global endpoint, and returns text in content blocks rather than candidate parts. That lives in `vertex_publishers.py` — pure, no network, tested in CI. Meta, Mistral, AI21, Cohere and xAI stay absent: they are served through the OpenAI-compatible MaaS endpoint, a third shape, and listing them before it exists is the bug being fixed. A test fails if a publisher appears without a handler.

**Regressions restored.** The Vertex region is honoured again rather than hardcoded to `us-central1` — dropping `VERTEX_AI_LOCATION` is the wrong direction for a product sold on compliance boundaries. Eight silent `except: pass` become one logged line. Bedrock's `byOutputModality="TEXT"` and `byInferenceType="ON_DEMAND"` are back, without which an embedding or image model appears in a triage picker and fails at request time rather than at selection.

**Azure's default moved with its catalog.** The old change added newer entries but left `default_model` at `gpt-4o-mini`, which is the only moment the curated list matters — discovery replaces it once credentials are saved. `DEFAULT_DEPLOYMENT` is pinned to the catalog by a test, and the entries are labelled as deployment-name conventions, because Azure addresses models by the deployment name a town chose.

## Retention

**Hard deletion is gone.** `delete` called `db.delete(record)` while `request_audit_logs` and `request_comments` hold NOT NULL foreign keys with no cascade, so the flush failed on every record — and every record has an audit entry, because submitting one writes it. Failures were caught per record, so the run reported success with nothing archived. A town on a delete policy was told retention was running and nothing was ever removed.

Making it succeed meant deleting audit rows that form a hash chain the compliance page advertises as tamper-evident. `purge` clears every field instead: the personal data goes, the row survives as a shell that still counts, and the chain stays whole.

**The AI summary was the description in different words.** Redaction cleared the description and kept the model's summary of it, which quotes the report — and `_error` carries whatever the provider said, which has included the prompt.

**The town chooses what is cleared.** Ten fields, each saying what it empties, defaulting to exactly the old fixed list so the first run after the migration removes precisely what the last run before it did.

**It is not anonymisation.** Anonymising means removing what ties data to a person; blanking a description is redaction, and those are not interchangeable words when the difference is what a town tells a judge. `anonymize` is still read, and the migration moves the stored value.

Every archival is written to the tamper-evident trail with the list of fields cleared.

## Time

All 40 datetime columns are `timestamptz`, so the database returns aware UTC while the code built naive values 73 times — and psycopg interprets naive in the database session's timezone, so on a database not set to UTC every timestamp was silently offset. Two more hid as `default=datetime.utcnow`, a reference rather than a call, both on columns feeding the audit hash chain.

A town now sets its own zone for display; storage stays UTC. Daylight saving is computed at the instant, not stored as an offset.

`vertex_ai_summary`, `vertex_ai_classification` and `vertex_ai_analyzed_at` lose the vendor name — same mistake as the old `google_kms`.

## Setup page

Backups and crash reporting are cards in the grid rather than a differently-sized block below it. Mute only appears where an alert exists, derived from the backend's own rule with a test that fails if the two drift. A capability with no credentials says "Not set up" and points at the guide, instead of reporting "cannot be tested" — two definitions of "empty" had diverged, so a whitespace value made a provider simultaneously configured and untestable. Switched-off features that are not capabilities now appear in that list.

## Migrations

`e1f2a3b4c5d6` (scrub fields), `f2a3b4c5d6e7` (AI column rename + town timezone), `a3b4c5d6e7f8` (retire hard delete). All additive or value-only, inspector-guarded.

## Testing

769 backend tests against a CI-equivalent venv, 149 frontend, clean build, no typecheck errors outside the known baseline. Verified by mutation throughout; several survived first and were fixed by moving the decision into a pure function CI can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_