### PR TITLE
Public comments, the rest of the queue sweep, and the random sign-outs

### DIFF
--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -7,9 +7,10 @@ from sqlalchemy import select
 from typing import List
 
 from app.db.session import get_db
-from app.models import RequestComment, ServiceRequest, User
+from app.models import RequestAuditLog, RequestComment, ServiceRequest, User
 from app.schemas import RequestCommentCreate, RequestCommentResponse
 from app.core.auth import get_current_user, get_current_staff
+from app.services.enqueue import enqueue
 
 router = APIRouter(prefix="/api/requests", tags=["comments"])
 
@@ -66,13 +67,33 @@ async def create_comment(
     )
     
     db.add(comment)
+
+    # Same timeline entry as the public path. `new_value` carries the
+    # visibility rather than the text: an internal note is a different event to
+    # a reply the resident can read, and the timeline is shown to both.
+    #
+    # The comment body stays in request_comments, which is what the retention
+    # policy scrubs. The audit trail is append-only, so a copy here would be a
+    # copy the scrub cannot reach.
+    db.add(RequestAuditLog(
+        service_request_id=request_id,
+        action="comment_added",
+        new_value=comment_data.visibility.value,
+        actor_type="staff",
+        actor_name=current_user.username,
+    ))
     await db.commit()
     await db.refresh(comment)
-    
+
+    # Everything below is enqueued, never called: the comment is committed, and
+    # a broker that is unreachable must cost a notification rather than turn a
+    # saved comment into a 500 that invites the author to post it twice.
+    #
     # Send notification to resident if comment is public/external
     if comment_data.visibility.value == "external":
         from app.tasks.service_requests import send_comment_notification_task
-        send_comment_notification_task.delay(
+        enqueue(
+            send_comment_notification_task,
             request_id,
             current_user.full_name or current_user.username,
             comment_data.content
@@ -80,12 +101,12 @@ async def create_comment(
 
         # Mirror the comment to linked govtech platforms
         from app.tasks.integrations import push_comment_to_integrations
-        push_comment_to_integrations.delay(comment.id)
+        enqueue(push_comment_to_integrations, comment.id)
 
     # Notify assigned staff / department of the comment (internal or external),
     # respecting each user's notification preferences. The commenter is skipped.
     from app.tasks.service_requests import notify_staff_of_activity
-    notify_staff_of_activity.delay(request_id, "comments", actor=current_user.username)
+    enqueue(notify_staff_of_activity, request_id, "comments", actor=current_user.username)
 
     return comment
 

--- a/backend/app/api/integrations.py
+++ b/backend/app/api/integrations.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_admin, get_current_staff
 from app.db.session import get_db
+from app.services.enqueue import QUEUE_UNAVAILABLE, enqueue
 from app.integrations import (
     PLATFORM_CATALOG, build_connector_for, store_credentials,
 )
@@ -295,9 +296,13 @@ async def trigger_sync(
     integration = await _get_integration(db, integration_id)
     if not integration.enabled:
         raise HTTPException(status_code=400, detail="Enable the integration before syncing")
+    # "Sync started" has to be true. This endpoint exists to start the job, so
+    # a broker that cannot take it is a failed request, not a quiet log line --
+    # otherwise an admin watches nothing happen and has no way to tell whether
+    # the sync ran and found nothing or never ran at all.
     from app.tasks.integrations import pull_integration_comments, pull_integration_updates
-    pull_integration_updates.delay()
-    pull_integration_comments.delay()
+    if not enqueue(pull_integration_updates) or not enqueue(pull_integration_comments):
+        raise HTTPException(status_code=503, detail=QUEUE_UNAVAILABLE)
     return {"message": "Sync started", "platform": integration.platform}
 
 
@@ -321,7 +326,8 @@ async def trigger_asset_sync(
         integration.config = {**(integration.config or {}), "sync_assets": True}
         await db.commit()
     from app.tasks.integrations import sync_integration_assets
-    sync_integration_assets.delay()
+    if not enqueue(sync_integration_assets):
+        raise HTTPException(status_code=503, detail=QUEUE_UNAVAILABLE)
     return {"message": "Asset sync started", "platform": integration.platform}
 
 
@@ -347,7 +353,11 @@ async def refresh_request_work_order(
     if not links:
         return {"ok": False, "detail": "This request isn't linked to any external platform."}
     from app.tasks.integrations import refresh_request_from_integrations
-    refresh_request_from_integrations.delay(sr.id)
+    if not enqueue(refresh_request_from_integrations, sr.id):
+        # Answered as ok:false rather than raised, matching the "not linked to
+        # any platform" case a few lines above -- this endpoint's contract is
+        # an {ok, detail} pair the staff dashboard renders inline.
+        return {"ok": False, "detail": QUEUE_UNAVAILABLE}
     return {"ok": True, "detail": "Refreshing the latest work-order status — updates appear on the request in a moment."}
 
 
@@ -564,11 +574,10 @@ async def integration_webhook(
     await _import_webhook_comments(sr.id)
     await db.commit()
 
-    # Same post-processing as portal submissions (AI triage)
-    try:
-        from app.tasks.service_requests import analyze_request
-        analyze_request.delay(sr.id)
-    except Exception:
-        logger.warning("[Integrations] Could not queue AI analysis for webhook intake")
+    # Same post-processing as portal submissions (AI triage). Incidental: the
+    # request is committed above, and a webhook sender that gets an error back
+    # will redeliver, creating a duplicate report.
+    from app.tasks.service_requests import analyze_request
+    enqueue(analyze_request, sr.id)
 
     return {"message": "created", "service_request_id": sr.service_request_id}

--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -866,17 +866,21 @@ async def _finalize_new_request(
     db.add(audit_entry)
     await db.commit()
 
+    # Everything from here is follow-up work on a report that is already saved.
+    # It is enqueued rather than called, so an unreachable broker costs a
+    # notification and a line in the log instead of answering "we could not
+    # take your report" for a report that is in the database.
     from app.tasks.service_requests import analyze_request, send_branded_notification, send_department_notification
     # AI triage / priority — same as a resident submission
-    analyze_request.delay(service_request.id)
+    enqueue(analyze_request, service_request.id)
 
     # Push to any connected govtech platforms (Accela, Tyler, CivicPlus, etc.)
     from app.tasks.integrations import push_request_to_integrations
-    push_request_to_integrations.delay(service_request.id)
+    enqueue(push_request_to_integrations, service_request.id)
 
     # Send branded confirmation only when we have a real resident email
     if notify_resident:
-        send_branded_notification.delay(service_request.id, "confirmation")
+        enqueue(send_branded_notification, service_request.id, "confirmation")
 
     # Notify department staff based on their notification preferences
     if assigned_department_id:
@@ -885,7 +889,7 @@ async def _finalize_new_request(
         )
         dept = dept_result.scalar_one_or_none()
         if dept and dept.routing_email:
-            send_department_notification.delay(service_request.id, dept.routing_email)
+            enqueue(send_department_notification, service_request.id, dept.routing_email)
 
 
 @router.get("/requests.json", response_model=List[ServiceRequestResponse])
@@ -1074,8 +1078,14 @@ async def update_request_status(
     
     # Send notification if status changed
     if "status" in update_dict and update_dict["status"] and update_dict["status"].value != old_status:
+        # Enqueued, not called: the status change and its audit entry are
+        # committed above. A broker outage must not roll a completed update
+        # back into an error, because the staffer's next move is to set the
+        # status again and the resident gets two "your report is closed"
+        # emails when the queue recovers.
         from app.tasks.service_requests import send_branded_notification, notify_staff_of_activity
-        send_branded_notification.delay(
+        enqueue(
+            send_branded_notification,
             request.id,
             "status_update",
             old_status=old_status,
@@ -1083,11 +1093,11 @@ async def update_request_status(
         )
 
         # Notify assigned staff / department (respects each user's preferences).
-        notify_staff_of_activity.delay(request.id, "status_changes", actor=current_user.username)
+        enqueue(notify_staff_of_activity, request.id, "status_changes", actor=current_user.username)
 
         # Mirror the status change to linked govtech platforms
         from app.tasks.integrations import push_status_to_integrations
-        push_status_to_integrations.delay(request.id, notes=update_dict.get("completion_message"))
+        enqueue(push_status_to_integrations, request.id, notes=update_dict.get("completion_message"))
     
     # Reload with relationship for response
     await db.refresh(request)

--- a/backend/app/api/open311.py
+++ b/backend/app/api/open311.py
@@ -31,6 +31,7 @@ def generate_request_id() -> str:
 
 
 from app.services import road_blocking
+from app.services.enqueue import enqueue
 from app.core.config import get_settings
 import redis.asyncio as redis
 import json
@@ -280,12 +281,39 @@ async def add_public_comment(
         visibility="external"
     )
     db.add(comment)
+
+    # Put it on the timeline. `comment_added` is a documented action on
+    # RequestAuditLog and is rendered in both the resident tracker and the
+    # staff dashboard, and until now nothing anywhere wrote one -- so a
+    # timeline that showed a report being filed, routed and closed silently
+    # omitted every word the resident said about it in between.
+    #
+    # The text itself is deliberately not copied here. It already lives in
+    # request_comments, which is what the retention policy scrubs; duplicating
+    # it into the audit trail would put a copy somewhere the scrub does not
+    # reach, and the audit chain is append-only by design.
+    db.add(RequestAuditLog(
+        service_request_id=sr.id,
+        action="comment_added",
+        new_value="external",
+        actor_type="resident",
+        actor_name="Resident",
+    ))
     await db.commit()
     await db.refresh(comment)
 
-    # Mirror the comment to linked govtech platforms
+    # Mirror the comment to linked govtech platforms. Enqueued rather than
+    # called: the comment is already saved, and a broker that is down must not
+    # turn a saved comment into an error the resident reads as "try again".
     from app.tasks.integrations import push_comment_to_integrations
-    push_comment_to_integrations.delay(comment.id)
+    enqueue(push_comment_to_integrations, comment.id)
+
+    # Tell whoever is working the request that a resident has said something.
+    # Without this a reply sits unread until somebody happens to open the
+    # request, which from the resident's side is indistinguishable from being
+    # ignored. `actor` matches no staff username, so nobody is skipped.
+    from app.tasks.service_requests import notify_staff_of_activity
+    enqueue(notify_staff_of_activity, sr.id, "comments", actor="Resident")
 
     return comment
 
@@ -384,10 +412,22 @@ async def get_public_audit_log(request_id: str, db: AsyncSession = Depends(get_d
         raise HTTPException(status_code=404, detail="Request not found")
     
     # Only return submitted and status_change events (not assignments which may be internal)
+    #
+    # `comment_added` joins them, but only for comments the resident can
+    # already read. An internal staff note is written to the same timeline with
+    # new_value="internal", and surfacing even its existence here would tell
+    # the public that staff had discussed a report privately -- which is the
+    # thing the internal/external split exists to keep separate. The comment
+    # text is never in the audit row either way; this is a marker, and the
+    # words come from the comments endpoint.
     audit_result = await db.execute(
         select(RequestAuditLog)
         .where(RequestAuditLog.service_request_id == request.id)
-        .where(RequestAuditLog.action.in_(["submitted", "status_change"]))
+        .where(or_(
+            RequestAuditLog.action.in_(["submitted", "status_change"]),
+            (RequestAuditLog.action == "comment_added")
+            & (RequestAuditLog.new_value == "external"),
+        ))
         .order_by(RequestAuditLog.created_at.asc())
     )
     entries = audit_result.scalars().all()

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -22,6 +22,8 @@ from app.schemas import (
 )
 from app.core.auth import get_current_admin, get_current_staff
 from app.services.system_settings import get_settings as read_settings_row
+from app.services.enqueue import QUEUE_UNAVAILABLE
+from app.core.sanitize import sanitize_for_log
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -1844,7 +1846,16 @@ async def run_retention_now(
                    'undone. Send confirm="PURGE" to proceed.',
         )
 
-    task = enforce_retention_policy.delay()
+    # Not swallowed. The admin typed a confirmation word to get here and is
+    # being handed a task id to watch; answering "triggered" for a job that
+    # never reached a worker would be the worst version of this -- a retention
+    # run they believe happened, on the strength of which they stop checking.
+    try:
+        task = enforce_retention_policy.delay()
+    except Exception as exc:
+        logger.warning("[Retention] could not queue enforcement: %s", sanitize_for_log(str(exc)))
+        raise HTTPException(status_code=503, detail=QUEUE_UNAVAILABLE)
+
     return {
         "status": "triggered",
         "task_id": task.id,

--- a/backend/app/services/enqueue.py
+++ b/backend/app/services/enqueue.py
@@ -27,6 +27,22 @@ from app.core.sanitize import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
+# For the other kind of call site. Some handoffs are not incidental: an admin
+# pressing "Run retention now" or "Sync now" is asking for precisely the queued
+# job and nothing else. Swallowing the failure there would answer "started" for
+# a job that never started -- the exact lie this codebase keeps finding in
+# itself, and worse than the 500 it replaced, because a 500 at least tells
+# somebody to look.
+#
+# So those sites check the return value and raise this. Deliberately plain
+# text and no FastAPI import: this module is reachable from the CI test suite,
+# which installs neither FastAPI nor Celery.
+QUEUE_UNAVAILABLE = (
+    "The background worker is not reachable, so this job did not start. "
+    "Nothing has been changed. Check that the worker and Redis are running, "
+    "then try again."
+)
+
 
 def enqueue(task: Any, *args: Any, **kwargs: Any) -> bool:
     """Queue `task`. Never raises.

--- a/backend/app/services/enqueue.py
+++ b/backend/app/services/enqueue.py
@@ -1,0 +1,49 @@
+"""Hand work to the queue without letting the queue break the request.
+
+`task.delay(...)` is a network call. It reaches Redis, and Redis is one more
+thing that can be down, full, or unreachable across a restart. Every call site
+in this codebase makes it *after* `db.commit()`, which means a broker outage
+turns a saved record into a 500: the row is in the database, the audit entry is
+in the database, and the person who pressed the button is told it failed.
+
+For a resident posting a comment that is not a cosmetic difference. They are
+told the comment did not post, so they post it again, and the town gets two.
+
+The work itself is genuinely optional at this instant -- an email, an AI triage
+pass, a mirror to a county system. None of it is the record. So a broker that
+cannot be reached costs a notification and a line in the log, not the thing the
+person actually came to do.
+
+Returns whether it went, so a caller that wants to say "we saved this, the
+email will follow when the queue is back" can.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.sanitize import sanitize_for_log
+
+logger = logging.getLogger(__name__)
+
+
+def enqueue(task: Any, *args: Any, **kwargs: Any) -> bool:
+    """Queue `task`. Never raises.
+
+    Deliberately swallows everything. A broker error arrives as any of half a
+    dozen exception types depending on transport and failure mode, and the
+    caller's correct response is the same for all of them: carry on, the record
+    is already saved.
+    """
+    name = getattr(task, "name", None) or getattr(task, "__name__", "task")
+    try:
+        task.delay(*args, **kwargs)
+        return True
+    except Exception as exc:  # noqa: BLE001 -- see docstring
+        logger.warning(
+            "[Queue] could not enqueue %s: %s. The record is saved; this "
+            "follow-up work did not run.",
+            sanitize_for_log(str(name)), sanitize_for_log(str(exc)),
+        )
+        return False

--- a/backend/tests/test_enqueue_never_breaks_the_write.py
+++ b/backend/tests/test_enqueue_never_breaks_the_write.py
@@ -10,6 +10,7 @@ comment, that means posting it again, and the town gets two.
 """
 
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -76,22 +77,99 @@ def test_a_hostile_task_name_cannot_forge_a_log_line():
     assert enqueue(task) is False
 
 
-def test_the_comment_endpoints_do_not_call_delay_directly():
-    """The regression guard. Adding a `.delay()` back to either comment handler
-    reinstates exactly the failure this module exists to prevent, and it is the
-    natural thing to write.
+ROOT = Path(__file__).resolve().parents[2]
+API = ROOT / "backend/app/api"
 
-    Scoped to the comment paths on purpose: the other API handlers still call
-    `.delay()` unguarded and converting them is a separate change with its own
-    blast radius. Widening this assertion is how that gets finished.
+# The two call sites that still say `.delay()` directly, and why each is
+# allowed to. Both wrap it themselves; neither is an oversight.
+#
+#   system.py  "Run retention now" -- must fail loudly, and does, with its own
+#              try/except raising 503. Not converted to `enqueue()` because it
+#              needs the returned task id, which `enqueue()` does not hand back.
+#   gis.py     road seeding -- already falls back to running inline when the
+#              queue is unavailable, which is better than either swallowing or
+#              raising, and predates this module.
+DELIBERATE = {"system.py": 1, "gis.py": 1}
+
+
+def test_no_handler_calls_delay_unguarded():
+    """The sweep, as a test.
+
+    Every `.delay()` in the API layer is made after `db.commit()`, so an
+    unreachable broker raised out of a handler whose work was already done.
+    Sixteen call sites had that shape. The two below are listed by name with a
+    reason; anything else is a regression, and adding one is the natural thing
+    to write.
     """
-    from pathlib import Path
+    found = {}
+    for path in sorted(API.glob("*.py")):
+        count = path.read_text().count(".delay(")
+        if count:
+            found[path.name] = count
 
-    root = Path(__file__).resolve().parents[2]
-    staff = (root / "backend/app/api/comments.py").read_text()
-    assert ".delay(" not in staff, "use enqueue() -- see the module docstring"
+    assert found == DELIBERATE, (
+        f"unguarded .delay() in {sorted(set(found) - set(DELIBERATE))}, "
+        f"or a count changed: {found} != {DELIBERATE}. Use enqueue() for "
+        f"follow-up work, or enqueue() + QUEUE_UNAVAILABLE where the queued "
+        f"job is the thing being asked for."
+    )
 
-    public = (root / "backend/app/api/open311.py").read_text()
-    handler = public[public.index("async def add_public_comment"):]
-    handler = handler[:handler.index("\n@router")]
-    assert ".delay(" not in handler, "use enqueue() -- see the module docstring"
+
+def test_the_deliberate_exceptions_still_handle_a_broker_failure():
+    """Naming a file in DELIBERATE is not a way of opting out. Each one has to
+    visibly cope with the call raising, or the exemption is just an unguarded
+    `.delay()` with a comment next to it."""
+    for name in DELIBERATE:
+        source = (API / name).read_text()
+        window = source[max(0, source.index(".delay(") - 600):source.index(".delay(") + 600]
+        assert "try:" in window and "except" in window, (
+            f"{name} is exempt from the sweep but does not handle the call failing"
+        )
+
+
+def test_a_job_somebody_asked_for_is_not_reported_as_started_when_it_is_not():
+    """The other half of the rule, and the easier one to get wrong.
+
+    `enqueue()` swallowing is right when the queued work is incidental -- a
+    resident filed a report, the email is a consequence. It is wrong when the
+    queued job *is* the request. "Sync started" and "Retention enforcement
+    started" are claims, and answering them for a job that never reached a
+    worker is the failure this codebase keeps finding in itself: a button that
+    reports success and does nothing. Worse than the 500 it replaced, because a
+    500 at least tells somebody to look.
+    """
+    integrations = (API / "integrations.py").read_text()
+    # Anchored on the returned value, not the bare phrase. The first draft
+    # searched for "Sync started" and matched the sentence in the comment
+    # explaining the guard, which sits *above* it -- so the test failed on
+    # correct code. Prose about a behaviour is not the behaviour.
+    for claim in ('"message": "Sync started"', '"message": "Asset sync started"'):
+        before = integrations[:integrations.index(claim)]
+        # The check must be the thing immediately guarding the claim.
+        assert "QUEUE_UNAVAILABLE" in before[-400:], (
+            f'{claim} is returned without confirming the job was queued'
+        )
+
+    system = (API / "system.py").read_text()
+    triggered = system[:system.index('"status": "triggered"')]
+    assert "QUEUE_UNAVAILABLE" in triggered[-800:], (
+        'retention reports "triggered" without confirming the job was queued'
+    )
+
+
+def test_the_unavailable_message_says_what_to_do_and_what_did_not_happen():
+    """It is read by a clerk, not an operator. "Service unavailable" tells them
+    nothing about whether their data changed."""
+    from app.services.enqueue import QUEUE_UNAVAILABLE
+
+    assert "did not start" in QUEUE_UNAVAILABLE
+    assert "Nothing has been changed" in QUEUE_UNAVAILABLE
+    assert "try again" in QUEUE_UNAVAILABLE
+
+
+def test_the_message_carries_no_hostname_or_credential():
+    """It is rendered in the admin UI and pasted into support threads."""
+    from app.services.enqueue import QUEUE_UNAVAILABLE
+
+    for leak in ("redis://", "amqp://", "://", "@", "password"):
+        assert leak not in QUEUE_UNAVAILABLE, f"{leak!r} in a user-facing string"

--- a/backend/tests/test_enqueue_never_breaks_the_write.py
+++ b/backend/tests/test_enqueue_never_breaks_the_write.py
@@ -1,0 +1,97 @@
+"""A broker outage must not turn a saved record into an error.
+
+Every `.delay()` in the API layer is made after `db.commit()`. That ordering is
+correct -- the record is what matters and it is safe before anything optional
+is attempted -- but it means an unreachable Redis raises out of a handler whose
+work is already done. The caller is told it failed. For a resident posting a
+comment, that means posting it again, and the town gets two.
+
+`enqueue()` is the whole fix: try, log, carry on, report whether it went.
+"""
+
+import logging
+
+import pytest
+
+from app.services.enqueue import enqueue
+
+
+class Task:
+    """Stands in for a Celery task. Records the call, or refuses to accept it."""
+
+    name = "app.tasks.integrations.push_comment_to_integrations"
+
+    def __init__(self, raises: Exception | None = None):
+        self.raises = raises
+        self.calls: list[tuple] = []
+
+    def delay(self, *args, **kwargs):
+        if self.raises:
+            raise self.raises
+        self.calls.append((args, kwargs))
+        return "task-id"
+
+
+def test_a_reachable_broker_gets_the_work():
+    task = Task()
+    assert enqueue(task, 7, "comments", actor="Resident") is True
+    assert task.calls == [((7, "comments"), {"actor": "Resident"})]
+
+
+def test_an_unreachable_broker_does_not_raise():
+    """The one behaviour the comment endpoint depends on."""
+    task = Task(raises=ConnectionRefusedError("Error 111 connecting to redis:6379"))
+    assert enqueue(task, 7) is False
+
+
+@pytest.mark.parametrize("failure", [
+    ConnectionRefusedError("connection refused"),
+    TimeoutError("timed out"),
+    OSError("no route to host"),
+    RuntimeError("kombu: no more channels"),
+    ValueError("could not serialize argument"),
+])
+def test_it_swallows_every_shape_a_broker_failure_arrives_in(failure):
+    """Deliberately not a narrow except. A broker error is any of these
+    depending on transport and failure mode, and the caller's correct response
+    is identical for all of them -- the record is already saved.
+    """
+    assert enqueue(Task(raises=failure)) is False
+
+
+def test_the_failure_is_written_down(caplog):
+    """Swallowed is not the same as hidden. An operator has to be able to find
+    out that a week of notifications did not go out."""
+    with caplog.at_level(logging.WARNING):
+        enqueue(Task(raises=ConnectionRefusedError("boom")))
+    assert any("could not enqueue" in r.getMessage() for r in caplog.records), caplog.text
+    assert "push_comment_to_integrations" in caplog.text
+
+
+def test_a_hostile_task_name_cannot_forge_a_log_line():
+    """The name reaches a log line, so it goes through the same sanitizer as
+    every other interpolated value (CWE-117)."""
+    task = Task(raises=ConnectionRefusedError("x"))
+    task.name = "evil\nWARNING:root:all systems normal"
+    assert enqueue(task) is False
+
+
+def test_the_comment_endpoints_do_not_call_delay_directly():
+    """The regression guard. Adding a `.delay()` back to either comment handler
+    reinstates exactly the failure this module exists to prevent, and it is the
+    natural thing to write.
+
+    Scoped to the comment paths on purpose: the other API handlers still call
+    `.delay()` unguarded and converting them is a separate change with its own
+    blast radius. Widening this assertion is how that gets finished.
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    staff = (root / "backend/app/api/comments.py").read_text()
+    assert ".delay(" not in staff, "use enqueue() -- see the module docstring"
+
+    public = (root / "backend/app/api/open311.py").read_text()
+    handler = public[public.index("async def add_public_comment"):]
+    handler = handler[:handler.index("\n@router")]
+    assert ".delay(" not in handler, "use enqueue() -- see the module docstring"

--- a/backend/tests/test_public_comment_posts.py
+++ b/backend/tests/test_public_comment_posts.py
@@ -1,0 +1,267 @@
+"""A resident's comment has to reach the endpoint that stores it.
+
+It did not. `POST /open311/v2/public/requests/{id}/comments` declares its
+content as `Body(..., embed=True)`, and the browser sent it as a query string
+with no body at all. FastAPI answered 422 on every attempt, the component
+logged it to `console.error`, and the resident saw the button stop spinning and
+nothing appear. Reproduced against a real FastAPI app before fixing:
+
+    as the browser sends it : 422 {"detail":[{"type":"missing",
+                                   "loc":["body","content"],...}]}
+    with a JSON body       : 200
+
+Nothing caught it, because nothing tested it. Both halves of the contract were
+individually reasonable and no test looked at them together -- which is the
+same shape as every other bug in this codebase that survived a release: a thing
+that stores fine, reads back fine, and silently does nothing.
+
+So this file pins the two halves against each other. It lives in the backend
+suite for the reason the other frontend contract tests do: it is the suite that
+runs on every change, with no npm install and no browser.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ENDPOINT = ROOT / "backend/app/api/open311.py"
+API_CLIENT = ROOT / "frontend/src/services/api.ts"
+COMPONENT = ROOT / "frontend/src/components/TrackRequests.tsx"
+
+ROUTE = "/public/requests/{request_id}/comments"
+
+
+@pytest.fixture(scope="module")
+def handler() -> ast.AsyncFunctionDef:
+    """The `add_public_comment` function, as a syntax tree.
+
+    Found by name rather than by line number so the test survives the file
+    being reordered, and parsed rather than grepped so a mention of `Query` in
+    a docstring two functions away cannot decide the answer. An earlier test in
+    this suite was written the grep way and tripped over its own explanation.
+    """
+    tree = ast.parse(ENDPOINT.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "add_public_comment":
+            return node
+    pytest.fail("no add_public_comment handler in open311.py")
+
+
+def _content_default(handler: ast.AsyncFunctionDef) -> ast.AST:
+    args = handler.args.args + handler.args.kwonlyargs
+    names = [a.arg for a in args]
+    assert "content" in names, f"handler takes {names}, expected a `content` parameter"
+    # Defaults align to the tail of the positional list.
+    positional = handler.args.args
+    padding = len(positional) - len(handler.args.defaults)
+    for i, arg in enumerate(positional):
+        if arg.arg == "content":
+            assert i >= padding, "`content` has no default, so nothing declares where it is read from"
+            return handler.args.defaults[i - padding]
+    for arg, default in zip(handler.args.kwonlyargs, handler.args.kw_defaults):
+        if arg.arg == "content":
+            return default
+    pytest.fail("could not locate the default for `content`")
+
+
+def _source_of(node: ast.AST) -> str:
+    return ast.dump(node)
+
+
+def test_the_endpoint_reads_the_comment_from_the_body(handler):
+    """`Body(...)`, not `Query(...)`.
+
+    The body is the right place and this test is not neutral about which side
+    should have moved. A URL is written to the access log, the reverse proxy,
+    the CDN, the browser's history and the Referer header of the next click. A
+    resident's comment can name a neighbour or describe what happened to them.
+    Switching the endpoint to `Query` would make this pass and would put that
+    text in five logs a town never decided to keep it in.
+    """
+    default = _content_default(handler)
+    assert isinstance(default, ast.Call), "`content` should be declared with Body(...)"
+    called = default.func.id if isinstance(default.func, ast.Name) else getattr(default.func, "attr", "")
+    assert called == "Body", f"`content` is read from {called}(...), expected Body(...)"
+
+
+def test_the_body_is_a_named_field_rather_than_a_bare_string(handler):
+    """`embed=True` means `{"content": "..."}`.
+
+    Without it FastAPI expects the bare JSON string as the whole body, which no
+    caller writes by accident and no Open311 client sends. The frontend test
+    below pins the matching `JSON.stringify({ content })`; the pair is the
+    contract.
+    """
+    default = _content_default(handler)
+    embed = [kw for kw in default.keywords if kw.arg == "embed"]
+    assert embed and getattr(embed[0].value, "value", False) is True, (
+        "Body(..., embed=True) -- the frontend sends {\"content\": ...}"
+    )
+
+
+def test_a_comment_has_a_length_the_endpoint_will_accept(handler):
+    """Unauthenticated and public, so the bound is the only thing between a town
+    and somebody pasting a novel into its database."""
+    default = _content_default(handler)
+    bounds = {kw.arg: getattr(kw.value, "value", None) for kw in default.keywords}
+    assert bounds.get("min_length", 0) >= 1, "an empty comment is not a comment"
+    assert bounds.get("max_length"), "no upper bound on an unauthenticated public write"
+
+
+@pytest.fixture(scope="module")
+def client_source() -> str:
+    if not API_CLIENT.exists():
+        pytest.skip("frontend not present in this checkout")
+    return API_CLIENT.read_text()
+
+
+def _add_public_comment(client_source: str) -> str:
+    body = re.search(r"async addPublicComment\(.*?\n    \}", client_source, re.S)
+    assert body, "no addPublicComment in the api client"
+    return body.group(0)
+
+
+def test_the_browser_sends_the_comment_in_the_body(client_source):
+    """The half that was wrong. `JSON.stringify({ content })` and a POST."""
+    call = _add_public_comment(client_source)
+    assert "method: 'POST'" in call
+    assert "JSON.stringify({ content })" in call, (
+        "the comment must be sent as a JSON body -- a POST with no body is "
+        "answered 422 by the endpoint above and the comment is lost"
+    )
+
+
+def test_the_browser_does_not_put_the_comment_in_the_url(client_source):
+    """The specific regression. This is what shipped, and it 422'd every time.
+
+    Checked separately from the test above because adding a body while leaving
+    the query string in place would pass that one and still leak the text into
+    every log between the resident and the database.
+    """
+    call = _add_public_comment(client_source)
+    assert "?content=" not in call, "the comment text is in the URL"
+    assert "encodeURIComponent(content)" not in call, "the comment text is in the URL"
+
+
+@pytest.fixture(scope="module")
+def component_source() -> str:
+    if not COMPONENT.exists():
+        pytest.skip("frontend not present in this checkout")
+    return COMPONENT.read_text()
+
+
+def _handle_add_comment(component_source: str) -> str:
+    handler = re.search(r"const handleAddComment = async \(\) => \{.*?\n    \};",
+                        component_source, re.S)
+    assert handler, "no handleAddComment in TrackRequests"
+    return handler.group(0)
+
+
+def test_a_rejected_comment_tells_the_resident_why(component_source):
+    """The endpoint's moderation branch raises 400 with a sentence addressed to
+    the person who typed the comment. It was going to `console.error`.
+
+    That is the failure mode that made this bug take a release to notice: a
+    rejected comment, a broken endpoint and a dropped network request all
+    looked identical from the resident's chair -- the button stops spinning and
+    nothing appears.
+    """
+    handler = _handle_add_comment(component_source)
+
+    # The catch block specifically. Checking the whole handler is not enough:
+    # it opens with `setCommentError(null)` to clear the previous attempt, and
+    # that alone satisfied an earlier version of this assertion even with the
+    # catch reverted to console.error. The mutation survived and the test was
+    # wrong, not the code.
+    catch = handler[handler.index("} catch"):]
+    assert "setCommentError(" in catch, (
+        "the failure has to reach the screen, not just the console"
+    )
+    assert "console." not in catch, (
+        "the console is not a way of telling a resident anything"
+    )
+    assert "commentError &&" in component_source, "the error state is set but never rendered"
+
+
+def test_the_message_shown_is_the_one_the_endpoint_wrote(component_source):
+    """The moderation rejection names what to do about it -- "please rephrase
+    without offensive content". A generic "something went wrong" in its place
+    leaves the resident retyping the same comment into the same refusal."""
+    catch = _handle_add_comment(component_source)
+    catch = catch[catch.index("} catch"):]
+    assert "err.message" in catch, "the server's own sentence has to be preferred"
+    assert re.search(r"instanceof Error", catch), (
+        "a non-Error rejection has to fall back to something readable rather "
+        "than rendering [object Object]"
+    )
+
+
+def test_a_comment_reaches_the_timeline(handler):
+    """`comment_added` is a documented action on RequestAuditLog and is
+    rendered in both the resident tracker and the staff dashboard. Nothing
+    anywhere wrote one, so a timeline that showed a report being filed, routed
+    and closed silently omitted every word said about it in between.
+    """
+    written = [
+        node for node in ast.walk(handler)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") == "RequestAuditLog"
+    ]
+    assert written, "a public comment writes no timeline entry"
+    kwargs = {kw.arg: getattr(kw.value, "value", None) for kw in written[0].keywords}
+    assert kwargs.get("action") == "comment_added"
+    assert kwargs.get("actor_type") == "resident"
+
+
+def test_the_timeline_entry_does_not_carry_the_comment_text(handler):
+    """The words live in `request_comments`, which is what the retention policy
+    scrubs. The audit trail is append-only and hash-chained, so a copy here
+    would be a copy the scrub cannot reach and the chain will not let it
+    rewrite -- a redacted comment with its full text still on the timeline
+    beneath it."""
+    written = [
+        node for node in ast.walk(handler)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") == "RequestAuditLog"
+    ][0]
+    for kw in written.keywords:
+        assert not (isinstance(kw.value, ast.Name) and kw.value.id == "content"), (
+            f"the comment text is being copied into the audit trail as {kw.arg}"
+        )
+
+
+def test_the_public_timeline_hides_internal_notes():
+    """Staff notes are written to the same timeline with new_value="internal".
+    Showing even that one happened tells the public that a report was discussed
+    privately, which is the thing the internal/external split exists to keep
+    separate."""
+    source = ENDPOINT.read_text()
+    public = source[source.index("async def get_public_audit_log"):]
+    public = public[:public.index("\n@router")]
+    assert "comment_added" in public, "resident comments never reach the public timeline"
+    assert 'new_value == "external"' in public, (
+        "the public timeline does not distinguish an internal note from a reply"
+    )
+
+
+def test_the_public_tracker_reads_the_public_timeline(component_source):
+    """The tracker is opened by whoever holds the link, and that is a person
+    with no session. Calling the staff endpoint answered 401 every time, so the
+    timeline was empty for exactly the audience it was built for."""
+    assert "api.getPublicAuditLog(" in component_source
+    assert "api.getAuditLog(" not in component_source, (
+        "the staff audit endpoint requires a session this page never has"
+    )
+
+
+def test_what_somebody_typed_survives_a_failed_post(component_source):
+    """Clearing the box before the save is confirmed loses the comment to any
+    blip, and the resident has no copy of it."""
+    body = _handle_add_comment(component_source)
+    cleared = body.index("setNewComment('')")
+    posted = body.index("api.addPublicComment")
+    assert posted < cleared, "the box is cleared before the comment is known to be saved"
+    assert cleared < body.index("} catch"), "clearing must be on the success path only"

--- a/frontend/src/components/TrackRequests.tsx
+++ b/frontend/src/components/TrackRequests.tsx
@@ -69,6 +69,12 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
     const [comments, setComments] = useState<RequestComment[]>([]);
     const [newComment, setNewComment] = useState('');
     const [isSubmittingComment, setIsSubmittingComment] = useState(false);
+    // Why a post failed, in the resident's words. The moderation rejection is
+    // written to be read by the person who typed the comment, and until now it
+    // went to console.error -- so a rejected comment, a broken endpoint and a
+    // dropped network request all looked the same from the outside: the button
+    // stops spinning and nothing appears.
+    const [commentError, setCommentError] = useState<string | null>(null);
     const [isLoadingComments, setIsLoadingComments] = useState(false);
     const [copied, setCopied] = useState(false);
     const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
@@ -202,7 +208,13 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
 
     const loadAuditLog = async (requestId: string) => {
         try {
-            const log = await api.getAuditLog(requestId);
+            // The public endpoint, because this is the public tracker. The
+            // staff one requires a session, so for a logged-out resident --
+            // which is everybody following a tracking link -- it answered 401
+            // and the timeline was permanently empty. It also redacts staff
+            // usernames, which is the correct behaviour on a page anyone with
+            // the link can open.
+            const log = await api.getPublicAuditLog(requestId);
             setAuditLog(log);
         } catch (err) {
             console.error('Failed to load audit log:', err);
@@ -214,12 +226,19 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
         if (!selectedRequest || !newComment.trim()) return;
 
         setIsSubmittingComment(true);
+        setCommentError(null);
         try {
             await api.addPublicComment(selectedRequest.service_request_id, newComment.trim());
+            // Only cleared once it is actually saved. Clearing first loses
+            // something somebody typed to a network blip, with no copy of it.
             setNewComment('');
             await loadComments(selectedRequest.service_request_id);
         } catch (err) {
-            console.error('Failed to add comment:', err);
+            setCommentError(
+                err instanceof Error && err.message
+                    ? err.message
+                    : "Your comment could not be posted. Please try again."
+            );
         } finally {
             setIsSubmittingComment(false);
         }
@@ -632,10 +651,24 @@ export default function TrackRequests({ initialRequestId, selectedRequestId, onR
                         <Textarea
                             placeholder={"Share your thoughts or updates..."}
                             value={newComment}
-                            onChange={(e) => setNewComment(e.target.value)}
+                            onChange={(e) => {
+                                setNewComment(e.target.value);
+                                // The message described the last attempt. Once
+                                // they start rewording it, it is stale advice.
+                                if (commentError) setCommentError(null);
+                            }}
                             rows={3}
                             className="mb-3 bg-transparent border-white/20 focus:border-primary-500"
                         />
+                        {commentError && (
+                            <div
+                                role="alert"
+                                className="mb-3 flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200"
+                            >
+                                <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+                                <span>{commentError}</span>
+                            </div>
+                        )}
                         <div className="flex justify-end">
                             <Button
                                 onClick={handleAddComment}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -225,14 +225,35 @@ class ApiClient {
         const preferredLanguage = localStorage.getItem('preferred_language') || 'en';
         headers['Accept-Language'] = preferredLanguage;
 
+        // Whether *this* request carried a session, captured before it goes
+        // out. See the 401 branch below.
+        const sentWithToken = !!this.token;
+
         const response = await fetch(`${API_BASE}${endpoint}`, {
             ...options,
             headers,
         });
 
         if (!response.ok) {
-            // Auto-redirect on session expiry (401)
-            if (response.status === 401 && this.onUnauthorized) {
+            // Auto-logout on session expiry (401) -- but only for a request
+            // that actually presented a session.
+            //
+            // A 401 on a request with no token does not mean "your session
+            // ended". It means "that endpoint needs a login", and treating the
+            // two the same is why people were being signed out at random.
+            //
+            // The mechanism: AuthProvider restores the token from
+            // localStorage inside a useEffect. React runs child effects before
+            // parent ones, so a page that loads data on mount can fire its
+            // first request before the token has been put back. On the
+            // protected routes ProtectedRoute holds children back until that
+            // finishes, but the resident portal is public and ungated -- and
+            // it calls at least one staff-only endpoint. The unauthenticated
+            // request came back 401 and this handler deleted a perfectly good
+            // token out of localStorage.
+            //
+            // Intermittent, because it is a race; "random, while navigating".
+            if (response.status === 401 && this.onUnauthorized && sentWithToken) {
                 this.onUnauthorized();
             }
             const error = await response.json().catch(() => ({ detail: 'Request failed' }));

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -359,9 +359,20 @@ class ApiClient {
         return this.request<RequestComment[]>(`/open311/v2/public/requests/${requestId}/comments`);
     }
 
+    // The comment goes in the body, not the query string. Two reasons, and the
+    // first one is that the query-string version never worked: the endpoint
+    // declares `content` as Body(embed=True), so a POST with no body was
+    // answered 422 and every comment a resident tried to leave was dropped.
+    //
+    // The second is why the endpoint is right to want a body. A URL is logged
+    // everywhere -- the access log, the reverse proxy, the CDN, the browser's
+    // history, the Referer header on the next click. A resident's comment can
+    // name a neighbour or describe what happened to them, and none of those
+    // places is somewhere a town has decided to keep that.
     async addPublicComment(requestId: string, content: string): Promise<RequestComment> {
-        return this.request<RequestComment>(`/open311/v2/public/requests/${requestId}/comments?content=${encodeURIComponent(content)}`, {
+        return this.request<RequestComment>(`/open311/v2/public/requests/${requestId}/comments`, {
             method: 'POST',
+            body: JSON.stringify({ content }),
         });
     }
 

--- a/frontend/src/services/api.unauthorized.test.ts
+++ b/frontend/src/services/api.unauthorized.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { api } from './api';
+
+/**
+ * Being signed out at random, while clicking around.
+ *
+ * Every 401 from any endpoint ran the auto-logout, which deletes the token
+ * from localStorage. That is right for an expired session and wrong for
+ * everything else -- and "everything else" turned out to include a request
+ * that had not been given the token yet.
+ *
+ * AuthProvider restores the token inside a useEffect. React runs child effects
+ * before parent effects, so a page that loads data on mount can get its first
+ * request out the door before the token is back. ProtectedRoute holds
+ * protected pages back until auth resolves, but the resident portal is public,
+ * ungated, and calls a staff-only endpoint on mount. So: reload the portal
+ * while logged in, one request goes out bare, 401 comes back, and the handler
+ * throws away a session that had hours left on it.
+ *
+ * The rule is that a 401 only ends a session that was actually offered.
+ */
+
+const originalFetch = globalThis.fetch;
+
+function respond(status: number) {
+    return vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => ({ detail: 'nope' }),
+    } as unknown as Response);
+}
+
+describe('auto-logout on 401', () => {
+    let loggedOut: number;
+
+    beforeEach(() => {
+        loggedOut = 0;
+        api.setOnUnauthorized(() => { loggedOut += 1; });
+        api.setToken(null);
+    });
+
+    afterEach(() => {
+        api.setOnUnauthorized(null);
+        api.setToken(null);
+        globalThis.fetch = originalFetch;
+    });
+
+    it('signs you out when a request that carried a session is rejected', async () => {
+        // The case the handler exists for: the token was sent and the server
+        // said it is no longer good.
+        globalThis.fetch = respond(401);
+        api.setToken('a-real-token');
+
+        await expect(api.getMe()).rejects.toThrow();
+        expect(loggedOut).toBe(1);
+    });
+
+    it('does not sign you out over a request that carried no session', async () => {
+        // The regression. This is the request that raced ahead of the token
+        // being restored, and it was deleting the token it raced.
+        globalThis.fetch = respond(401);
+        api.setToken(null);
+
+        await expect(api.getMe()).rejects.toThrow();
+        expect(loggedOut).toBe(0);
+    });
+
+    it('does not sign you out over a permission error', async () => {
+        // 403 is "you are logged in and may not do this" -- a staff user on an
+        // admin endpoint. Ending their session for it would be absurd, and it
+        // is one typo in the status check away.
+        globalThis.fetch = respond(403);
+        api.setToken('a-real-token');
+
+        await expect(api.getMe()).rejects.toThrow();
+        expect(loggedOut).toBe(0);
+    });
+
+    it('does not sign you out over a missing record or a server fault', async () => {
+        for (const status of [404, 422, 500, 503]) {
+            globalThis.fetch = respond(status);
+            api.setToken('a-real-token');
+            await expect(api.getMe()).rejects.toThrow();
+        }
+        expect(loggedOut).toBe(0);
+    });
+
+    it('still surfaces the failure to the caller either way', async () => {
+        // Suppressing the logout must not turn into suppressing the error --
+        // the page still has to know its request did not work.
+        globalThis.fetch = respond(401);
+        api.setToken(null);
+        await expect(api.getMe()).rejects.toThrow();
+    });
+});


### PR DESCRIPTION
Three related things, all in the family of "it stores fine, reads back fine, and silently does nothing."

## 1. Public comments were being posted into the URL

A resident typing a comment on their report got nothing back. The button stopped spinning and no comment appeared.

The client sent the text as a **query string with no request body**; the endpoint declares it as `Body(..., embed=True)`. FastAPI answered **422 to every attempt**. Reproduced against a real FastAPI app before changing anything:

```
as the browser sends it : 422 {"type":"missing","loc":["body","content"]}
with a JSON body       : 200
```

The client moved, not the endpoint. Switching the endpoint to `Query` would also have made it work, and would have written every resident's comment into the access log, the reverse proxy, the CDN, the browser history and the Referer header of the next click.

Four more on the same path, all of them reasons this took a release to notice:

- **The failure went to `console.error`.** The moderation rejection is a sentence written *for the resident* and it reached nobody. A rejected comment, a broken endpoint and a dropped request all looked identical. Now shown, in the server's own wording, and the textarea keeps what was typed.
- **Nothing ever wrote a `comment_added` audit entry**, though it is documented on the model and rendered in both timelines. The comment text is deliberately *not* copied into the entry: it lives in `request_comments`, which is what retention scrubs, and the audit chain is append-only, so a copy there is a copy no redaction can reach. Internal staff notes stay off the public timeline.
- **The public tracker called the staff audit endpoint**, which needs a session — so every logged-out resident got a 401 and an empty timeline.
- A resident comment **notified nobody**, which from the resident's side is the same as being ignored.

## 2. The rest of the queue sweep

Sixteen handoffs to the background queue ran after `db.commit()` unguarded, so an unreachable broker raised out of a handler whose work was already done. Resident submission was the worst: report saved, handoff fails, resident files it again.

They do not all get the same treatment, and that is the interesting part:

| | Treatment | Sites |
|---|---|---|
| Queued work is **incidental** — somebody filed a report, the email is a consequence | `enqueue()`: log it, carry on | 11 |
| The queued job **is** the request — "Sync now", "Run retention now" | Check, and 503 with a sentence a clerk can act on | 4 |

Swallowing in the second class would answer "Sync started" for a sync that never started — a button that reports success and does nothing, which is *worse* than the 500 it replaced, because a 500 at least tells somebody to look.

Two direct `.delay()` calls remain, listed by name in the test with a reason. Retention needs the returned task id and raises 503 itself; road seeding already falls back to running inline. The test asserts each still visibly handles the call failing, so naming a file is not a way to opt out.

## 3. Being signed out at random while clicking around

Every 401 from any endpoint ran the auto-logout, which deletes the token from `localStorage`. Right for an expired session, wrong for everything else — and "everything else" included requests that had not been handed the token yet.

`AuthProvider` restores the token inside a `useEffect`. React runs child effects before parent effects, so a page that loads data on mount can get its first request out before the token is back. `ProtectedRoute` holds protected pages back until auth resolves, but **the resident portal is public, ungated, and calls a staff-only endpoint (`GET /departments/`) on mount**. Reload it while logged in: one request goes out bare, comes back 401, and the handler throws away a session with hours left on it. Intermittent, because it is a race — "random, while navigating".

A 401 now only ends a session that was actually offered. Expiry itself is unchanged at 8 hours.

## Verification

- 808 backend tests pass (23 new), 158 frontend tests (5 new), typecheck clean against the CI gate, build green
- **Twenty mutations checked.** Two are worth recording:
  - One survived: an assertion looked at the whole handler and was satisfied by the `setCommentError(null)` that clears the *previous* attempt, so it passed with the catch block reverted to `console.error`. Narrowed to the catch block.
  - One test failed against *correct* code: it searched for the phrase `"Sync started"` and matched the comment explaining the guard rather than the value being returned. Anchored on the returned value. Third time in this codebase a test has tripped over its own prose.

## Left for a decision, not done here

The resident portal calls a **staff-only** departments endpoint at all. It wants department names for a dropdown, and there is already a public staff-list endpoint next to it. That is a visibility question rather than a bug, so it is flagged rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_