### PR TITLE
Keep what a check found, not only when it happened

### DIFF
--- a/backend/alembic/versions/20260801_1000_b4c5d6e7f8a9_persist_last_check_result.py
+++ b/backend/alembic/versions/20260801_1000_b4c5d6e7f8a9_persist_last_check_result.py
@@ -1,0 +1,65 @@
+"""Keep what the last check said, not only when it happened.
+
+A failing check stored its message in `last_error`. A passing one stored a
+timestamp and nothing else, so "Twilio credentials accepted, nothing was sent"
+or "SES reachable, 12 of 50,000 sent today" was shown once and gone on reload
+-- leaving a card that says "checked 6 hours ago" and cannot say what it found.
+
+And a provider that cannot be checked from here at all -- a generic HTTP SMS
+gateway needs a real message sent -- recorded nothing, so that answer lived
+only in the browser session that produced it. On reload the card reverted to
+"not checked yet", which invites somebody to press a button that can never
+succeed and makes a genuinely unchecked connector indistinguishable from one
+that is unverifiable by nature.
+
+Revision ID: b4c5d6e7f8a9
+Revises: a3b4c5d6e7f8
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b4c5d6e7f8a9"
+down_revision: Union[str, None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "connector_health"
+COLUMNS = (
+    ("last_result", lambda: sa.Column("last_result", sa.Text(), nullable=True)),
+    ("verifiable", lambda: sa.Column("verifiable", sa.Boolean(), nullable=True)),
+)
+
+
+def _columns() -> set:
+    inspector = sa.inspect(op.get_bind())
+    if TABLE not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(TABLE)}
+
+
+def upgrade() -> None:
+    existing = _columns()
+    if not existing:
+        return  # fresh install: created from the models, already complete
+    for name, make in COLUMNS:
+        if name not in existing:
+            op.add_column(TABLE, make())
+
+    # Backfill the one thing already known: a connector whose last check failed
+    # has its message in last_error. NULL stays NULL elsewhere -- inventing a
+    # result for a check that never ran would be worse than an empty line.
+    if "last_error" in existing:
+        op.execute(sa.text(
+            f'UPDATE "{TABLE}" SET last_result = last_error '  # nosec B608 - fixed identifier
+            f"WHERE last_result IS NULL AND last_error IS NOT NULL"
+        ))
+
+
+def downgrade() -> None:
+    existing = _columns()
+    for name, _ in reversed(COLUMNS):
+        if name in existing:
+            op.drop_column(TABLE, name)

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -264,6 +264,9 @@ async def connector_health_report(
                 "last_error_at": h.last_error_at.isoformat() if h.last_error_at else None,
                 "last_error": h.last_error,
                 "consecutive_failures": h.consecutive_failures,
+                # What the last check said, and whether one is even possible.
+                "last_result": h.last_result,
+                "verifiable": h.verifiable,
                 "total_successes": h.total_successes,
                 "total_failures": h.total_failures,
                 # Surfaced so the card can say alerts are muted and until when.
@@ -1023,7 +1026,9 @@ async def test_provider(
     async def _remember(outcome: dict) -> dict:
         try:
             if outcome.get("ok"):
-                await connector_health.record_success(db, capability)
+                # The message too, not just the timestamp. "Checked 6 hours
+                # ago" cannot say what it found.
+                await connector_health.record_success(db, capability, detail=outcome.get("detail"))
             else:
                 await connector_health.record_failure(db, capability, outcome.get("detail", ""))
         except Exception:
@@ -1043,7 +1048,18 @@ async def test_provider(
         # An outcome we could not verify is shown but not written to connector
         # health: "we cannot check this from here" is not "this is broken", and
         # a red badge that can never go green teaches people to ignore badges.
-        return outcome if outcome.get("recorded") is False else await _remember(outcome)
+        if outcome.get("recorded") is False:
+            # Not a failure, and not nothing. Stored as "we tried and cannot
+            # tell", so the answer survives a reload instead of living only in
+            # the session that produced it.
+            try:
+                if outcome.get("configured") is not False:
+                    await connector_health.record_unverifiable(
+                        db, capability, outcome.get("detail", ""))
+            except Exception:
+                pass
+            return outcome
+        return await _remember(outcome)
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1006,6 +1006,25 @@ class ConnectorHealth(Base):
     alert_muted_until = Column(DateTime(timezone=True))
     alert_muted_level = Column(String(16))
 
+    # What the last check actually said, whichever way it went.
+    #
+    # A failure kept its message in `last_error`; a success kept nothing but a
+    # timestamp. So "Twilio credentials accepted, nothing was sent" or "SES
+    # reachable, 12 of 50,000 sent today" was shown once and gone on reload,
+    # leaving a card that says "checked 6 hours ago" and cannot say what it
+    # found. The evidence is the useful part.
+    last_result = Column(Text)
+
+    # False when the provider cannot be checked from here at all -- a generic
+    # HTTP SMS gateway needs a real message sent. Stored, because otherwise
+    # that answer lives only in the browser session that ran the test and the
+    # card reverts to "not checked yet" on reload, inviting somebody to press
+    # a button that can never succeed.
+    #
+    # Deliberately not a status: it is not healthy, not broken, and not
+    # unknown, and folding it into any of those loses the distinction.
+    verifiable = Column(Boolean)
+
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 

--- a/backend/app/services/connector_health.py
+++ b/backend/app/services/connector_health.py
@@ -82,6 +82,9 @@ class Health:
     # already said this on Tuesday" without a second query per connector.
     alerted_level: Optional[str] = None
     alerted_at: Optional[datetime] = None
+    # What the last check said, either way, and whether one is even possible.
+    last_result: Optional[str] = None
+    verifiable: Optional[bool] = None
 
     @property
     def ok(self) -> bool:
@@ -140,6 +143,8 @@ def to_health(row: Any, *, now: Optional[datetime] = None) -> Health:
         total_failures=getattr(row, "total_failures", 0) or 0,
         alerted_level=getattr(row, "alerted_level", None),
         alerted_at=getattr(row, "alerted_at", None),
+        last_result=getattr(row, "last_result", None),
+        verifiable=getattr(row, "verifiable", None),
     )
 
 
@@ -171,7 +176,8 @@ async def _row(db, connector: str):
     return row
 
 
-async def record_success(db, connector: str, provider: Optional[str] = None) -> None:
+async def record_success(db, connector: str, provider: Optional[str] = None,
+                         detail: Optional[str] = None) -> None:
     """A real call worked. Never raises."""
     try:
         now = datetime.now(timezone.utc)
@@ -179,6 +185,10 @@ async def record_success(db, connector: str, provider: Optional[str] = None) -> 
         row.provider = provider or row.provider
         row.last_attempt_at = now
         row.last_success_at = now
+        # Kept, so a card can say what the last check found rather than only
+        # when it happened.
+        row.last_result = (detail or "")[:500] or None
+        row.verifiable = True
         # Reset, not decrement: the connector demonstrably works right now, and
         # carrying old failures forward would keep it amber after it recovered.
         row.consecutive_failures = 0
@@ -187,6 +197,32 @@ async def record_success(db, connector: str, provider: Optional[str] = None) -> 
         await db.commit()
     except Exception as exc:
         logger.warning("[Health] could not record success for %s: %s",
+                       sanitize_for_log(connector), sanitize_for_log(str(exc)))
+
+
+async def record_unverifiable(db, connector: str, detail: str,
+                              provider: Optional[str] = None) -> None:
+    """We tried, and this provider cannot be checked from here at all.
+
+    Recorded so the answer survives the browser session that produced it.
+    Without this the card reverts to "not checked yet" on reload and invites
+    somebody to press a button that can never succeed -- and worse, a genuinely
+    unchecked connector and one that is unverifiable by nature look identical.
+
+    Deliberately touches neither the success nor the failure counters. It is
+    not evidence either way, and letting it move the failure count would feed
+    the escalation that emails administrators about a connector nobody can do
+    anything about.
+    """
+    try:
+        row = await _row(db, connector)
+        row.provider = provider or row.provider
+        row.last_attempt_at = datetime.now(timezone.utc)
+        row.last_result = (detail or "")[:500] or None
+        row.verifiable = False
+        await db.commit()
+    except Exception as exc:
+        logger.warning("[Health] could not record unverifiable for %s: %s",
                        sanitize_for_log(connector), sanitize_for_log(str(exc)))
 
 
@@ -200,6 +236,8 @@ async def record_failure(db, connector: str, error: Any,
         row.last_attempt_at = now
         row.last_error_at = now
         row.last_error = clean_error(error)
+        row.last_result = row.last_error
+        row.verifiable = True
         row.consecutive_failures = (row.consecutive_failures or 0) + 1
         row.total_failures = (row.total_failures or 0) + 1
         await db.commit()

--- a/backend/tests/test_check_results_persist.py
+++ b/backend/tests/test_check_results_persist.py
@@ -1,0 +1,162 @@
+"""What a check found has to outlive the browser session that ran it.
+
+Two gaps, both invisible until you reload.
+
+A failing check kept its message in `last_error`. A passing one kept a
+timestamp and nothing else, so the card could say "checked 6 hours ago" and not
+what it found -- and the evidence is the useful half.
+
+Worse, a provider that cannot be checked from here at all recorded nothing. On
+reload the card reverted to "not checked yet", which invites somebody to press
+a button that can never succeed, and makes a genuinely unchecked connector look
+identical to one that is unverifiable by nature.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services import connector_health as ch
+
+
+class Row:
+    """Stands in for the ORM row. Attribute assignment is the whole contract."""
+
+    def __init__(self, **kw):
+        self.connector = "sms"
+        self.provider = None
+        self.last_attempt_at = None
+        self.last_success_at = None
+        self.last_error_at = None
+        self.last_error = None
+        self.last_result = None
+        self.verifiable = None
+        self.consecutive_failures = 0
+        self.total_successes = 0
+        self.total_failures = 0
+        self.alerted_level = None
+        self.alerted_at = None
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class FakeDB:
+    def __init__(self, row):
+        self.row = row
+        self.commits = 0
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.fixture(autouse=True)
+def _row(monkeypatch):
+    row = Row()
+
+    async def fake_row(db, connector):
+        return row
+
+    monkeypatch.setattr(ch, "_row", fake_row)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_a_passing_check_keeps_what_it_said(_row):
+    await ch.record_success(FakeDB(_row), "sms", detail="Twilio credentials accepted. Nothing was sent.")
+    assert _row.last_result == "Twilio credentials accepted. Nothing was sent."
+    assert _row.verifiable is True
+    assert _row.last_success_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_passing_check_with_nothing_to_say_stores_nothing(_row):
+    """An empty string in the column would render as a blank line under the
+    card, which reads as a missing value rather than as no comment."""
+    await ch.record_success(FakeDB(_row), "sms", detail="")
+    assert _row.last_result is None
+
+
+@pytest.mark.asyncio
+async def test_a_failing_check_keeps_its_message_in_both_places(_row):
+    await ch.record_failure(FakeDB(_row), "sms", "401 rejected")
+    assert _row.last_error == "401 rejected"
+    assert _row.last_result == "401 rejected"
+    assert _row.verifiable is True
+
+
+@pytest.mark.asyncio
+async def test_unverifiable_is_recorded_rather_than_dropped(_row):
+    await ch.record_unverifiable(FakeDB(_row), "sms", "There is no way to check http without sending a real text.")
+    assert _row.verifiable is False
+    assert "no way to check" in _row.last_result
+    assert _row.last_attempt_at is not None
+
+
+@pytest.mark.asyncio
+async def test_unverifiable_moves_neither_counter(_row):
+    """It is not evidence either way. Letting it count as a failure would feed
+    the escalation that emails administrators about a connector nobody can do
+    anything about."""
+    await ch.record_unverifiable(FakeDB(_row), "sms", "cannot check")
+    assert _row.consecutive_failures == 0
+    assert _row.total_failures == 0
+    assert _row.total_successes == 0
+    assert _row.last_success_at is None
+    assert _row.last_error_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_later_real_result_replaces_the_unverifiable_one(_row):
+    """A town that switches from an HTTP gateway to Twilio must not keep being
+    told its text messages cannot be tested."""
+    await ch.record_unverifiable(FakeDB(_row), "sms", "cannot check")
+    await ch.record_success(FakeDB(_row), "sms", detail="Twilio accepted")
+    assert _row.verifiable is True
+    assert _row.last_result == "Twilio accepted"
+
+
+@pytest.mark.asyncio
+async def test_a_long_provider_message_is_bounded(_row):
+    await ch.record_success(FakeDB(_row), "sms", detail="x" * 5000)
+    assert len(_row.last_result) <= 500
+
+
+def test_the_snapshot_carries_both_fields():
+    """Stored and not surfaced is the same as not stored."""
+    h = ch.to_health(Row(last_result="all good", verifiable=False,
+                         last_success_at=datetime.now(timezone.utc)))
+    assert h.last_result == "all good"
+    assert h.verifiable is False
+
+
+def test_a_row_from_before_the_migration_does_not_explode():
+    class Old:
+        connector = "sms"
+        status = "unknown"
+
+    h = ch.to_health(Old())
+    assert h.last_result is None and h.verifiable is None
+
+
+def test_the_endpoint_returns_them():
+    from pathlib import Path
+
+    api = (Path(__file__).resolve().parents[1] / "app/api/system.py").read_text()
+    assert '"last_result": h.last_result' in api
+    assert '"verifiable": h.verifiable' in api
+
+
+def test_the_test_endpoint_records_the_unverifiable_case():
+    from pathlib import Path
+
+    api = (Path(__file__).resolve().parents[1] / "app/api/system.py").read_text()
+    assert "record_unverifiable" in api
+
+
+def test_nothing_saved_is_not_recorded_as_unverifiable():
+    """"You have entered nothing" is not "this cannot be checked". Recording it
+    would make an empty provider permanently untestable-looking."""
+    from pathlib import Path
+
+    api = (Path(__file__).resolve().parents[1] / "app/api/system.py").read_text()
+    assert 'outcome.get("configured") is not False' in api

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -137,7 +137,17 @@ export interface CapStatus {
 export function capabilityState(s: CapStatus | undefined, health?: ConnectorHealth): CapabilityState | null {
     if (!s) return null;                      // catalog still loading
     if (!s.configured) return 'unset';
-    if (s.verifiable === false) return 'unverifiable';
+    /* The session's answer when there is one, the stored one otherwise.
+     *
+     * Not an `||` of the two: a town that swapped an HTTP gateway for Twilio
+     * has `verifiable: true` from the test it just ran and `false` still in
+     * the health row, and reading both would keep telling it that text
+     * messages cannot be checked. The stored value is a fallback for a fresh
+     * page, not a second opinion. */
+    const knownUnverifiable = s.verifiable !== undefined
+        ? s.verifiable === false
+        : health?.verifiable === false;
+    if (knownUnverifiable) return 'unverifiable';
     // A test run in this session is fresher than the stored health row.
     if (s.verified === true) return 'working';
     if (s.verified === false) return 'failing';
@@ -418,7 +428,7 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     /* The provider's own words when there are any. A clerk searching the web
      * for their error needs the actual string, not our paraphrase of it. */
     const spotlightDetail = bad
-        ? (health?.last_error || health?.summary || 'The last check failed.')
+        ? (health?.last_error || health?.last_result || health?.summary || 'The last check failed.')
         : shown === 'unchecked'
             ? 'Nothing has used this yet, so we cannot say whether it works.'
             : blurb;
@@ -523,7 +533,7 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                         {configured ? (
                             <span className="block text-[11px] text-white/45 mt-2.5">
                                 {shown === 'unverifiable'
-                                    ? 'Set up. There is no way to test this one from here.'
+                                    ? (health?.last_result || 'Set up. There is no way to test this one from here.')
                                     : checkedLine}
                             </span>
                         ) : (

--- a/frontend/src/components/capabilityState.test.ts
+++ b/frontend/src/components/capabilityState.test.ts
@@ -13,9 +13,12 @@ import { capabilityState } from './ServiceProviders';
  * just mislabels a card, it files a broken connector under "healthy" and hides
  * it in a bubble.
  */
+// Module scope, so every block below shares one definition of what a health
+// row looks like rather than each growing its own.
+const health = (status: string, extra: Record<string, unknown> = {}) =>
+    ({ connector: 'x', status, consecutive_failures: 0, ...extra }) as never;
+
 describe('capabilityState', () => {
-    const health = (status: string, extra: Record<string, unknown> = {}) =>
-        ({ connector: 'x', status, consecutive_failures: 0, ...extra }) as never;
 
     it('says nothing at all until the catalog has loaded', () => {
         // Not "unset". A page that is merely slow must not accuse a town of
@@ -79,5 +82,33 @@ describe('capabilityState', () => {
 
     it('does not let a session test override the absence of credentials', () => {
         expect(capabilityState({ configured: false, verified: true }, health('working'))).toBe('unset');
+    });
+});
+
+describe('a check result outlives the session that ran it', () => {
+    it('remembers "cannot be tested" from the stored health row', () => {
+        // Without this the answer lives only in the browser session that ran
+        // the test: reload, and the card is back to "not checked yet",
+        // inviting another press of a button that can never succeed.
+        expect(capabilityState({ configured: true }, health('unknown', { verifiable: false })))
+            .toBe('unverifiable');
+    });
+
+    it('lets a fresh session result override the stored one', () => {
+        // A town that swapped an HTTP gateway for Twilio must not keep being
+        // told its text messages cannot be tested.
+        expect(capabilityState({ configured: true, verified: true, verifiable: true },
+                               health('working', { verifiable: false })))
+            .toBe('working');
+    });
+
+    it('still puts "not set up" ahead of "cannot be tested"', () => {
+        expect(capabilityState({ configured: false }, health('unknown', { verifiable: false })))
+            .toBe('unset');
+    });
+
+    it('treats an absent flag as unknown rather than as unverifiable', () => {
+        // Rows written before the column existed have neither value.
+        expect(capabilityState({ configured: true }, health('unknown'))).toBe('unchecked');
     });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -490,6 +490,14 @@ export interface ConnectorHealth {
      *  muted it. The badge is never affected -- a mute that hid the problem as
      *  well as the email would be indistinguishable from broken alerting. */
     alerts_muted_until?: string | null;
+    /** What the last check said, either way. A card that knows only *when* it
+     *  was checked cannot say what it found. */
+    last_result?: string | null;
+    /** False when this provider cannot be checked from here at all. Stored, so
+     *  the answer survives the session that produced it -- otherwise the card
+     *  reverts to "not checked yet" and invites another press of a button that
+     *  can never succeed. */
+    verifiable?: boolean | null;
 }
 
 export interface ConnectorHealthReport {


### PR DESCRIPTION
A check that ran leaves nothing behind but a timestamp. This stores what it actually found.

## A passing check kept no detail

`record_success` stored the time and cleared the error, and nothing else. So "Twilio credentials accepted. Nothing was sent." or "SES reachable, 12 of 50,000 sent in the last 24 hours" appeared once in the session that ran it and was gone on reload — leaving a card that says *checked 6 hours ago* and cannot say what it found. The evidence is the useful half.

Failures already kept their message in `last_error`. Successes now keep theirs in `last_result`, and failures write both, so one field answers "what did the last check say" regardless of which way it went.

## An unverifiable result recorded nothing at all

A generic HTTP SMS gateway cannot be exercised without sending a real message, and the backend is right to refuse to write that as a failure — a red badge that can never go green is worse than none. But it wrote nothing, so the answer lived only in the browser session that produced it.

Reload, and the card was back to "not checked yet": inviting another press of a button that can never succeed, and making a genuinely unchecked connector indistinguishable from one that is unverifiable by nature.

`record_unverifiable` stores it, and deliberately moves neither counter. It is not evidence either way, and letting it count as a failure would feed the escalation that emails administrators daily about a connector nobody can do anything about. A later real result replaces it, so a town that swaps an HTTP gateway for Twilio stops being told its text messages cannot be checked.

"You have entered nothing" is still not recorded as unverifiable. Those are different facts, and conflating them would leave an empty provider looking permanently untestable.

## Two things caught during the change

My first frontend version read the session flag and the stored one with an `||`. That meant a town which had just switched providers kept being told the new one could not be checked — the stored value outranking a fresher answer. The session wins when it has one; the stored value is a fallback for a fresh page, not a second opinion. My own test caught it before it left the branch.

The frontend gate added in #434 then caught a type error in that test file — the first time it has paid for itself on my own work rather than on the PR it was written for.

## Migration

`b4c5d6e7f8a9` — adds `last_result` and `verifiable`, backfills `last_result` from `last_error` where one exists, and leaves it NULL otherwise. Inventing a result for a check that never ran would be worse than an empty line.

## Testing

782 backend tests against a CI-equivalent venv, 153 frontend, clean build, no typecheck errors outside the known baseline.

Four mutations checked: a passing check forgetting its message, unverifiable counting as a failure, unverifiable storing nothing, and the stored flag outranking the session. All four fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_