### PR TITLE
Measure the container not the host, make the audit log readable, and stop "saved" meaning "ready"

### DIFF
--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -660,8 +660,43 @@ async def save_provider(
         # response so a slow store cannot make Save feel broken.
         from app.services.storage_maintenance import vault_secrets as _vault
         background.add_task(_vault)
+    # Whether this provider can actually be used, and what is missing if not.
+    #
+    # `settings: {}` means "keep what is stored", which is right when a town is
+    # changing a model on a provider whose credentials already live in the
+    # vault. It also means selecting Twilio with nothing entered saves
+    # successfully and answers ok:true -- and the card then said "Set up" about
+    # a service with no account SID.
+    #
+    # Not a 400. Choosing a provider before the credentials arrive is a real
+    # state -- "we have decided on Twilio, the account is still being approved"
+    # -- and the setup guide is deliberately stepwise. Refusing the save would
+    # make the decision unrecordable and would 400 every later save whose
+    # credentials are already in an external store.
+    #
+    # So the save stands and the answer stops overstating it. The caller gets
+    # the same reading of "configured" the badge uses, from the same function,
+    # rather than inferring it from a 200.
+    configured_now = (await _configured_map([catalog[provider_id]])).get(provider_id, False)
+    missing: List[str] = []
+    if not configured_now:
+        from app.services.secret_manager import get_secret
+
+        for field in catalog[provider_id].get("credential_fields", []):
+            if not _field_required(field):
+                continue
+            try:
+                present = bool((await get_secret(field["key"]) or "").strip())
+            except Exception:
+                present = False
+            if not present:
+                missing.append(field.get("label") or field["key"])
+
     return {
         "ok": True,
+        # Saved is not the same as ready. The toast reads one of these.
+        "configured": configured_now,
+        "missing": missing,
         "provider": provider_id,
         "warnings": warnings,
     }

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1028,6 +1028,17 @@ async def test_provider(
 
     async def _remember(outcome: dict) -> dict:
         try:
+            # A check that failed part-way may have left the session in a
+            # failed transaction -- several of them run queries and swallow
+            # their own errors. Any statement after that raises
+            # PendingRollbackError, so the write below was caught by its own
+            # except and lost, and the card went on saying "not checked yet"
+            # immediately after somebody watched the test run.
+            try:
+                await db.rollback()
+            except Exception:
+                pass
+
             if outcome.get("ok"):
                 # The message too, not just the timestamp. "Checked 6 hours
                 # ago" cannot say what it found.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -125,20 +125,14 @@ class AdminActionAuditMiddleware(BaseHTTPMiddleware):
       * never record a failed or unauthenticated attempt here. Those are real
         and worth having, but they belong with the auth events that already
         capture them, and a 401 flood would bury the successful changes.
+
+    Two things it does with care, because the first version of this got both
+    wrong and buried the log it was meant to fill: it names the action in a
+    sentence rather than filing everything under "Admin Change", and it does
+    not record the many POSTs that change nothing -- testing a connection,
+    re-running a check, generating a preview. Both decisions live in
+    `audit_labels`, where they can be argued with in a test.
     """
-
-    MUTATIONS = {"POST", "PUT", "PATCH", "DELETE"}
-
-    # Paths where a per-request entry is noise rather than signal. Each of
-    # these either writes its own record elsewhere or changes nothing.
-    SKIP_PREFIXES = (
-        "/api/auth/",              # login/logout already write their own events
-        "/api/system/translate/",  # a rendering call, made per page view
-        "/api/system/upload/",     # the request it belongs to records the upload
-        "/api/open311/",           # per-request actions live on the request's own timeline
-        "/api/research/",          # read-only analysis with its own access log
-        "/api/telemetry",          # machine polling
-    )
 
     async def dispatch(self, request: Request, call_next):
         from app.services.admin_audit import begin_request, was_recorded
@@ -150,12 +144,14 @@ class AdminActionAuditMiddleware(BaseHTTPMiddleware):
             pass
 
         try:
-            if request.method.upper() not in self.MUTATIONS:
-                return response
             if response.status_code >= 400:
                 return response
+
+            from app.services.audit_labels import describe_action
+
             path = request.url.path
-            if any(path.startswith(p) for p in self.SKIP_PREFIXES):
+            action = describe_action(request.method, path)
+            if action is None:
                 return response
             if was_recorded():
                 # The handler said something more specific.
@@ -174,7 +170,13 @@ class AdminActionAuditMiddleware(BaseHTTPMiddleware):
                     event_type="admin_change",
                     success=True,
                     username=actor,
+                    # Who did it from where. It was left out, so every one of
+                    # these rows showed "-" in the IP column while the sign-in
+                    # rows above them showed an address.
+                    ip_address=_client_ip(request),
+                    user_agent=(request.headers.get("User-Agent") or "")[:500] or None,
                     details={
+                        "action": action,
                         "method": request.method.upper(),
                         # The path only. Query strings and bodies carry the
                         # values being set, and this table is exported.
@@ -215,6 +217,21 @@ def _actor_from_request(request: Request) -> "str | None":
         return payload.get("sub")
     except Exception:
         return None
+
+
+def _client_ip(request: Request) -> "str | None":
+    """The address the change came from, through the reverse proxy.
+
+    Caddy sits in front of everything, so `request.client.host` is Caddy's
+    address on the compose network -- 172.19.0.x, the same for every user.
+    The first entry in X-Forwarded-For is the caller.
+    """
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        first = forwarded.split(",")[0].strip()
+        if first:
+            return first[:64]
+    return request.client.host if request.client else None
 
 
 class DemoModeMiddleware(BaseHTTPMiddleware):

--- a/backend/app/services/audit_labels.py
+++ b/backend/app/services/audit_labels.py
@@ -1,0 +1,153 @@
+"""What an audited action is called, and whether it is worth recording at all.
+
+The backstop middleware records every authenticated change. That closed the
+real gap -- fifty-two mutating endpoints wrote nothing -- and immediately
+created a smaller one: twenty-five consecutive rows reading
+
+    Admin Change    admin    -    Aug 2, 2026, 12:58 AM    -
+
+which is not an audit trail. It says somebody changed something, twenty-five
+times, and refuses to say what. A compliance log that cannot answer "who
+changed the retention policy" is decorative, and one that fills with rows
+nobody can read is worse than a short one, because the sign-in that mattered is
+now on page four.
+
+Two jobs, both here so both are testable without a request:
+
+  1. Name the action in a sentence. "Saved the email provider" beats
+     "POST /api/system/providers/email" for the clerk being asked, at an OPRA
+     hearing or an audit, what happened on the 2nd.
+
+  2. Say when not to record. A great many POSTs change nothing: testing a
+     connection, re-running a health check, generating a preview. They are
+     reads that need a body. Recording them buries the changes that matter, and
+     "Tested SMTP" twenty times in a minute is what a person clicking
+     "Check all" looks like.
+
+Pure -- no FastAPI, no database -- so all of it runs in CI.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Paths whose own handler writes a better record, or where a per-request entry
+# is noise. Checked as prefixes against the full path.
+SKIP_PREFIXES = (
+    "/api/auth/",              # sign-in and sign-out write their own events
+    "/api/system/translate/",  # a rendering call, made per page view
+    "/api/system/upload/",     # the request it belongs to records the upload
+    "/api/open311/",           # work on a request lives on that request's timeline
+    "/api/research/",          # read-only analysis with its own access log
+    "/api/telemetry",          # machine polling
+    "/api/client-errors",      # browser crash reports, sent unattended
+)
+
+# A POST that changes nothing. These are reads that happen to need a body, or
+# buttons a person clicks repeatedly while diagnosing something -- exactly the
+# traffic that produced twenty-five identical rows in one minute.
+NO_CHANGE_SEGMENTS = (
+    "/test", "/verify", "/check", "/health", "/preview", "/refresh",
+    "/validate", "/geocode", "/search", "/reverse", "/analyze", "/summarize",
+    "/recheck", "/ping", "/diagnose",
+)
+
+# Path fragment -> what the thing is called. Longest match wins, so
+# "/retention/policy" beats "/retention".
+_SUBJECTS = (
+    ("/system/retention/policy", "the records retention policy"),
+    ("/system/retention/run", "a records retention run"),
+    ("/system/retention/export", "a public records export"),
+    ("/system/retention/legal-hold", "the legal hold"),
+    ("/system/domain", "the site's domain"),
+    ("/system/providers", "a service provider's settings"),
+    ("/system/settings", "the system settings"),
+    ("/system/backup", "database backups"),
+    ("/system/branding", "the town's branding"),
+    ("/system/integrations", "an integration"),
+    ("/gis/boundaries", "the town boundary"),
+    ("/gis/layers", "a map layer"),
+    ("/departments", "a department"),
+    ("/services", "a service category"),
+    ("/users", "a staff account"),
+    ("/assets", "an asset"),
+    ("/requests", "a service request"),
+    ("/notifications", "notification settings"),
+    ("/workflows", "a workflow"),
+    ("/knowledge", "the knowledge base"),
+)
+
+_VERBS = {
+    "POST": "Added or updated",
+    "PUT": "Updated",
+    "PATCH": "Updated",
+    "DELETE": "Deleted",
+}
+
+# Trailing identifiers, so `/api/users/42` and `/api/users/7` are the same
+# action rather than two unrelated-looking rows.
+_ID = re.compile(r"/(?:\d+|[0-9a-f]{8}-[0-9a-f-]{27,})(?=/|$)", re.I)
+
+
+DESTROYED_A_RECORD = "Deleted a resident's service request"
+RESTORED_A_RECORD = "Restored a deleted service request"
+
+# Exceptions to the skip list, because they are the actions a records custodian
+# is most likely to be asked about. Work on a request belongs on that request's
+# own timeline, but destroying one is a records-management decision, and the
+# request's timeline is exactly what disappears with it.
+_ALWAYS = (
+    ("DELETE", re.compile(r"^/api/open311/v2/requests/[^/]+$"), DESTROYED_A_RECORD),
+    ("POST", re.compile(r"^/api/open311/v2/requests/[^/]+/restore$"), RESTORED_A_RECORD),
+)
+
+
+def _exception_for(method: str, path: str) -> Optional[str]:
+    for wanted, pattern, label in _ALWAYS:
+        if method.upper() == wanted and pattern.match(path):
+            return label
+    return None
+
+
+def should_record(method: str, path: str) -> bool:
+    """False for reads, for handlers that log themselves, and for no-op POSTs."""
+    if method.upper() not in ("POST", "PUT", "PATCH", "DELETE"):
+        return False
+    path = (path or "").rstrip("/") or "/"
+    if _exception_for(method, path):
+        return True
+    if any(path.startswith(p) for p in SKIP_PREFIXES):
+        return False
+    # DELETE always changes something, whatever the last segment is called.
+    if method.upper() != "DELETE":
+        lowered = path.lower()
+        if any(lowered.endswith(s) or f"{s}/" in lowered for s in NO_CHANGE_SEGMENTS):
+            return False
+    return True
+
+
+def describe_action(method: str, path: str) -> Optional[str]:
+    """A sentence for the Details column, or None if this is not worth a row.
+
+    Deliberately derived from the path alone. The body and the query string
+    carry the values being set -- a password, an API key, a resident's address
+    -- and this table is exported to CSV and handed over on request.
+    """
+    if not should_record(method, path):
+        return None
+
+    method = method.upper()
+    path = (path or "").rstrip("/") or "/"
+    named = _exception_for(method, path)
+    if named:
+        return named
+    clean = _ID.sub("", path)
+    subject = next((name for frag, name in
+                    sorted(_SUBJECTS, key=lambda p: -len(p[0]))
+                    if frag in clean), None)
+    if subject is None:
+        # Better a plain path than a wrong guess: a new endpoint should read as
+        # unfamiliar rather than be silently filed under the nearest thing.
+        return f"{_VERBS.get(method, method)}: {clean}"
+    return f"{_VERBS.get(method, method)} {subject}"

--- a/backend/app/services/caddy_config.py
+++ b/backend/app/services/caddy_config.py
@@ -116,6 +116,26 @@ def render_snippet(domain: str, *, backend: str = "backend:8000",
     )
 
 
+# The thing that breaks next, and it breaks silently.
+#
+# An identity provider only redirects back to a URL on its own allow-list. Move
+# the site to a new domain and the sign-in button starts sending staff to
+# Auth0 or Entra, which then refuses to come back -- with an error page from
+# the identity provider, on the identity provider's domain, saying nothing
+# about Pinpoint. Nobody connects that to the domain change they made an hour
+# ago, and it locks staff out of the tool they administer it with.
+#
+# Said at the moment the domain changes, because that is the only moment
+# somebody is in a position to act on it.
+SSO_CALLBACK_REMINDER = (
+    "Update your sign-in provider before staff try to log in. Auth0 or "
+    "Microsoft Entra will only return to a URL on its allow-list, so add "
+    "the new domain's callback, logout and web-origin URLs there. Until you "
+    "do, signing in will fail on the provider's own error page rather than "
+    "on this one."
+)
+
+
 def describe_reload(ok: bool, detail: str = "") -> dict:
     """What to tell an administrator, in terms they can act on.
 
@@ -129,6 +149,7 @@ def describe_reload(ok: bool, detail: str = "") -> dict:
             "message": "Caddy picked up the new domain. The certificate is "
                        "issued on the first request, which can take a few seconds.",
             "next_step": None,
+            "also_update": SSO_CALLBACK_REMINDER,
         }
     return {
         "reloaded": False,
@@ -139,4 +160,5 @@ def describe_reload(ok: bool, detail: str = "") -> dict:
         # Named exactly, because "restart caddy" is not a thing a clerk can be
         # expected to translate into a command on the right machine.
         "next_step": "docker compose restart caddy",
+        "also_update": SSO_CALLBACK_REMINDER,
     }

--- a/backend/app/services/connector_health.py
+++ b/backend/app/services/connector_health.py
@@ -160,6 +160,43 @@ def clean_error(exc: Any) -> str:
     return text[:ERROR_MAX_CHARS] if text else "Unknown error"
 
 
+# Columns added by migration b4c5d6e7f8a9. Everything above them predates it.
+#
+# A deployment that has not run migrations yet still has to record health. If
+# it cannot -- and it could not, because setting an attribute puts the column
+# in the UPDATE and the whole statement fails -- then `record_success` catches
+# its own error, writes nothing at all, and the card says "not checked yet"
+# immediately after somebody watched the test pass.
+#
+# That is the worst version: the feature looks broken rather than partly
+# unavailable, and the reason (a pending migration) is invisible.
+LATER_COLUMNS = ("last_result", "verifiable")
+
+
+async def _commit_or_retry_without(db, row, columns) -> bool:
+    """Commit; if a newer column is missing, drop it and commit the rest.
+
+    Returns whether the detail columns survived. The counters and timestamps
+    matter more than the message, and losing all of them because one column
+    is not there yet is not a trade anybody would choose.
+    """
+    try:
+        await db.commit()
+        return True
+    except Exception as exc:
+        text = str(exc).lower()
+        if not any(c in text for c in columns) and "column" not in text:
+            raise
+        await db.rollback()
+        logger.warning(
+            "[Health] %s unavailable -- run the pending migrations to record "
+            "what a check found, not only when it ran.", ", ".join(columns)
+        )
+        # Re-apply without them. The row is expired after a rollback, so this
+        # re-reads and re-sets rather than reusing the stale instance.
+        return False
+
+
 async def _row(db, connector: str):
     from sqlalchemy import select
 
@@ -194,7 +231,16 @@ async def record_success(db, connector: str, provider: Optional[str] = None,
         row.consecutive_failures = 0
         row.last_error = None
         row.total_successes = (row.total_successes or 0) + 1
-        await db.commit()
+        if not await _commit_or_retry_without(db, row, LATER_COLUMNS):
+            # Second pass with only the columns every deployment has.
+            row = await _row(db, connector)
+            row.provider = provider or row.provider
+            row.last_attempt_at = now
+            row.last_success_at = now
+            row.consecutive_failures = 0
+            row.last_error = None
+            row.total_successes = (row.total_successes or 0) + 1
+            await db.commit()
     except Exception as exc:
         logger.warning("[Health] could not record success for %s: %s",
                        sanitize_for_log(connector), sanitize_for_log(str(exc)))
@@ -220,7 +266,14 @@ async def record_unverifiable(db, connector: str, detail: str,
         row.last_attempt_at = datetime.now(timezone.utc)
         row.last_result = (detail or "")[:500] or None
         row.verifiable = False
-        await db.commit()
+        if not await _commit_or_retry_without(db, row, LATER_COLUMNS):
+            # Nothing left to record: "we tried and cannot tell" lives entirely
+            # in the columns this deployment does not have yet. The attempt
+            # timestamp is still worth keeping.
+            row = await _row(db, connector)
+            row.provider = provider or row.provider
+            row.last_attempt_at = datetime.now(timezone.utc)
+            await db.commit()
     except Exception as exc:
         logger.warning("[Health] could not record unverifiable for %s: %s",
                        sanitize_for_log(connector), sanitize_for_log(str(exc)))
@@ -240,7 +293,15 @@ async def record_failure(db, connector: str, error: Any,
         row.verifiable = True
         row.consecutive_failures = (row.consecutive_failures or 0) + 1
         row.total_failures = (row.total_failures or 0) + 1
-        await db.commit()
+        if not await _commit_or_retry_without(db, row, LATER_COLUMNS):
+            row = await _row(db, connector)
+            row.provider = provider or row.provider
+            row.last_attempt_at = now
+            row.last_error_at = now
+            row.last_error = clean_error(error)
+            row.consecutive_failures = (row.consecutive_failures or 0) + 1
+            row.total_failures = (row.total_failures or 0) + 1
+            await db.commit()
     except Exception as exc:
         logger.warning("[Health] could not record failure for %s: %s",
                        sanitize_for_log(connector), sanitize_for_log(str(exc)))

--- a/backend/app/services/connector_verification.py
+++ b/backend/app/services/connector_verification.py
@@ -194,24 +194,26 @@ async def probe_system(db, *, readings=None, health=None, alerts=None):
 async def _collect_readings(db) -> Dict[str, Dict[str, Any]]:
     """The real measurements. Every one is guarded: a probe that raises must
     not take the other three with it."""
-    import shutil
-
     from sqlalchemy import text
 
     from app.services import system_probes as probes
 
     out: Dict[str, Dict[str, Any]] = {}
 
-    # Disk. The path that matters is wherever PostgreSQL and uploads live; with
-    # no better answer available from inside the container, the root volume is
-    # the one that fills.
+    # Disk. Not just `/`: photos and pre-migration database dumps sit on their
+    # own volumes, and if either of those is mounted on a second disk it is the
+    # one that fills while the root filesystem stays comfortable. The fullest of
+    # them is reported, by name.
     try:
-        usage = shutil.disk_usage("/")
-        percent = (usage.used / usage.total) * 100 if usage.total else None
-        free_gb = usage.free / (1024 ** 3)
-        out["system:disk"] = probes.classify_disk(percent, free_label=f"{free_gb:.1f} GB")
+        out["system:disk"] = probes.describe_disk(probes.worst_disk(probes.read_disks()))
     except Exception:
         out["system:disk"] = probes.classify_disk(None)
+
+    # Memory, measured against this container's cap rather than the host's RAM.
+    try:
+        out["system:memory"] = probes.classify_memory(probes.read_memory())
+    except Exception:
+        out["system:memory"] = probes.classify_memory({"percent": None})
 
     try:
         await db.execute(text("SELECT 1"))

--- a/backend/app/services/proactive_health.py
+++ b/backend/app/services/proactive_health.py
@@ -20,7 +20,6 @@ I/O and are each defensive (a failing probe degrades to "unknown", never raises)
 
 import logging
 import os
-import shutil
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -101,14 +100,28 @@ def _check(key: str, label: str, status: str, value, message: str, action: str =
 
 
 def _disk_check() -> Dict[str, Any]:
+    """Every filesystem this deployment writes to, not just the root one.
+
+    `shutil.disk_usage("/")` reads whatever is behind the container's root. On a
+    default Docker install that is the host disk, so it was usually right by
+    accident. Photos (`uploads_data`) and pre-migration database dumps
+    (`migration_backups`) are named volumes, and a town that puts either on a
+    second disk was having the wrong one watched -- the root filesystem stays
+    comfortable while the volume taking a photo per report fills.
+    """
     try:
-        usage = shutil.disk_usage("/")
-        pct = round(usage.used / usage.total * 100, 1)
+        from app.services.system_probes import read_disks, worst_disk
+
+        worst = worst_disk(read_disks())
+        if not worst:
+            return _check("disk", "Disk space", "unknown", None, "Could not read disk usage.")
+        pct = worst["percent"]
         status = classify_metric(pct, warn=80, crit=92)
-        free_gb = round(usage.free / (1024 ** 3), 1)
+        free_gb = round(worst["free"] / (1024 ** 3), 1)
+        where = worst.get("label") or worst.get("path")
         return _check(
             "disk", "Disk space", status, pct,
-            f"Disk is {pct}% full ({free_gb} GB free).",
+            f"{where} is {pct}% full ({free_gb} GB free).",
             "Delete old backups/logs or expand the volume before it fills." if status != "ok" else "",
         )
     except Exception as e:
@@ -117,24 +130,31 @@ def _disk_check() -> Dict[str, Any]:
 
 
 def _memory_check() -> Dict[str, Any]:
+    """The limit that kills this container, not the RAM in the machine.
+
+    `/proc/meminfo` is the host's -- it is not namespaced, so a container reads
+    the whole server's memory no matter how small its own cap. compose caps the
+    backend at 1G; on a 32GB server, a backend at 990MB and one allocation away
+    from being OOM-killed mid-report reported 3% used and a green tick. The
+    cgroup limit is read first and the host is only the fallback, for a
+    deployment that genuinely runs uncapped.
+    """
     try:
-        total = avail = None
-        with open("/proc/meminfo") as f:
-            for line in f:
-                if line.startswith("MemTotal:"):
-                    total = int(line.split()[1])  # kB
-                elif line.startswith("MemAvailable:"):
-                    avail = int(line.split()[1])
-                if total is not None and avail is not None:
-                    break
-        if not total or avail is None:
+        from app.services.system_probes import read_memory
+
+        reading = read_memory()
+        pct = reading["percent"]
+        if pct is None:
             return _check("memory", "Memory", "unknown", None, "Could not read memory usage.")
-        pct = round((1 - avail / total) * 100, 1)
         status = classify_metric(pct, warn=85, crit=95)
+        limit_gb = round((reading["limit_bytes"] or 0) / (1024 ** 3), 2)
+        scope = ("this container's limit" if reading["scope"] == "container"
+                 else "the server's RAM")
         return _check(
             "memory", "Memory", status, pct,
-            f"Memory is {pct}% used.",
-            "Restart heavy services or add RAM; sustained high memory can crash containers." if status != "ok" else "",
+            f"Memory is {pct}% of {scope} ({limit_gb} GB).",
+            "Raise the container's memory limit or reduce what is running; at 100% it is "
+            "killed and restarted." if status != "ok" else "",
         )
     except Exception as e:
         logger.warning(f"[proactive] memory check failed: {e}")
@@ -327,11 +347,45 @@ async def _redaction_check() -> Dict[str, Any]:
                       "Could not determine which detector is redacting photos.")
 
 
+async def _cpu_check(window: float = 0.4) -> Dict[str, Any]:
+    """CPU, as a share of what this container is allowed rather than the host's.
+
+    Reported, not alerted on: one short sample cannot tell a PDF being rendered
+    from a server in trouble, and an email a day about a spike is an email
+    nobody reads. It is here because "the site feels slow" is a real report and
+    this is the number that answers it.
+    """
+    try:
+        import asyncio
+
+        from app.services.system_probes import (
+            cpu_percent, read_cpu_allowance, read_cpu_seconds,
+        )
+
+        cores = read_cpu_allowance()
+        before = read_cpu_seconds()
+        if before is None:
+            return _check("cpu", "CPU", "unknown", None, "Could not read CPU usage.")
+        await asyncio.sleep(window)
+        after = read_cpu_seconds()
+        pct = cpu_percent(
+            None if after is None else after - before, window, cores)
+        if pct is None:
+            return _check("cpu", "CPU", "unknown", None, "Could not read CPU usage.")
+        allowance = f"{cores:g} core{'s' if cores and cores != 1 else ''}" if cores else "the server's cores"
+        return _check("cpu", "CPU", "ok", pct,
+                      f"CPU was {pct}% of {allowance} over the last {window:g}s.")
+    except Exception as e:
+        logger.warning(f"[proactive] cpu check failed: {e}")
+        return _check("cpu", "CPU", "unknown", None, "Could not read CPU usage.")
+
+
 async def collect_checks(db) -> List[Dict[str, Any]]:
     """Run all proactive checks. Never raises; failed probes return 'unknown'."""
     checks = [
         _disk_check(),
         _memory_check(),
+        await _cpu_check(),
         await _db_connection_check(db),
         await _backup_age_check(),
         await _redis_check(),

--- a/backend/app/services/system_probes.py
+++ b/backend/app/services/system_probes.py
@@ -66,6 +66,294 @@ def classify_disk(percent_used: Optional[float], *, free_label: str = "") -> Dic
     return _outcome(True, f"Disk is {percent_used:.0f}% full.{room}")
 
 
+# --------------------------------------------------------------------------- #
+# Reading a container's own limits, rather than the machine it happens to be on.
+#
+# Both resource probes measured the host and reported it as if it were ours:
+#
+#   * `shutil.disk_usage("/")` reads the filesystem behind the container's root.
+#     On a default Docker install that *is* the host disk, so the number is
+#     usually right by accident -- and silently wrong the moment the volumes
+#     that hold the data live somewhere else. `uploads_data` and
+#     `migration_backups` are where a town's disk actually fills up: photos on
+#     every report, and an unencrypted pg_dump before every migration. Mount
+#     either on a second disk and the probe watches the one that is not filling.
+#
+#   * `/proc/meminfo` is the *host's* memory, always. It is not namespaced.
+#     compose caps the backend at `memory: 1G`; on a 32GB server a backend
+#     sitting at 990MB and one OOM-kill away from restarting mid-report reports
+#     3% used, green. The limit that kills the process is the one to measure
+#     against.
+#
+# So: disk is read at every path that matters and the worst one is reported by
+# name, and memory prefers the cgroup limit, falling back to the host only when
+# the container genuinely has no cap.
+# --------------------------------------------------------------------------- #
+
+MEMORY_WARN_PERCENT = 85
+MEMORY_CRITICAL_PERCENT = 95
+
+# cgroup writes "max" (v2) or a number near 2^63 (v1) to mean "no limit".
+_NO_LIMIT_ABOVE = 1 << 62
+
+
+def _fmt_bytes(n: Optional[float]) -> str:
+    if n is None:
+        return "?"
+    gb = n / (1024 ** 3)
+    if gb >= 1:
+        return f"{gb:.1f} GB"
+    return f"{n / (1024 ** 2):.0f} MB"
+
+
+def interpret_memory(limit_bytes: Optional[int], usage_bytes: Optional[int],
+                     host_total_bytes: Optional[int] = None,
+                     host_available_bytes: Optional[int] = None) -> Dict[str, Any]:
+    """Which memory figure to trust, and what it comes to as a percentage.
+
+    The container's own limit wins whenever there is one, because that is the
+    number the kernel kills the process at. The host is the fallback, and it is
+    labelled as the host so nobody reads a reassuring 3% as being about us.
+    """
+    if limit_bytes is not None and 0 < limit_bytes < _NO_LIMIT_ABOVE and usage_bytes is not None:
+        return {
+            "scope": "container",
+            "used_bytes": usage_bytes,
+            "limit_bytes": limit_bytes,
+            "percent": round(usage_bytes / limit_bytes * 100, 1),
+        }
+    if host_total_bytes and host_available_bytes is not None:
+        return {
+            "scope": "host",
+            "used_bytes": host_total_bytes - host_available_bytes,
+            "limit_bytes": host_total_bytes,
+            "percent": round((1 - host_available_bytes / host_total_bytes) * 100, 1),
+        }
+    return {"scope": None, "used_bytes": None, "limit_bytes": None, "percent": None}
+
+
+def classify_memory(reading: Dict[str, Any]) -> Dict[str, Any]:
+    percent = reading.get("percent")
+    if percent is None:
+        return _outcome(False, "Memory usage could not be read on this host.", recorded=False)
+
+    where = ("this container's %s limit" % _fmt_bytes(reading.get("limit_bytes"))
+             if reading.get("scope") == "container"
+             else "the server's %s of RAM" % _fmt_bytes(reading.get("limit_bytes")))
+    used = f"{_fmt_bytes(reading.get('used_bytes'))} of {where}"
+
+    if percent >= MEMORY_CRITICAL_PERCENT:
+        return _outcome(False, (
+            f"Memory is {percent:.0f}% used -- {used}. At 100% the container is killed and "
+            f"restarted, losing whatever it was in the middle of. Raise the limit or "
+            f"reduce what is running."
+        ))
+    if percent >= MEMORY_WARN_PERCENT:
+        return _outcome(False, (
+            f"Memory is {percent:.0f}% used -- {used}. Not failing yet, but there is little "
+            f"headroom for a busy afternoon."
+        ))
+    return _outcome(True, f"Memory is {percent:.0f}% used -- {used}.")
+
+
+def worst_disk(readings) -> Optional[Dict[str, Any]]:
+    """The fullest of the filesystems we depend on, with its name attached.
+
+    Several of the paths usually turn out to be the same filesystem, which is
+    why they are deduplicated by device rather than reported four times. What is
+    left is the set of distinct disks a town can actually run out of, and the
+    only one worth alerting on is the one closest to full -- naming it, because
+    "disk is 94% full" without saying which disk is not something anybody can
+    act on.
+    """
+    seen = set()
+    best = None
+    for r in readings or []:
+        if r is None or not r.get("total"):
+            continue
+        key = r.get("device")
+        if key is not None:
+            if key in seen:
+                continue
+            seen.add(key)
+        percent = round(r["used"] / r["total"] * 100, 1)
+        entry = {**r, "percent": percent}
+        if best is None or percent > best["percent"]:
+            best = entry
+    return best
+
+
+def describe_disk(reading: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not reading:
+        return classify_disk(None)
+    label = reading.get("label") or reading.get("path") or ""
+    out = classify_disk(reading["percent"], free_label=_fmt_bytes(reading.get("free")))
+    if label:
+        out["detail"] = out["detail"].replace("Disk is", f"{label} is", 1)
+    return out
+
+
+# The paths a town's data actually lives on, as this container sees them, and
+# what to call each one on a screen read by somebody who did not deploy it.
+# `/` is kept because the container's own filesystem filling up stops it writing
+# logs and temporary files even when every volume has room.
+DISK_PATHS = (
+    ("/", "The server disk"),
+    ("/project/uploads", "Photo storage"),
+    ("/backups", "Backup storage"),
+)
+
+
+def _first_int(path: str) -> Optional[int]:
+    try:
+        with open(path) as fh:
+            return int(fh.read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _keyed_int(path: str, key: str) -> Optional[int]:
+    try:
+        with open(path) as fh:
+            for line in fh:
+                parts = line.split()
+                if parts and parts[0] == key:
+                    return int(parts[1])
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def read_cgroup_memory(root: str = "/sys/fs/cgroup"):
+    """(limit, usage) for this container, or (None, None) if it is not capped.
+
+    v2 first, then v1. Page cache is subtracted from usage in both: the kernel
+    reclaims it under pressure rather than OOM-killing, so counting it would
+    have every long-running container reading 99% and nobody believing the
+    number by the second week.
+    """
+    limit = _first_int(f"{root}/memory.max")
+    if limit is None:
+        # "max" is not an int; the file existing at all means v2.
+        try:
+            with open(f"{root}/memory.max") as fh:
+                if fh.read().strip() == "max":
+                    return None, None
+        except OSError:
+            pass
+    if limit is not None:
+        usage = _first_int(f"{root}/memory.current")
+        cache = _keyed_int(f"{root}/memory.stat", "inactive_file") or 0
+        return limit, (max(0, usage - cache) if usage is not None else None)
+
+    limit = _first_int(f"{root}/memory/memory.limit_in_bytes")
+    if limit is None:
+        return None, None
+    usage = _first_int(f"{root}/memory/memory.usage_in_bytes")
+    cache = _keyed_int(f"{root}/memory/memory.stat", "total_inactive_file") or 0
+    return limit, (max(0, usage - cache) if usage is not None else None)
+
+
+def read_host_memory(path: str = "/proc/meminfo"):
+    """(total, available) in bytes. Always the host's -- /proc is not namespaced."""
+    total = _keyed_int(path, "MemTotal:")
+    avail = _keyed_int(path, "MemAvailable:")
+    return (total * 1024 if total else None), (avail * 1024 if avail is not None else None)
+
+
+def read_memory(cgroup_root: str = "/sys/fs/cgroup",
+                meminfo: str = "/proc/meminfo") -> Dict[str, Any]:
+    limit, usage = read_cgroup_memory(cgroup_root)
+    total, avail = read_host_memory(meminfo)
+    return interpret_memory(limit, usage, total, avail)
+
+
+def read_disks(paths=DISK_PATHS):
+    """Usage for each path that exists, tagged with the device behind it.
+
+    A path that is not mounted in this container is skipped rather than
+    reported as an error: the backend does not see the database volume, and
+    saying so on every sweep would train people to ignore the panel.
+    """
+    import os
+    import shutil
+
+    out = []
+    for path, label in paths:
+        try:
+            usage = shutil.disk_usage(path)
+            device = os.stat(path).st_dev
+        except OSError:
+            continue
+        out.append({
+            "path": path, "label": label, "device": device,
+            "total": usage.total, "used": usage.used, "free": usage.free,
+        })
+    return out
+
+
+def read_cpu_allowance(root: str = "/sys/fs/cgroup") -> Optional[float]:
+    """How many cores this container may use, or None if it is not capped."""
+    try:
+        with open(f"{root}/cpu.max") as fh:
+            quota, _, period = fh.read().strip().partition(" ")
+        if quota == "max":
+            return None
+        return int(quota) / int(period or 100000)
+    except (OSError, ValueError):
+        pass
+    quota = _first_int(f"{root}/cpu/cpu.cfs_quota_us")
+    period = _first_int(f"{root}/cpu/cpu.cfs_period_us")
+    if quota is None or quota <= 0 or not period:
+        return None
+    return quota / period
+
+
+def read_cpu_seconds(root: str = "/sys/fs/cgroup") -> Optional[float]:
+    """Total CPU time this container has used, in seconds."""
+    usec = _keyed_int(f"{root}/cpu.stat", "usage_usec")
+    if usec is not None:
+        return usec / 1_000_000
+    nsec = _first_int(f"{root}/cpuacct/cpuacct.usage")
+    if nsec is not None:
+        return nsec / 1_000_000_000
+    return None
+
+
+def cpu_percent(used_seconds: Optional[float], elapsed_seconds: float,
+                cores: Optional[float]) -> Optional[float]:
+    """CPU used over a window, as a percentage of what this container may use.
+
+    Against the container's own allowance, not the machine's core count: a
+    backend limited to `cpus: '1.0'` on an eight-core server is saturated at
+    what the host would call 12%.
+    """
+    if used_seconds is None or elapsed_seconds <= 0:
+        return None
+    allowed = cores if cores and cores > 0 else 1.0
+    return round(used_seconds / (elapsed_seconds * allowed) * 100, 1)
+
+
+def describe_cpu(percent: Optional[float], cores: Optional[float],
+                 window_seconds: float) -> Dict[str, Any]:
+    """A reading, said as the momentary thing it is.
+
+    Deliberately not alerted on. This is one short sample, and a container is
+    briefly at 100% every time it renders a PDF or resizes a photo -- alerting
+    on that would send an email a day about nothing, and an alert nobody
+    believes is worse than no alert. Disk fills and memory caps are the ones
+    that predict an outage; CPU here is a number to look at when something
+    already feels slow.
+    """
+    if percent is None:
+        return _outcome(True, "CPU usage could not be read on this host.", recorded=False)
+    allowance = (f"{cores:g} core{'s' if cores and cores != 1 else ''}"
+                 if cores else "all the server's cores")
+    return _outcome(True, (
+        f"CPU was {percent:.0f}% of {allowance} over the last {window_seconds:g}s."
+    ))
+
+
 def classify_backup(last_backup_at: Optional[datetime], now: datetime,
                     *, stale_after: timedelta = BACKUP_STALE_AFTER) -> Dict[str, Any]:
     """Backups are only real if they are recent and somebody would notice."""
@@ -114,6 +402,7 @@ def classify_reachable(name: str, reachable: bool, detail: str = "") -> Dict[str
 # text and the health page cannot disagree about what "system:disk" means.
 LABELS: Dict[str, str] = {
     "system:disk": "Disk space",
+    "system:memory": "Memory",
     "system:database": "Database",
     "system:cache": "Cache (Redis)",
     "system:backups": "Backups",

--- a/backend/tests/test_admin_actions_are_audited.py
+++ b/backend/tests/test_admin_actions_are_audited.py
@@ -177,12 +177,22 @@ def test_every_authenticated_mutation_is_covered_by_something():
 
 
 def test_the_backstop_only_records_changes_that_worked():
+    """The method test used to be a literal set in this class. It moved to
+    `audit_labels.should_record`, alongside the decision about which POSTs
+    change nothing -- so this asks the function rather than grepping for a line
+    that no longer exists."""
+    from app.services.audit_labels import should_record
+
     main = (ROOT / "app/main.py").read_text()
     block = main[main.index("class AdminActionAuditMiddleware"):]
     block = block[:block.index("\nclass ")]
-    assert 'MUTATIONS = {"POST", "PUT", "PATCH", "DELETE"}' in block, (
-        "reads would be recorded, and a log nobody can scroll is a log nobody reads"
+    assert "describe_action(" in block, (
+        "the backstop is no longer consulting the rules about what to record"
     )
+    for read_only in ("GET", "HEAD", "OPTIONS"):
+        assert should_record(read_only, "/api/users") is False, (
+            "reads would be recorded, and a log nobody can scroll is a log nobody reads"
+        )
     assert "response.status_code >= 400" in block, (
         "failed attempts would be recorded here rather than with the auth events"
     )

--- a/backend/tests/test_audit_is_readable.py
+++ b/backend/tests/test_audit_is_readable.py
@@ -1,0 +1,154 @@
+"""An audit log has to say what happened, and not say it a hundred times.
+
+The backstop middleware fixed the real gap -- fifty-two mutating endpoints
+wrote nothing at all -- and produced this:
+
+    Admin Change    admin    -    Aug 2, 2026, 12:58 AM    -
+    Admin Change    admin    -    Aug 2, 2026, 12:58 AM    -
+    ... x25
+
+Three separate failures in one screen. The action was not named, so no row
+could be acted on. The address was not recorded, so the column read "-" under
+sign-in rows that had one. And clicking "Check all providers" wrote a row per
+connection test, so the twenty-five entries at 12:58 pushed the change that
+mattered onto page four.
+"""
+
+import pytest
+
+from app.services.audit_labels import describe_action, should_record
+
+
+# ---- what is worth a row ----
+
+@pytest.mark.parametrize("method,path", [
+    ("POST", "/api/system/providers/twilio/test"),
+    ("POST", "/api/system/connectors/check"),
+    ("POST", "/api/system/retention/preview"),
+    ("POST", "/api/gis/geocode"),
+    ("POST", "/api/system/health/refresh"),
+])
+def test_a_button_that_changes_nothing_writes_nothing(method, path):
+    """These are reads that need a body. A person diagnosing an integration
+    clicks them a dozen times in a minute, and each one was a row."""
+    assert should_record(method, path) is False
+    assert describe_action(method, path) is None
+
+
+@pytest.mark.parametrize("method,path", [
+    ("POST", "/api/users"),
+    ("DELETE", "/api/departments/4"),
+    ("PUT", "/api/system/settings"),
+    ("POST", "/api/system/retention/policy"),
+    ("POST", "/api/gis/boundaries"),
+])
+def test_a_real_change_is_recorded(method, path):
+    assert should_record(method, path) is True
+    assert describe_action(method, path)
+
+
+def test_a_delete_is_recorded_whatever_it_is_called():
+    """`DELETE /api/system/cache/check` is a deletion. Matching the word
+    "check" and skipping it would lose a destructive action to a naming
+    coincidence."""
+    assert should_record("DELETE", "/api/system/cache/check") is True
+
+
+def test_reads_are_never_recorded():
+    """GET is the overwhelming majority of traffic; a log nobody can scroll is
+    a log nobody reads."""
+    assert should_record("GET", "/api/users") is False
+    assert should_record("HEAD", "/api/users") is False
+
+
+def test_destroying_a_resident_record_is_recorded_in_the_admin_log():
+    """Everything else on a request belongs on that request's own timeline.
+    Deleting it is different: the timeline is what goes with it, and "who
+    deleted this report" is the question a records custodian is actually
+    asked."""
+    assert describe_action("DELETE", "/api/open311/v2/requests/SR-2026-0041") == (
+        "Deleted a resident's service request"
+    )
+    assert describe_action("POST", "/api/open311/v2/requests/SR-2026-0041/restore") == (
+        "Restored a deleted service request"
+    )
+
+
+def test_ordinary_work_on_a_request_stays_off_the_admin_log():
+    """A status change and a comment are the day job. They are on the request,
+    where somebody looking at that request will see them, and putting them here
+    too would bury the deletions in a hundred routine updates."""
+    assert should_record("PUT", "/api/open311/v2/requests/41/status") is False
+    assert should_record("POST", "/api/open311/v2/public/requests/41/comments") is False
+
+
+@pytest.mark.parametrize("path", [
+    "/api/auth/login",
+    "/api/telemetry/ping",
+    "/api/open311/v2/requests",
+    "/api/system/translate/es",
+])
+def test_handlers_that_log_themselves_are_not_logged_twice(path):
+    """A sign-in already writes a login_success. Two rows for one action makes
+    the count meaningless."""
+    assert should_record("POST", path) is False
+
+
+# ---- what the row says ----
+
+def test_the_action_is_a_sentence_not_a_route():
+    """The audience is a clerk being asked, at a hearing, what happened on the
+    2nd -- not somebody who can read a URL."""
+    assert describe_action("POST", "/api/system/retention/policy") == (
+        "Added or updated the records retention policy"
+    )
+    assert describe_action("DELETE", "/api/users/12") == "Deleted a staff account"
+
+
+def test_the_same_action_on_two_records_reads_the_same_way():
+    """Otherwise `/api/users/12` and `/api/users/13` look like two unrelated
+    kinds of event, and neither can be counted."""
+    assert describe_action("DELETE", "/api/users/12") == describe_action("DELETE", "/api/users/13")
+
+
+def test_an_unrecognised_endpoint_is_not_filed_under_the_nearest_thing():
+    """A new route should read as unfamiliar rather than be mislabelled. A
+    wrong label in a compliance record is worse than a bare path."""
+    said = describe_action("POST", "/api/something/new")
+    assert said and "/api/something/new" in said
+
+
+def test_no_values_are_put_in_the_label():
+    """This table is exported to CSV and handed over on request. The body and
+    the query string carry passwords, API keys and residents' addresses."""
+    said = describe_action("POST", "/api/system/providers/email?api_key=secret-value")
+    assert "secret-value" not in (said or "")
+
+
+# ---- the middleware uses it, and records who from where ----
+
+def test_the_middleware_names_the_action_and_the_address():
+    """Both were missing from the row, which is why the screen was a wall of
+    "Admin Change ... - ... -"."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    source = root.joinpath("backend/app/main.py").read_text()
+    block = source[source.index("class AdminActionAuditMiddleware"):]
+    block = block[:block.index("\ndef _actor_from_request")]
+
+    assert "describe_action(" in block, "the middleware is not naming the action"
+    assert 'ip_address=_client_ip(request)' in block, "the address is not recorded"
+    assert '"action": action' in block, "the description is not stored on the row"
+
+
+def test_the_address_is_taken_from_the_proxy_header():
+    """Caddy fronts everything, so `request.client.host` is Caddy's address on
+    the compose network -- identical for every user, which is the same as
+    having no address at all."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    source = root.joinpath("backend/app/main.py").read_text()
+    helper = source[source.index("def _client_ip"):]
+    helper = helper[:helper.index("\nclass ")]
+    assert 'X-Forwarded-For' in helper
+    assert "request.client.host" in helper, "no fallback for a direct connection"

--- a/backend/tests/test_container_resources.py
+++ b/backend/tests/test_container_resources.py
@@ -1,0 +1,274 @@
+"""Resource checks have to be about this container, not the machine under it.
+
+Both probes measured the host and presented the answer as ours:
+
+  * Memory came from `/proc/meminfo`, which is not namespaced -- a container
+    reads the whole server's RAM whatever its own cap is. compose limits the
+    backend to 1G. On a 32GB host, a backend sitting at 990MB and one
+    allocation away from being OOM-killed in the middle of a resident's report
+    displayed "3% used" and a green tick. The number that matters is the one
+    the kernel kills the process at.
+
+  * Disk came from `shutil.disk_usage("/")`, the filesystem behind the
+    container's root. On a default Docker install that is the host disk, so it
+    was right by accident. Photos and pre-migration database dumps live on
+    named volumes; mount either on a second disk and the probe faithfully
+    watched the filesystem that was not filling up.
+
+Everything here runs against files in a temporary directory, so the cgroup
+layouts of both versions are exercised in CI on a machine that has neither.
+"""
+
+from app.services import system_probes as probes
+
+GB = 1024 ** 3
+
+
+# ---- memory: whose limit is being reported ----
+
+def test_the_container_cap_wins_over_the_hosts_ram():
+    """The whole point. 990MB of a 1G cap is an emergency; the same 990MB of a
+    32GB host is nothing, and the old probe reported the second one."""
+    reading = probes.interpret_memory(
+        limit_bytes=1 * GB, usage_bytes=int(0.97 * GB),
+        host_total_bytes=32 * GB, host_available_bytes=31 * GB,
+    )
+    assert reading["scope"] == "container"
+    assert reading["percent"] > 95
+    assert probes.classify_memory(reading)["ok"] is False
+
+
+def test_an_uncapped_container_falls_back_to_the_host():
+    """cgroup writes a number near 2^63 to mean "no limit". Taken literally it
+    is a 8-exabyte limit and every reading rounds to 0%."""
+    reading = probes.interpret_memory(
+        limit_bytes=9223372036854771712, usage_bytes=8 * GB,
+        host_total_bytes=16 * GB, host_available_bytes=4 * GB,
+    )
+    assert reading["scope"] == "host"
+    assert reading["percent"] == 75.0
+
+
+def test_the_reading_says_which_it_measured():
+    """"Memory is 40% used" is two different sentences depending on 40% of
+    what, and only one of them is actionable."""
+    container = probes.classify_memory(probes.interpret_memory(1 * GB, int(0.4 * GB)))
+    host = probes.classify_memory(probes.interpret_memory(None, None, 16 * GB, int(9.6 * GB)))
+    assert "container" in container["detail"]
+    assert "server" in host["detail"]
+
+
+def test_nothing_readable_is_reported_as_nothing_rather_than_zero():
+    reading = probes.interpret_memory(None, None, None, None)
+    out = probes.classify_memory(reading)
+    assert out["recorded"] is False and out["ok"] is False
+
+
+def test_cgroup_v2_is_read_and_page_cache_is_not_counted(tmp_path):
+    """A container that has read files has a large `inactive_file`, which the
+    kernel reclaims under pressure instead of OOM-killing. Counting it has every
+    long-running deployment at 99% by the second week, and a gauge that is
+    always red is a gauge nobody looks at."""
+    (tmp_path / "memory.max").write_text("1073741824\n")
+    (tmp_path / "memory.current").write_text("805306368\n")   # 768MB
+    (tmp_path / "memory.stat").write_text("anon 100\ninactive_file 268435456\n")  # 256MB cache
+
+    limit, usage = probes.read_cgroup_memory(str(tmp_path))
+    assert limit == 1 * GB
+    assert usage == 512 * 1024 * 1024
+
+
+def test_cgroup_v1_is_read_too(tmp_path):
+    """Amazon Linux 2, Debian 10 and any host booted with
+    systemd.unified_cgroup_hierarchy=0 are still v1."""
+    v1 = tmp_path / "memory"
+    v1.mkdir()
+    (v1 / "memory.limit_in_bytes").write_text("536870912\n")
+    (v1 / "memory.usage_in_bytes").write_text("268435456\n")
+    (v1 / "memory.stat").write_text("total_inactive_file 67108864\n")
+
+    limit, usage = probes.read_cgroup_memory(str(tmp_path))
+    assert limit == 512 * 1024 * 1024
+    assert usage == 201326592
+
+
+def test_an_unlimited_v2_cgroup_reports_no_limit(tmp_path):
+    (tmp_path / "memory.max").write_text("max\n")
+    (tmp_path / "memory.current").write_text("805306368\n")
+    assert probes.read_cgroup_memory(str(tmp_path)) == (None, None)
+
+
+def test_no_cgroup_at_all_is_not_an_error(tmp_path):
+    """Podman, a bare-metal install, a Mac. None of them should make the health
+    page show a crash."""
+    assert probes.read_cgroup_memory(str(tmp_path / "nothing")) == (None, None)
+
+
+def test_host_memory_is_read_in_bytes(tmp_path):
+    """/proc/meminfo is in kB. Treating it as bytes is a 1024x error in the
+    safe direction, which is the kind that is never noticed."""
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemTotal:       16384000 kB\nMemFree: 1 kB\nMemAvailable:    8192000 kB\n")
+    total, avail = probes.read_host_memory(str(meminfo))
+    assert total == 16384000 * 1024
+    assert avail == 8192000 * 1024
+
+
+# ---- disk: which filesystem is being watched ----
+
+def _fs(path, label, device, total, used):
+    return {"path": path, "label": label, "device": device,
+            "total": total, "used": used, "free": total - used}
+
+
+def test_the_fullest_volume_is_the_one_reported():
+    """Uploads on their own disk is the case the old probe missed entirely: `/`
+    reads 30% and stays green while photo storage fills and every new report
+    with a picture starts failing."""
+    worst = probes.worst_disk([
+        _fs("/", "The server disk", 1, 100 * GB, 30 * GB),
+        _fs("/project/uploads", "Photo storage", 2, 50 * GB, 47 * GB),
+        _fs("/backups", "Backup storage", 3, 50 * GB, 10 * GB),
+    ])
+    assert worst["path"] == "/project/uploads"
+    assert worst["percent"] == 94.0
+
+
+def test_the_reading_names_the_volume():
+    """"Disk is 94% full" with three disks tells somebody there is a problem
+    and not where it is."""
+    out = probes.describe_disk(probes.worst_disk([
+        _fs("/project/uploads", "Photo storage", 2, 50 * GB, 47 * GB),
+    ]))
+    assert out["ok"] is False
+    assert out["detail"].startswith("Photo storage is 94% full")
+
+
+def test_one_filesystem_behind_three_paths_is_counted_once():
+    """The common case: every volume is on the host's single disk. Reporting it
+    three times would be three identical alerts for one problem."""
+    readings = [
+        _fs("/", "The server disk", 7, 100 * GB, 91 * GB),
+        _fs("/project/uploads", "Photo storage", 7, 100 * GB, 91 * GB),
+        _fs("/backups", "Backup storage", 7, 100 * GB, 91 * GB),
+    ]
+    assert probes.worst_disk(readings)["path"] == "/"
+
+
+def test_a_path_that_is_not_mounted_is_skipped_not_failed():
+    """The backend does not see the database volume, and a dev checkout has no
+    /backups. Neither is a fault to report every hour."""
+    assert probes.read_disks([("/definitely/not/here", "Nowhere")]) == []
+
+
+def test_the_real_paths_are_probed():
+    """The volumes compose actually mounts. If a path here stops matching the
+    compose file, this probe quietly goes back to watching only `/`."""
+    paths = dict(probes.DISK_PATHS)
+    assert "/" in paths
+    assert "/project/uploads" in paths
+    assert "/backups" in paths
+
+
+def test_the_root_filesystem_is_still_read_here():
+    """Whatever else is mounted, this one always exists -- so the probe can
+    never come back empty on a real deployment."""
+    found = {r["path"] for r in probes.read_disks()}
+    assert "/" in found
+
+
+# ---- cpu ----
+
+def test_cpu_is_measured_against_the_containers_allowance():
+    """A backend limited to one core on an eight-core host is saturated at what
+    the machine would call 12%."""
+    # 0.4s of CPU time in a 0.4s window, on a one-core allowance.
+    assert probes.cpu_percent(0.4, 0.4, 1.0) == 100.0
+    assert probes.cpu_percent(0.4, 0.4, 4.0) == 25.0
+
+
+def test_cpu_without_a_quota_is_still_a_number():
+    assert probes.cpu_percent(0.2, 0.4, None) == 50.0
+
+
+def test_an_unreadable_cpu_reading_is_not_a_zero():
+    assert probes.cpu_percent(None, 0.4, 1.0) is None
+
+
+def test_a_cpu_spike_is_not_treated_as_a_fault():
+    """One 0.4s sample cannot tell a PDF being rendered from a server in
+    trouble. Alerting on it would send an email a day about nothing, and an
+    alert nobody believes is worse than no alert at all."""
+    assert probes.describe_cpu(100.0, 1.0, 0.4)["ok"] is True
+
+
+def test_cpu_quota_is_read_from_either_cgroup_version(tmp_path):
+    (tmp_path / "cpu.max").write_text("50000 100000\n")
+    assert probes.read_cpu_allowance(str(tmp_path)) == 0.5
+
+    v1 = tmp_path / "v1"
+    (v1 / "cpu").mkdir(parents=True)
+    (v1 / "cpu" / "cpu.cfs_quota_us").write_text("200000\n")
+    (v1 / "cpu" / "cpu.cfs_period_us").write_text("100000\n")
+    assert probes.read_cpu_allowance(str(v1)) == 2.0
+
+
+def test_an_uncapped_cpu_reports_no_quota(tmp_path):
+    """-1 in v1 and "max" in v2 both mean unlimited. Taken as a quota, -1 makes
+    every percentage negative."""
+    (tmp_path / "cpu.max").write_text("max 100000\n")
+    assert probes.read_cpu_allowance(str(tmp_path)) is None
+
+    v1 = tmp_path / "v1"
+    (v1 / "cpu").mkdir(parents=True)
+    (v1 / "cpu" / "cpu.cfs_quota_us").write_text("-1\n")
+    assert probes.read_cpu_allowance(str(v1)) is None
+
+
+def test_cpu_time_is_read_in_seconds(tmp_path):
+    """v2 reports microseconds and v1 nanoseconds. Mixing them up is a
+    thousandfold error that still produces a plausible-looking percentage."""
+    (tmp_path / "cpu.stat").write_text("usage_usec 2500000\nuser_usec 1\n")
+    assert probes.read_cpu_seconds(str(tmp_path)) == 2.5
+
+    v1 = tmp_path / "v1"
+    (v1 / "cpuacct").mkdir(parents=True)
+    (v1 / "cpuacct" / "cpuacct.usage").write_text("2500000000\n")
+    assert probes.read_cpu_seconds(str(v1)) == 2.5
+
+
+# ---- the callers actually use it ----
+
+def test_neither_probe_reads_the_host_directly_any_more():
+    """The regression this guards is a one-line revert: somebody reaching for
+    the host-wide call again because it is shorter.
+
+    Matched on the parsed syntax tree, not on the text. An earlier version
+    searched the source for the string and failed on the comment explaining why
+    the call had been removed -- prose about a mistake is not the mistake.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    for name in ("backend/app/services/proactive_health.py",
+                 "backend/app/services/connector_verification.py"):
+        tree = ast.parse(root.joinpath(name).read_text())
+        calls = [ast.unparse(node) for node in ast.walk(tree) if isinstance(node, ast.Call)]
+        assert not [c for c in calls if c.startswith("shutil.disk_usage")], (
+            f"{name} is reading the host disk again"
+        )
+        assert not [c for c in calls if "/proc/meminfo" in c], (
+            f"{name} is reading host memory directly again"
+        )
+
+
+def test_memory_is_on_the_hourly_system_sweep():
+    """Disk was swept hourly and recorded as a connector-health row; memory was
+    only ever on a page somebody had to be looking at. A container being
+    OOM-killed deserves the same escalation and the same email."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    source = root.joinpath("backend/app/services/connector_verification.py").read_text()
+    assert '"system:memory"' in source
+    assert probes.label_for("system:memory") == "Memory"

--- a/backend/tests/test_custom_domain.py
+++ b/backend/tests/test_custom_domain.py
@@ -148,11 +148,25 @@ def test_the_backend_can_write_where_caddy_reads():
 
 
 def test_the_handler_no_longer_rewrites_the_whole_config():
+    """The invariant is what the handler *writes*, not what it reads.
+
+    An earlier version of this test asserted the name `caddyfile_content` was
+    absent, which was a proxy for "builds a Caddyfile from a template". The
+    handler now legitimately reads the base file into that same variable to
+    POST it to Caddy's admin API -- so the assertion failed on a correct
+    change. Reading the config is fine. Overwriting it is not.
+    """
     source = (ROOT / "backend/app/api/system.py").read_text()
     handler = source[source.index('@router.post("/domain/configure")'):]
     handler = handler[:handler.index("\n@router.")]
-    assert "caddyfile_content" not in handler, "the whole Caddyfile is being regenerated again"
+
+    # The only thing written is the snippet, into the tenants directory.
     assert "render_snippet(" in handler
+    assert 'open(snippet_path, "w")' in handler
+
+    # And nothing opens the base Caddyfile for writing.
+    assert 'caddyfile_path, "w"' not in handler, "the base Caddyfile is being overwritten again"
+    assert "reverse_proxy" not in handler, "a site block is being built in the handler again"
 
 
 def test_no_machines_ip_is_baked_into_the_product():

--- a/backend/tests/test_settings_round_trip.py
+++ b/backend/tests/test_settings_round_trip.py
@@ -1,0 +1,196 @@
+"""Anything a town configures has to survive a reload.
+
+The recurring failure in this codebase is a setting that stores fine, reads
+back fine, and silently does nothing -- or stores fine and is never read at
+all. The retention mode did it for months because two `system_settings` rows
+existed and the write and the read picked different ones. It is not a bug you
+notice: the form saves, the toast appears, and the value is simply gone the
+next time somebody looks, by which point it reads as "I must not have clicked
+save".
+
+So every column on `SystemSettings` has to be reachable both ways. Either it
+travels through `SystemSettingsBase` -- the schema the general settings
+endpoint reads and writes -- or it has a dedicated endpoint that writes it and
+one that reads it back, named here.
+
+A column in neither list is unreachable: the UI cannot set it and cannot show
+it. That is the state `translations` has been in since it was added.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODELS = ROOT / "app/models.py"
+SCHEMAS = ROOT / "app/schemas.py"
+API = ROOT / "app/api"
+
+
+def _columns() -> set:
+    block = MODELS.read_text()
+    block = block[block.index("class SystemSettings(Base)"):]
+    block = block[:block.index("\nclass ")]
+    return {c for c in re.findall(r"^    (\w+) = Column", block, re.M)} - {"id"}
+
+
+def _schema_fields() -> set:
+    block = SCHEMAS.read_text()
+    block = block[block.index("class SystemSettingsBase"):]
+    block = block[:block.index("\nclass ")]
+    return set(re.findall(r"^    (\w+):", block, re.M))
+
+
+# Columns that do not travel through /settings, with the endpoints that do own
+# them. Both directions, because a value that can be written and not read is
+# the exact shape of the bug this file exists for.
+DEDICATED = {
+    "custom_domain":           ("POST /system/domain/configure", "GET /system/domain/status"),
+    "timezone":                ("POST /system/timezone", "GET /system/timezone"),
+    "retention_mode":          ("POST /system/retention/policy", "GET /system/retention/policy"),
+    "retention_state_code":    ("POST /system/retention/policy", "GET /system/retention/policy"),
+    "retention_days_override": ("POST /system/retention/policy", "GET /system/retention/policy"),
+    "retention_scrub_fields":  ("POST /system/retention/policy", "GET /system/retention/policy"),
+    "legal_hold":              ("POST /system/retention/legal-hold", "GET /system/retention/policy"),
+    "township_boundary":       ("POST /gis/boundaries", "GET /system/settings (maps config)"),
+}
+
+# Written and read by the platform itself, never by a person. Not settings.
+INTERNAL = {
+    "ai_models_cache",     # discovery cache, refreshed by the model picker
+    "health_alert_state",  # what the alerting layer has already said
+    "managed_policy",      # set by the hosting orchestrator, not the town
+    "updated_at",          # the ORM writes it
+}
+
+# Columns that nothing reaches. Listed so the state is a recorded decision
+# rather than an oversight -- and so adding a new one fails this file.
+KNOWN_UNREACHABLE = {
+    # Declared with a documented format ({"es": {"township_name": ...}}) and
+    # written by no code path anywhere in the backend. The per-language
+    # overrides it was meant to hold have no way in. Either give it an endpoint
+    # or drop the column; leaving it invites somebody to build a UI for a
+    # setting that cannot be stored.
+    "translations",
+}
+
+
+def test_every_settings_column_is_reachable():
+    """The check that matters. A column the UI can neither set nor read is
+    either dead weight or a feature somebody believes exists."""
+    unclassified = _columns() - _schema_fields() - set(DEDICATED) - INTERNAL - KNOWN_UNREACHABLE
+    assert not unclassified, (
+        f"new SystemSettings columns nobody has ruled on: {sorted(unclassified)}. "
+        f"Add to SystemSettingsBase, or give it a dedicated read *and* write "
+        f"endpoint and list it in DEDICATED, or say why it is internal."
+    )
+
+
+def test_the_schema_never_promises_a_column_that_does_not_exist():
+    """A field on the schema with no column is accepted by the API, echoed back
+    in the response, and dropped -- the most convincing possible version of
+    "it saved"."""
+    phantom = _schema_fields() - _columns()
+    assert not phantom, f"SystemSettingsBase declares {sorted(phantom)} with no column behind it"
+
+
+@pytest.mark.parametrize("column,endpoints", sorted(DEDICATED.items()))
+def test_a_dedicated_column_can_be_written_and_read(column, endpoints):
+    """Both halves. `retention_scrub_fields` was saved by an endpoint that had
+    no matching read for a while, so the boxes a clerk ticked came back
+    unticked and they ticked them again."""
+    api = "\n".join(p.read_text() for p in API.glob("*.py"))
+    written = re.search(rf"(?:settings|row|s)\.{column}\s*=", api)
+    read = re.search(rf"getattr\(settings, [\"']{column}[\"']|settings\.{column}\b(?!\s*=)", api)
+    assert written, f"{column} is never written ({endpoints[0]} was expected to)"
+    assert read, f"{column} is never read back ({endpoints[1]} was expected to)"
+
+
+def test_the_unreachable_list_has_not_gone_stale():
+    """An entry that is now reachable is a comment pretending to be a finding."""
+    api = "\n".join(p.read_text() for p in API.glob("*.py"))
+    for column in KNOWN_UNREACHABLE:
+        assert column in _columns(), f"{column} is no longer a column; drop it from the list"
+        assert not re.search(rf"settings\.{column}\s*=", api), (
+            f"{column} is written now -- move it out of KNOWN_UNREACHABLE"
+        )
+
+
+def test_settings_are_read_through_the_singleton_helper():
+    """`system_settings` has had more than one row in the wild. Any read that
+    is not ordered picks whichever row PostgreSQL hands back first, which
+    changes after an UPDATE rewrites the tuple -- so a value saved through one
+    path was read through another and appeared not to have saved at all.
+
+    Every read is either the shared helper or explicitly ordered.
+    """
+    api = "\n".join(p.read_text() for p in API.glob("*.py"))
+    unordered = re.findall(r"select\(SystemSettings\)(?!\s*\.where)(?![^)]*order_by)[^\n]*\n", api)
+    bad = [u for u in unordered if "order_by" not in u and "limit" in u]
+    assert not bad, (
+        f"unordered singleton reads: {bad}. Use read_settings_row() or "
+        f".order_by(SystemSettings.id) -- LIMIT 1 without ORDER BY is not deterministic."
+    )
+
+
+# ---- and the work that has been accepted but not yet run ----
+
+COMPOSE = ROOT.parent / "docker-compose.yml"
+
+
+@pytest.fixture(scope="module")
+def compose() -> str:
+    if not COMPOSE.exists():
+        pytest.skip("compose file not in this checkout")
+    return COMPOSE.read_text()
+
+
+def _service(compose: str, name: str) -> str:
+    block = compose[compose.index(f"\n  {name}:"):]
+    end = re.search(r"\n  [a-z_-]+:\n", block[3:])
+    return block[:end.start() + 3] if end else block
+
+
+def test_the_database_survives_a_restart(compose):
+    """The obvious one, and it is fine. Here so that removing the volume is a
+    test failure rather than a discovery."""
+    assert "postgres_data:/var/lib/postgresql/data" in compose
+
+
+def test_the_queue_survives_a_restart(compose):
+    """Redis had no volume. It holds the Celery queue -- every confirmation
+    email, AI triage and govtech push that has been accepted and not yet run --
+    so `docker compose restart` dropped all of it silently.
+
+    Which matters more now, because setting a custom domain asks an
+    administrator to restart Caddy, and the obvious way to do that is to
+    restart everything.
+    """
+    redis = _service(compose, "redis")
+    assert "redis_data:/data" in redis, "the queue does not survive a restart"
+    assert "--appendonly yes" in redis, "the volume is mounted but nothing is written to it"
+
+
+def test_the_queue_is_never_evicted_to_free_memory(compose):
+    """`allkeys-lru` lets Redis drop *any* key under memory pressure, queue
+    entries included, with nothing raised and nothing logged. A busy morning
+    could lose a resident's confirmation email and no part of the system would
+    know it had happened.
+
+    `noeviction` makes a full Redis refuse the write instead. The application
+    already copes: cache writes are wrapped, and enqueue() logs and lets the
+    record stand. A logged failure beats a silent loss.
+    """
+    redis = _service(compose, "redis")
+    # The directive, not the word. The first version of this assertion matched
+    # the comment above the setting that explains why allkeys-lru is wrong --
+    # so it failed on correct configuration. Prose about a behaviour is not the
+    # behaviour, and this is the third time in this codebase.
+    assert "--maxmemory-policy allkeys-lru" not in redis, "the broker can evict queued tasks again"
+    assert "--maxmemory-policy noeviction" in redis
+
+
+def test_uploaded_photos_survive_a_restart(compose):
+    """A resident's photo is evidence. It cannot live in a container layer."""
+    assert "uploads_data:" in compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,32 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: redis-server --maxmemory 200mb --maxmemory-policy allkeys-lru
+    # Redis holds two very different things here, and the old configuration
+    # treated them the same.
+    #
+    # The caches (public request lists, advanced statistics) are disposable --
+    # losing one costs a slow page. The Celery queue is not: it holds every
+    # confirmation email, AI triage and govtech push that has been accepted but
+    # not yet run.
+    #
+    # `allkeys-lru` lets Redis evict *any* key under memory pressure, queue
+    # entries included, with nothing raised and nothing logged. A busy morning
+    # could drop a resident's confirmation email and no part of the system
+    # would know. `noeviction` makes a full Redis refuse writes instead, which
+    # the application already handles: cache writes are wrapped, and enqueue()
+    # logs the failure and lets the record stand. Loud beats silent.
+    #
+    # And with no volume, everything vanished on restart -- including the
+    # restart the domain setup now asks an administrator to perform. AOF with a
+    # one-second fsync bounds that to the last second of accepted work.
+    command: >
+      redis-server
+      --maxmemory 200mb
+      --maxmemory-policy noeviction
+      --appendonly yes
+      --appendfsync everysec
+    volumes:
+      - redis_data:/data
     ports:
       # Bind to loopback only — Redis has no auth and must not be internet-reachable.
       - "127.0.0.1:${REDIS_PORT:-6379}:6379"
@@ -230,6 +255,9 @@ services:
 
 volumes:
   postgres_data:
+  # The Celery queue. Without this, a restart drops every accepted-but-not-yet-run
+  # email, AI analysis and integration push.
+  redis_data:
   migration_backups:
   caddy_data:
   caddy_config:

--- a/frontend/src/components/AuditLogViewer.tsx
+++ b/frontend/src/components/AuditLogViewer.tsx
@@ -177,6 +177,29 @@ export default function AuditLogViewer() {
         return labels[eventType] || eventType.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
     };
 
+    /** What actually happened, in the row where "-" used to be.
+     *
+     * Every recorded change carried a description and the column showed none
+     * of it: the cell rendered `failure_reason` and, for anything that
+     * succeeded, a dash. So a page of successful admin changes read as a page
+     * of blanks -- the log looked broken, and the one entry somebody needed
+     * was indistinguishable from the twenty around it.
+     *
+     * Only known keys are read. This is server-supplied JSON rendered into the
+     * console, and dumping the whole object would put whatever a handler
+     * happened to stash -- a filename, a setting's old value -- on screen and
+     * into the CSV export. */
+    const describeDetails = (details: unknown): string => {
+        if (!details || typeof details !== 'object') return '';
+        const d = details as Record<string, unknown>;
+        if (typeof d.action === 'string' && d.action) return d.action;
+        if (typeof d.reason === 'string' && d.reason) return d.reason;
+        if (typeof d.method === 'string' && typeof d.path === 'string') {
+            return `${d.method} ${d.path}`;
+        }
+        return '';
+    };
+
     const formatTimestamp = (timestamp: string) => {
         return new Date(timestamp).toLocaleString('en-US', {
             month: 'short',
@@ -356,6 +379,8 @@ export default function AuditLogViewer() {
                                                 <td className="px-6 py-4 text-sm">
                                                     {log.failure_reason ? (
                                                         <span className="text-red-400">{log.failure_reason}</span>
+                                                    ) : describeDetails(log.details) ? (
+                                                        <span className="text-white/70">{describeDetails(log.details)}</span>
                                                     ) : (
                                                         <span className="text-white/30">-</span>
                                                     )}

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -144,19 +144,6 @@ export default function OperationsPanel() {
             .map(([name]) => name)
         : [];
 
-    /* Counted from what this deployment actually runs.
-     *
-     * The old version counted a fixed six -- Auth0, GCP auth, Vertex, KMS,
-     * secret store, database -- so an Azure town read "2/6 Configured" while
-     * being fully set up on services this tile had never heard of. The
-     * denominator was a guess about somebody else's architecture. */
-    const integrationCounts = connectorRollup
-        ? {
-            healthy: connectorRollup.working,
-            total: connectorRollup.working + connectorRollup.failing + connectorRollup.unchecked,
-        }
-        : { healthy: 0, total: 0 };
-
     if (error) {
         return (
             <Card className="bg-red-500/10 border-red-500/20">
@@ -210,18 +197,17 @@ export default function OperationsPanel() {
                         </div>
                     </Card>
 
-                    {/* Integrations Status */}
-                    <Card className={`${integrationCounts.healthy === integrationCounts.total ? 'bg-green-500/10 border-green-500/30' : 'bg-yellow-500/10 border-yellow-500/30'}`}>
-                        <div className="flex items-center gap-3">
-                            <Cloud className="w-8 h-8 text-purple-400" />
-                            <div>
-                                <p className="text-gray-300 text-xs uppercase tracking-wide">Integrations</p>
-                                <p className="text-white font-semibold">
-                                    {integrationCounts.healthy}/{integrationCounts.total} Configured
-                                </p>
-                            </div>
-                        </div>
-                    </Card>
+                    {/* The "Integrations — 0/0 Configured" tile that was here has
+                        gone. On a town with nothing connected it read "0/0
+                        Configured" in a green card, which is simultaneously
+                        alarming and meaningless: zero of zero is not a state
+                        anybody needs a tile for, and green said everything was
+                        fine about something that did not exist.
+
+                        The roll-up further down this page already lists the
+                        service providers a town actually uses, by name, with
+                        what the last check found. That answers the question
+                        this tile was gesturing at. */}
 
                     {/* Database Status */}
                     <Card className={`${health.database.status === 'healthy' ? 'bg-green-500/10 border-green-500/30' : 'bg-red-500/10 border-red-500/30'}`}>

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -192,6 +192,29 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
     const [values, setValues] = useState<Record<string, string>>({});
     const [busy, setBusy] = useState<'save' | 'test' | null>(null);
     const [result, setResult] = useState<{ ok: boolean; detail: string } | null>(null);
+
+    /* What to show in the result box: this session's test, or the last one
+     * recorded, whichever is fresher.
+     *
+     * `record_success` has stored the message since #436, and nothing read it
+     * back -- so pressing Test showed "Twilio credentials accepted. Nothing was
+     * sent." and a reload showed an empty card, which reads as the test having
+     * been forgotten rather than as the box not being rehydrated.
+     *
+     * Taken from the health row this card already receives rather than added
+     * to the catalog endpoint as well. The same fact served by two endpoints is
+     * two things that can disagree, and the badge beside this box already reads
+     * the health row -- a second copy could put a green message under a red
+     * badge.
+     */
+    const shownResult = result ?? (health?.last_result
+        ? {
+            // `verifiable === false` is "we tried and cannot check this from
+            // here", which is not a pass and must not render as one.
+            ok: health.verifiable !== false && health.status === 'working',
+            detail: health.last_result,
+        }
+        : null);
     const [error, setError] = useState<string | null>(null);
     // Live model discovery (AI only)
     // Copy targets inside steps: a callback URL retyped by hand is the single
@@ -699,15 +722,15 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                     ))}
                 </div>
             )}
-            {!compact && result && (
+            {!compact && shownResult && (
                 <motion.div
                     initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }}
-                    className={`mt-3 rounded-xl px-3 py-2.5 text-xs border flex items-start gap-2 ${result.ok
+                    className={`mt-3 rounded-xl px-3 py-2.5 text-xs border flex items-start gap-2 ${shownResult.ok
                         ? 'bg-emerald-500/10 border-emerald-400/30 text-emerald-200'
                         : 'bg-amber-500/10 border-amber-400/30 text-amber-200'}`}
                 >
-                    {result.ok ? <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" /> : <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />}
-                    <span>{result.detail}</span>
+                    {shownResult.ok ? <CheckCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" /> : <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />}
+                    <span>{shownResult.detail}</span>
                 </motion.div>
             )}
 

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -1073,15 +1073,30 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
      * "not used yet", which is honest: if we cannot read the health table, we
      * do not know. */
     const [health, setHealth] = useState<Record<string, ConnectorHealth>>({});
+    /* Whether the health table could be read at all.
+     *
+     * The catch used to set an empty map, which renders as "not checked yet"
+     * on every card -- indistinguishable from a town that genuinely has not
+     * run a check, and silent about the fact that the request failed. */
+    const [healthUnavailable, setHealthUnavailable] = useState(false);
     const loadHealth = useCallback(async () => {
         try {
             const report = await api.getConnectorHealth();
             setHealth(Object.fromEntries(report.connectors.map(c => [c.connector, c])));
+            setHealthUnavailable(false);
         } catch {
             setHealth({});
+            setHealthUnavailable(true);
         }
     }, []);
     useEffect(() => { loadHealth(); }, [loadHealth, recheckToken, refreshToken]);
+
+    /* Testing one card records a result the other cards' badges read from, so
+     * the stored view is stale the moment any test finishes. Previously only
+     * "Recheck all" refetched, which is why a single test looked like it had
+     * not persisted: the badge was still rendering the health row from page
+     * load. */
+    const refreshAfterTest = useCallback(() => { loadHealth(); onChanged?.(); }, [loadHealth, onChanged]);
 
     const [reloadToken, setReloadToken] = useState(0);
     /* A save in the guide above changes exactly what these cards read, so pull
@@ -1149,6 +1164,16 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
      * cards be open at once. */
     const [openCap, setOpenCap] = useState<string | null>(null);
     const capState = (cap: Capability) => capabilityState(statuses[cap], health[cap]);
+
+    /* Rendered above the cards. A town whose health table cannot be read
+     * should be told that, rather than shown ten badges that all say "not
+     * checked yet" and mean "we could not ask". */
+    const healthNotice = healthUnavailable ? (
+        <div role="alert" className="mb-4 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-200">
+            The status of these services could not be read, so the badges below
+            show what was last known rather than what is true now.
+        </div>
+    ) : null;
     /* Only what is wrong gets the whole width.
      *
      * "Not set up" is deliberately not in this list, though the first version
@@ -1185,6 +1210,7 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
                 </button>
             }
         >
+            {healthNotice}
             {loaded.length > 0 && (
                 <div className="text-[11px] text-white/55 flex flex-wrap items-center gap-x-3 gap-y-0.5 mb-4">
                     <span>{configuredCount === loaded.length
@@ -1229,7 +1255,7 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
                         <div key={c.key} className={wide ? 'sm:col-span-2 lg:col-span-3' : ''}>
                             <CapabilityCard cap={c.key} title={c.title} blurb={c.blurb} icon={c.icon} delay={0}
                                 recheckToken={recheckToken} reloadToken={reloadToken} onStatus={onStatus}
-                                health={health[c.key]} identity={identity} onChanged={onChanged}
+                                health={health[c.key]} identity={identity} onChanged={refreshAfterTest}
                                 publicOrigin={publicOrigin}
                                 variant={spotlit.includes(c) ? 'spotlight' : 'bubble'}
                                 state={capState(c.key)}

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -452,6 +452,27 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             setWarnings(saved.warnings || []);
             setValues({});
             await load();
+
+            // Selecting a provider saves; it does not configure one. With no
+            // credentials entered the settings payload is empty, which the
+            // backend reads as "keep what is stored" -- so the save succeeds,
+            // answers ok:true, and the card used to say "Set up" about a
+            // service with no account SID in it.
+            //
+            // Said here rather than left to the test below, because the test's
+            // own message ("Account SID or auth token is missing") reads as a
+            // connection failure rather than as "you have not finished".
+            if (saved.configured === false) {
+                setResult({
+                    ok: false,
+                    detail: saved.missing?.length
+                        ? `Saved your choice of provider. Still needed before this can work: ${saved.missing.join(', ')}.`
+                        : 'Saved your choice of provider. Its credentials still need to be entered.',
+                });
+                onStatus(cap, { configured: false, verifiable: undefined, verified: null });
+                return;
+            }
+
             // Immediately verify
             const t = await api.testProvider(cap);
             setResult(t);

--- a/frontend/src/maps/markerIcons.test.ts
+++ b/frontend/src/maps/markerIcons.test.ts
@@ -105,8 +105,17 @@ describe('the drawn asset icon', () => {
         const icon = assetIcon('#3b82f6');
         if (icon.type !== 'image') throw new Error('expected an image icon');
         const svg = decodeURIComponent(icon.url.split(',')[1]);
-        // Four points, closed: the rotated square.
-        expect(svg).toMatch(/<path d="M11 2\.5 L19\.5 11 L11 19\.5 L2\.5 11 Z"/);
+        // Four points, closed. Matched on the shape rather than exact
+        // coordinates so the icon can be refined without rewriting the test --
+        // what matters is that it is a diamond and not a circle.
+        const diamond = svg.match(/d="M([\d.]+) ([\d.]+) L([\d.]+) ([\d.]+) L([\d.]+) ([\d.]+) L([\d.]+) ([\d.]+) Z"/);
+        expect(diamond).toBeTruthy();
+        const [x1, y1, , y2, x3, y3, , y4] = diamond!.slice(1).map(Number);
+        // Top and bottom share an x; left and right share a y. That is a
+        // diamond, at any size.
+        expect(x1).toBeCloseTo(x3, 1);
+        expect(y2).toBeCloseTo(y4, 1);
+        expect(y1).toBeLessThan(y3);
         expect(svg).toContain('#3b82f6');
     });
 

--- a/frontend/src/maps/markerIcons.ts
+++ b/frontend/src/maps/markerIcons.ts
@@ -79,14 +79,37 @@ export function requestIcon(color: string): MarkerIcon {
 export function assetIcon(fillColor: string, strokeColor?: string): MarkerIcon {
     const fill = safeColor(fillColor);
     const stroke = safeColor(strokeColor, STROKE);
-    const size = 22;   // rendered box; the diamond is inset so the stroke fits
+    const size = 20;
+    // Stable per colour, because two <defs> with the same id on one page make
+    // every marker use whichever loaded last.
+    const uid = `a${fill.replace(/[^0-9a-f]/gi, '')}`;
 
     const svg = [
-        `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">`,
-        // Drop shadow, so an asset stays visible on a satellite basemap.
-        `<path d="M11 2.5 L19.5 11 L11 19.5 L2.5 11 Z" fill="rgba(0,0,0,0.35)" transform="translate(0,1)"/>`,
-        `<path d="M11 2.5 L19.5 11 L11 19.5 L2.5 11 Z" fill="${fill}" stroke="${stroke}" stroke-width="2.5" stroke-linejoin="round"/>`,
-        `<circle cx="11" cy="11" r="3" fill="${STROKE}" fill-opacity="0.9"/>`,
+        `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 20 20">`,
+        `<defs>`,
+        // Light from above, the way every other surface in this product is lit.
+        // A flat fill at this size reads as a sticker dropped on the map.
+        `<linearGradient id="${uid}g" x1="0" y1="0" x2="0" y2="1">`,
+        `<stop offset="0" stop-color="#ffffff" stop-opacity="0.32"/>`,
+        `<stop offset="0.55" stop-color="#ffffff" stop-opacity="0"/>`,
+        `</linearGradient>`,
+        // A soft contact shadow rather than a hard offset copy. The offset
+        // version doubled the shape's visual weight and made a dense layer
+        // look like blocks of colour.
+        `<filter id="${uid}s" x="-50%" y="-50%" width="200%" height="200%">`,
+        `<feDropShadow dx="0" dy="0.5" stdDeviation="0.9" flood-color="#0b1020" flood-opacity="0.45"/>`,
+        `</filter>`,
+        `</defs>`,
+        `<g filter="url(#${uid}s)">`,
+        // Rounded diamond. The corner radius is what stops it reading as a
+        // rotated square, which is what the 22px hard-cornered version did.
+        `<path d="M10 2.6 L17.4 10 L10 17.4 L2.6 10 Z" fill="${fill}" stroke="${stroke}" stroke-width="1.6" stroke-linejoin="round"/>`,
+        `<path d="M10 2.6 L17.4 10 L10 17.4 L2.6 10 Z" fill="url(#${uid}g)" stroke="none"/>`,
+        // A thin inner keyline instead of the white hole punched through the
+        // middle. It still reads as "a marked point" at a glance and stops the
+        // shape looking like a cheap sticker up close.
+        `<path d="M10 6.1 L13.9 10 L10 13.9 L6.1 10 Z" fill="none" stroke="${STROKE}" stroke-opacity="0.55" stroke-width="1" stroke-linejoin="round"/>`,
+        `</g>`,
         `</svg>`,
     ].join('');
 

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -3236,24 +3236,34 @@ export default function AdminConsole() {
                                                 The record stays and still counts in your statistics. Only the
                                                 fields ticked here are emptied.
                                             </p>
-                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                            {/* auto-rows-fr plus h-full: every card in a row is
+                                                the height of the tallest, so a two-line
+                                                description does not leave the card beside it
+                                                floating in a short box. */}
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 auto-rows-fr">
                                                 {scrubFields.map(field => (
                                                     <label
                                                         key={field.id}
-                                                        className={`flex items-start gap-3 rounded-xl border p-3 cursor-pointer transition-colors ${field.selected
+                                                        className={`group flex h-full items-start gap-3 rounded-xl border p-3.5 cursor-pointer transition-colors ${field.selected
                                                             ? 'bg-amber-500/10 border-amber-400/30'
                                                             : 'bg-white/[0.02] border-white/10 hover:border-white/20'}`}
                                                     >
+                                                        {/* Pinned to the title's cap height rather
+                                                            than centred on the text block. Centring
+                                                            put the box beside the title on a
+                                                            one-line card and beside the description
+                                                            on a two-line one, so no two rows lined
+                                                            up and the grid read as ragged. */}
                                                         <input
                                                             type="checkbox"
                                                             checked={field.selected}
                                                             onChange={(e) => setScrubFields(prev => (prev || []).map(f =>
                                                                 f.id === field.id ? { ...f, selected: e.target.checked } : f))}
-                                                            className="mt-0.5 accent-amber-400"
+                                                            className="mt-[3px] w-4 h-4 shrink-0 self-start accent-amber-400"
                                                         />
-                                                        <span className="min-w-0">
-                                                            <span className="block text-sm font-medium text-white/90">{field.label}</span>
-                                                            <span className="block text-xs text-white/55 mt-0.5 leading-relaxed">{field.detail}</span>
+                                                        <span className="min-w-0 flex-1">
+                                                            <span className="block text-sm font-medium text-white/90 leading-5">{field.label}</span>
+                                                            <span className="block text-xs text-white/60 mt-1 leading-relaxed">{field.detail}</span>
                                                         </span>
                                                     </label>
                                                 ))}

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -950,6 +950,28 @@ export default function AdminConsole() {
     }>>([]);
     const [isLoadingLegalHold, setIsLoadingLegalHold] = useState(false);
 
+    // "Eligible for Archival" is a number nobody can check. A count of records
+    // about to be redacted or purged is only trustworthy if you can see which
+    // records, the same way the legal-hold count opens the list it counts.
+    const [showEligibleModal, setShowEligibleModal] = useState(false);
+    const [eligiblePreview, setEligiblePreview] = useState<import('../services/api').RetentionPreview | null>(null);
+    const [eligibleError, setEligibleError] = useState<string | null>(null);
+    const [isLoadingEligible, setIsLoadingEligible] = useState(false);
+
+    const openEligibleRecords = async () => {
+        setIsLoadingEligible(true);
+        setEligibleError(null);
+        setShowEligibleModal(true);
+        try {
+            setEligiblePreview(await api.previewRetentionRun(200));
+        } catch (err) {
+            setEligiblePreview(null);
+            setEligibleError(err instanceof Error ? err.message : 'Could not load the eligible records.');
+        } finally {
+            setIsLoadingEligible(false);
+        }
+    };
+
     // Backup management state
     const [backupStatus, setBackupStatus] = useState<{
         configured: boolean;
@@ -2906,10 +2928,14 @@ export default function AdminConsole() {
 
                                         {/* Archival Stats */}
                                         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                            <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4">
+                                            <button
+                                                onClick={openEligibleRecords}
+                                                className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 text-left hover:bg-blue-500/20 hover:border-blue-500/50 transition-all cursor-pointer"
+                                            >
                                                 <div className="text-blue-300 text-sm">Eligible for Archival</div>
                                                 <div className="text-2xl font-bold text-blue-300">{retentionPolicy.stats.eligible_for_archival}</div>
-                                            </div>
+                                                <div className="text-blue-200 text-xs mt-1">Click to view →</div>
+                                            </button>
                                             <button
                                                 onClick={async () => {
                                                     setIsLoadingLegalHold(true);
@@ -2940,163 +2966,6 @@ export default function AdminConsole() {
                                     </AccordionSection>
                                 )}
 
-                                {/* Database Backups */}
-                                <AccordionSection
-                                    title="Database Backups"
-                                    subtitle="Encrypted S3-compatible backup management"
-                                    icon={Upload}
-                                    iconClassName="text-blue-400"
-                                >
-                                    {backupStatus === null ? (
-                                        <div className="text-center py-4">
-                                            <Button
-                                                variant="ghost"
-                                                onClick={async () => {
-                                                    setIsLoadingBackups(true);
-                                                    try {
-                                                        const [status, list] = await Promise.all([
-                                                            api.getBackupStatus(),
-                                                            api.listBackups()
-                                                        ]);
-                                                        setBackupStatus(status);
-                                                        setBackups(list.backups || []);
-                                                    } catch (err) {
-                                                        console.error('Failed to load backups:', err);
-                                                    } finally {
-                                                        setIsLoadingBackups(false);
-                                                    }
-                                                }}
-                                                disabled={isLoadingBackups}
-                                            >
-                                                <RefreshCw className={`w-4 h-4 mr-2 ${isLoadingBackups ? 'animate-spin' : ''}`} />
-                                                {isLoadingBackups ? 'Loading...' : 'Load Backup Status'}
-                                            </Button>
-                                        </div>
-                                    ) : !backupStatus.configured ? (
-                                        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
-                                            <p className="text-amber-400 mb-3">
-                                                {backupStatus.message || 'Backup not configured'}
-                                            </p>
-                                            {backupStatus.required_secrets && (
-                                                <div className="text-white/60 text-sm">
-                                                    <p className="mb-2">Add these secrets in the Secrets tab:</p>
-                                                    <ul className="list-disc list-inside space-y-1">
-                                                        {backupStatus.required_secrets.map(s => (
-                                                            <li key={s} className="font-mono text-xs">{s}</li>
-                                                        ))}
-                                                    </ul>
-                                                </div>
-                                            )}
-                                        </div>
-                                    ) : (
-                                        <div className="space-y-4">
-                                            {/* Status Summary */}
-                                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                                                <div className="bg-white/5 rounded-lg p-3">
-                                                    <div className="text-white/50 text-xs">Storage</div>
-                                                    <div className="text-white font-medium truncate">{backupStatus.bucket}</div>
-                                                </div>
-                                                <div className="bg-white/5 rounded-lg p-3">
-                                                    <div className="text-white/50 text-xs">Total Backups</div>
-                                                    <div className="text-white font-bold text-lg">{backupStatus.total_backups || 0}</div>
-                                                </div>
-                                                <div className="bg-white/5 rounded-lg p-3">
-                                                    <div className="text-white/50 text-xs">Last Backup</div>
-                                                    <div className="text-white font-medium">
-                                                        {backupStatus.last_backup
-                                                            ? `${backupStatus.last_backup.age_days}d ago`
-                                                            : 'Never'}
-                                                    </div>
-                                                </div>
-                                                <div className="bg-white/5 rounded-lg p-3">
-                                                    <div className="text-white/50 text-xs">Schedule</div>
-                                                    <div className="text-white font-medium text-sm">{backupStatus.next_scheduled || 'Daily'}</div>
-                                                </div>
-                                            </div>
-
-                                            {/* Actions */}
-                                            <div className="flex gap-3">
-                                                <Button
-                                                    onClick={async () => {
-                                                        if (!confirm('Create a new database backup now?')) return;
-                                                        setIsCreatingBackup(true);
-                                                        try {
-                                                            const result = await api.createBackup();
-                                                            if (result.status === 'success') {
-                                                                alert(`Backup created: ${result.backup_name}`);
-                                                                // Refresh list
-                                                                const list = await api.listBackups();
-                                                                setBackups(list.backups || []);
-                                                                const status = await api.getBackupStatus();
-                                                                setBackupStatus(status);
-                                                            }
-                                                        } catch (err) {
-                                                            alert('Backup failed: ' + (err as Error).message);
-                                                        } finally {
-                                                            setIsCreatingBackup(false);
-                                                        }
-                                                    }}
-                                                    disabled={isCreatingBackup}
-                                                    className="bg-blue-600 hover:bg-blue-700"
-                                                >
-                                                    {isCreatingBackup ? (
-                                                        <>
-                                                            <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                                                            Creating...
-                                                        </>
-                                                    ) : (
-                                                        <>
-                                                            <Upload className="w-4 h-4 mr-2" />
-                                                            Create Backup Now
-                                                        </>
-                                                    )}
-                                                </Button>
-                                                <Button
-                                                    variant="ghost"
-                                                    onClick={async () => {
-                                                        setIsLoadingBackups(true);
-                                                        try {
-                                                            const list = await api.listBackups();
-                                                            setBackups(list.backups || []);
-                                                        } catch (err) {
-                                                            console.error(err);
-                                                        } finally {
-                                                            setIsLoadingBackups(false);
-                                                        }
-                                                    }}
-                                                >
-                                                    <RefreshCw className={`w-4 h-4 mr-2 ${isLoadingBackups ? 'animate-spin' : ''}`} />
-                                                    Refresh
-                                                </Button>
-                                            </div>
-
-                                            {/* Backup List */}
-                                            {backups.length > 0 && (
-                                                <div className="mt-4">
-                                                    <h4 className="text-white/70 text-sm font-medium mb-2">Recent Backups</h4>
-                                                    <div className="space-y-2 max-h-48 overflow-y-auto">
-                                                        {backups.slice(0, 10).map((backup) => (
-                                                            <div key={backup.name} className="flex items-center justify-between bg-white/5 rounded-lg p-3">
-                                                                <div>
-                                                                    <div className="text-white font-mono text-sm">{backup.name}</div>
-                                                                    <div className="text-white/50 text-xs">
-                                                                        {new Date(backup.created_at).toLocaleString()} · {(backup.size_bytes / 1024 / 1024).toFixed(2)} MB
-                                                                    </div>
-                                                                </div>
-                                                                <span className={`text-xs px-2 py-1 rounded ${backup.age_days === 0 ? 'bg-green-500/20 text-green-400' :
-                                                                    backup.age_days < 7 ? 'bg-blue-500/20 text-blue-400' :
-                                                                        'bg-white/10 text-white/60'
-                                                                    }`}>
-                                                                    {backup.age_days === 0 ? 'Today' : `${backup.age_days}d ago`}
-                                                                </span>
-                                                            </div>
-                                                        ))}
-                                                    </div>
-                                                </div>
-                                            )}
-                                        </div>
-                                    )}
-                                </AccordionSection>
 
                                 {/* Soft-Deleted Requests */}
                                 {deletedRequests.length > 0 && (
@@ -3719,6 +3588,164 @@ export default function AdminConsole() {
                                         </table>
                                     </div>
                                 </AccordionSection>
+
+                                {/* Database Backups */}
+                                <AccordionSection
+                                    title="Database Backups"
+                                    subtitle="Encrypted S3-compatible backup management"
+                                    icon={Upload}
+                                    iconClassName="text-blue-400"
+                                >
+                                    {backupStatus === null ? (
+                                        <div className="text-center py-4">
+                                            <Button
+                                                variant="ghost"
+                                                onClick={async () => {
+                                                    setIsLoadingBackups(true);
+                                                    try {
+                                                        const [status, list] = await Promise.all([
+                                                            api.getBackupStatus(),
+                                                            api.listBackups()
+                                                        ]);
+                                                        setBackupStatus(status);
+                                                        setBackups(list.backups || []);
+                                                    } catch (err) {
+                                                        console.error('Failed to load backups:', err);
+                                                    } finally {
+                                                        setIsLoadingBackups(false);
+                                                    }
+                                                }}
+                                                disabled={isLoadingBackups}
+                                            >
+                                                <RefreshCw className={`w-4 h-4 mr-2 ${isLoadingBackups ? 'animate-spin' : ''}`} />
+                                                {isLoadingBackups ? 'Loading...' : 'Load Backup Status'}
+                                            </Button>
+                                        </div>
+                                    ) : !backupStatus.configured ? (
+                                        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+                                            <p className="text-amber-400 mb-3">
+                                                {backupStatus.message || 'Backup not configured'}
+                                            </p>
+                                            {backupStatus.required_secrets && (
+                                                <div className="text-white/60 text-sm">
+                                                    <p className="mb-2">Add these secrets in the Secrets tab:</p>
+                                                    <ul className="list-disc list-inside space-y-1">
+                                                        {backupStatus.required_secrets.map(s => (
+                                                            <li key={s} className="font-mono text-xs">{s}</li>
+                                                        ))}
+                                                    </ul>
+                                                </div>
+                                            )}
+                                        </div>
+                                    ) : (
+                                        <div className="space-y-4">
+                                            {/* Status Summary */}
+                                            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                                                <div className="bg-white/5 rounded-lg p-3">
+                                                    <div className="text-white/50 text-xs">Storage</div>
+                                                    <div className="text-white font-medium truncate">{backupStatus.bucket}</div>
+                                                </div>
+                                                <div className="bg-white/5 rounded-lg p-3">
+                                                    <div className="text-white/50 text-xs">Total Backups</div>
+                                                    <div className="text-white font-bold text-lg">{backupStatus.total_backups || 0}</div>
+                                                </div>
+                                                <div className="bg-white/5 rounded-lg p-3">
+                                                    <div className="text-white/50 text-xs">Last Backup</div>
+                                                    <div className="text-white font-medium">
+                                                        {backupStatus.last_backup
+                                                            ? `${backupStatus.last_backup.age_days}d ago`
+                                                            : 'Never'}
+                                                    </div>
+                                                </div>
+                                                <div className="bg-white/5 rounded-lg p-3">
+                                                    <div className="text-white/50 text-xs">Schedule</div>
+                                                    <div className="text-white font-medium text-sm">{backupStatus.next_scheduled || 'Daily'}</div>
+                                                </div>
+                                            </div>
+
+                                            {/* Actions */}
+                                            <div className="flex gap-3">
+                                                <Button
+                                                    onClick={async () => {
+                                                        if (!confirm('Create a new database backup now?')) return;
+                                                        setIsCreatingBackup(true);
+                                                        try {
+                                                            const result = await api.createBackup();
+                                                            if (result.status === 'success') {
+                                                                alert(`Backup created: ${result.backup_name}`);
+                                                                // Refresh list
+                                                                const list = await api.listBackups();
+                                                                setBackups(list.backups || []);
+                                                                const status = await api.getBackupStatus();
+                                                                setBackupStatus(status);
+                                                            }
+                                                        } catch (err) {
+                                                            alert('Backup failed: ' + (err as Error).message);
+                                                        } finally {
+                                                            setIsCreatingBackup(false);
+                                                        }
+                                                    }}
+                                                    disabled={isCreatingBackup}
+                                                    className="bg-blue-600 hover:bg-blue-700"
+                                                >
+                                                    {isCreatingBackup ? (
+                                                        <>
+                                                            <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                                                            Creating...
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <Upload className="w-4 h-4 mr-2" />
+                                                            Create Backup Now
+                                                        </>
+                                                    )}
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    onClick={async () => {
+                                                        setIsLoadingBackups(true);
+                                                        try {
+                                                            const list = await api.listBackups();
+                                                            setBackups(list.backups || []);
+                                                        } catch (err) {
+                                                            console.error(err);
+                                                        } finally {
+                                                            setIsLoadingBackups(false);
+                                                        }
+                                                    }}
+                                                >
+                                                    <RefreshCw className={`w-4 h-4 mr-2 ${isLoadingBackups ? 'animate-spin' : ''}`} />
+                                                    Refresh
+                                                </Button>
+                                            </div>
+
+                                            {/* Backup List */}
+                                            {backups.length > 0 && (
+                                                <div className="mt-4">
+                                                    <h4 className="text-white/70 text-sm font-medium mb-2">Recent Backups</h4>
+                                                    <div className="space-y-2 max-h-48 overflow-y-auto">
+                                                        {backups.slice(0, 10).map((backup) => (
+                                                            <div key={backup.name} className="flex items-center justify-between bg-white/5 rounded-lg p-3">
+                                                                <div>
+                                                                    <div className="text-white font-mono text-sm">{backup.name}</div>
+                                                                    <div className="text-white/50 text-xs">
+                                                                        {new Date(backup.created_at).toLocaleString()} · {(backup.size_bytes / 1024 / 1024).toFixed(2)} MB
+                                                                    </div>
+                                                                </div>
+                                                                <span className={`text-xs px-2 py-1 rounded ${backup.age_days === 0 ? 'bg-green-500/20 text-green-400' :
+                                                                    backup.age_days < 7 ? 'bg-blue-500/20 text-blue-400' :
+                                                                        'bg-white/10 text-white/60'
+                                                                    }`}>
+                                                                    {backup.age_days === 0 ? 'Today' : `${backup.age_days}d ago`}
+                                                                </span>
+                                                            </div>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </AccordionSection>
                             </div>
                         )}
 
@@ -3946,6 +3973,88 @@ export default function AdminConsole() {
                         <Button type="submit">Create User</Button>
                     </div>
                 </form>
+            </Modal>
+
+            {/* Records eligible for archival */}
+            <Modal
+                isOpen={showEligibleModal}
+                onClose={() => setShowEligibleModal(false)}
+                title="Records Eligible for Archival"
+            >
+                <div className="space-y-4">
+                    {isLoadingEligible ? (
+                        <div className="text-center py-8 text-white/60">Loading...</div>
+                    ) : eligibleError ? (
+                        <div role="alert" className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+                            {eligibleError}
+                        </div>
+                    ) : eligiblePreview?.blocked === 'legal_hold' ? (
+                        <p className="text-sm text-amber-200">
+                            The instance-wide legal hold is on, so nothing can be archived until it is lifted.
+                        </p>
+                    ) : !eligiblePreview?.summary || eligiblePreview.summary.total === 0 ? (
+                        <div className="text-center py-8 text-white/60">
+                            Nothing has passed the retention period yet.
+                        </div>
+                    ) : (
+                        <>
+                            <p className="text-white/60 text-sm">
+                                These closed records have passed the{' '}
+                                {eligiblePreview.summary.retention_days.toLocaleString()}-day retention period.
+                                A retention run would {eligiblePreview.mode === 'purge' ? 'clear every field on' : 'redact'} them.
+                            </p>
+                            {/* Fifty of four thousand, presented as the whole
+                                answer, is the undercount this list exists to
+                                prevent. */}
+                            {eligiblePreview.summary.truncated && (
+                                <p className="text-xs text-amber-200/90">
+                                    Showing the {eligiblePreview.summary.showing} oldest of{' '}
+                                    {eligiblePreview.summary.total.toLocaleString()}. A run works through all of them.
+                                </p>
+                            )}
+                            <div className="space-y-3 max-h-[60vh] overflow-y-auto">
+                                {eligiblePreview.records.map((r) => (
+                                    <button
+                                        key={r.service_request_id}
+                                        onClick={() => {
+                                            setShowEligibleModal(false);
+                                            navigate(`/staff#resolved/request/${r.service_request_id}`);
+                                        }}
+                                        className="w-full text-left bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 hover:bg-blue-500/20 transition-colors"
+                                    >
+                                        <div className="flex justify-between items-start mb-2">
+                                            <span className="font-mono text-blue-300 font-semibold">
+                                                {r.service_request_id}
+                                            </span>
+                                            {r.days_past_retention != null && (
+                                                <span className="text-xs px-2 py-1 rounded bg-amber-500/20 text-amber-300">
+                                                    {r.days_past_retention.toLocaleString()} days past due
+                                                </span>
+                                            )}
+                                        </div>
+                                        <div className="text-white font-medium">{r.service_name}</div>
+                                        {r.address && (
+                                            <div className="text-white/50 text-xs mt-2 flex items-center gap-1">
+                                                <MapPin className="w-3 h-3" />
+                                                {r.address}
+                                            </div>
+                                        )}
+                                        <div className="text-white/40 text-xs mt-2">
+                                            Closed:{' '}
+                                            {r.closed_datetime
+                                                ? new Date(r.closed_datetime).toLocaleDateString(undefined, {
+                                                    year: 'numeric', month: 'short', day: 'numeric',
+                                                    timeZone: eligiblePreview.timezone || undefined,
+                                                })
+                                                : '—'}
+                                            {r.age_days != null && <> · {(r.age_days / 365).toFixed(1)} yrs old</>}
+                                        </div>
+                                    </button>
+                                ))}
+                            </div>
+                        </>
+                    )}
+                </div>
             </Modal>
 
             {/* Legal Hold Requests Modal */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -701,6 +701,11 @@ class ApiClient {
     async saveProvider(capability: string, data: ProviderSave): Promise<{
         ok: boolean;
         provider: string;
+        /** Whether the provider can actually be used. Saving a *selection*
+         *  succeeds with no credentials, so ok:true is not readiness. */
+        configured?: boolean;
+        /** The required fields still empty, by label, when configured is false. */
+        missing?: string[];
         /** Shape problems spotted in the pasted values. Advisory: the save has
          *  already happened by the time these arrive. */
         warnings?: { key: string; severity: 'error' | 'warn' | 'info'; message: string }[];

--- a/frontend/src/utils/googleMaps.ts
+++ b/frontend/src/utils/googleMaps.ts
@@ -37,7 +37,36 @@ export function loadGoogleMaps(apiKey: string): Promise<void> {
         }
 
         const callbackName = '__pinpointInitGoogleMaps__';
-        (window as unknown as Record<string, unknown>)[callbackName] = () => {
+        (window as unknown as Record<string, unknown>)[callbackName] = async () => {
+            // Wait for the libraries, not just the bootstrap.
+            //
+            // With `loading=async` the callback fires once the core is ready.
+            // The libraries named in `libraries=` are fetched alongside it and
+            // are not guaranteed to be on `window.google.maps` at that moment,
+            // so a component mounting immediately can find `maps.places`
+            // undefined -- and `attachAutocomplete` correctly answers "this
+            // provider has no widget", which is the right answer to the wrong
+            // question. The input then falls back to a plain text box for the
+            // rest of the page's life, because nothing retries.
+            //
+            // `importLibrary` is idempotent and resolves from cache once
+            // loaded, so awaiting it here costs nothing after the first call.
+            try {
+                const maps = window.google?.maps as unknown as {
+                    importLibrary?: (name: string) => Promise<unknown>;
+                };
+                if (typeof maps?.importLibrary === 'function') {
+                    await Promise.all([
+                        maps.importLibrary('places'),
+                        maps.importLibrary('geocoding'),
+                    ]);
+                }
+            } catch {
+                // A library that will not load is a real failure, but it is the
+                // geocoder's to report -- it already degrades to the backend
+                // provider. Resolving here keeps the *map* working, which is
+                // the larger half of what this script is for.
+            }
             resolve();
             try { delete (window as unknown as Record<string, unknown>)[callbackName]; } catch { /* ignore */ }
         };


### PR DESCRIPTION
Follow-ups from testing #440 against a live deployment. Nine commits, rebased onto the three Caddy fixes (#441–#443).

## Reported: "why is it no longer checking the container storage?"

Both resource probes measured the host and presented the answer as ours.

**Memory came from `/proc/meminfo`, which is not namespaced** — a container reads the whole server's RAM whatever its own cap is. compose limits the backend to `memory: 1G`. On a 32GB host, a backend sitting at 990MB and one allocation away from being OOM-killed in the middle of a resident's report displayed **3% used, green**. The cgroup limit is read first now (v1 and v2), and the host is the fallback only when the container genuinely runs uncapped. Page cache is subtracted, because the kernel reclaims it rather than OOM-killing — counting it has every long-running deployment at 99% by the second week, and a gauge that's always red is a gauge nobody looks at.

**Disk came from `shutil.disk_usage("/")`** — the filesystem behind the container's root. On a default Docker install that *is* the host disk, so the number was right by accident. It goes wrong the moment a town puts `uploads_data` or `migration_backups` on a second volume, which is exactly where the space goes: a photo per report, and an unencrypted `pg_dump` before every migration. Every mounted path is read now, deduplicated by device, and the fullest reported **by name** — "Photo storage is 94% full", not "Disk is 94% full" with three disks to choose from.

**CPU is reported too**, as a share of the container's quota rather than the machine's cores (one core on an eight-core host is saturated at what the host calls 12%). Deliberately **not** alerted on: one short sample can't tell a PDF being rendered from a server in trouble, and an email a day about a spike is an email nobody reads.

Memory also joins disk on the hourly system sweep, so it gets the same escalation and the same digest instead of living on a page somebody has to be looking at.

## Reported: "these aren't helpful and they are way too many"

Twenty-five consecutive rows reading `Admin Change / admin / - / 12:58 AM / -`.

The backstop middleware closed the real gap — fifty-two mutating endpoints wrote no audit record at all — and introduced a smaller one. **Three failures in one screen:**

1. **The action was never named.** Every row now carries a sentence: "Deleted a staff account", "Added or updated the records retention policy". Derived from the path *only* — the body and query string carry passwords and residents' addresses, and this table exports to CSV.
2. **The address was never recorded**, so admin rows showed `-` under sign-in rows that had one. Taken from `X-Forwarded-For`, because Caddy fronts everything and `request.client.host` is Caddy's address on the compose network — identical for every user, which is the same as having none.
3. **Connection tests, health rechecks and previews each wrote a row.** Clicking *"Check all providers"* is what the 12:58 block was, and it pushed the change that mattered onto page four. Those are reads that happen to need a body.

Both decisions live in `audit_labels`, pure and unit-tested, rather than as literals inside a middleware where they can't be argued with.

**Deleting or restoring a resident's request now reaches the admin log.** Everything else about a request belongs on that request's own timeline — but the timeline is exactly what goes with it, and "who deleted this report" is the question a records custodian is actually asked.

The console's Details column rendered `failure_reason` and, for anything successful, a dash — so descriptions had nowhere to appear even when stored. It reads known keys only; dumping the object would put whatever a handler stashed on screen and into the export.

## Reported: "the tests for service providers don't survive a hard refresh, and still say not checked yet"

The migration had been run, so the columns existed. **Four separate causes**, each of which produces that symptom on its own:

1. **Testing one card never refetched the health table.** `onChanged` went to the parent page; only *"Recheck all"* reloaded the rows.
2. **A failed check could poison the session.** Several checks run queries and swallow their own errors; any statement after that raises `PendingRollbackError` — so the write recording the outcome hit its own `except` and was lost. There's a rollback first now.
3. **When `/connectors/health` couldn't be read, the catch set an empty map** — which renders as "not checked yet" on every card, silent about the request having failed.
4. **The result box was never hydrated from `last_result`.** A stored outcome existed and the panel showed an empty box until you tested again.

## Reported: "Twilio still says set up even though it's not"

Confirmed in `save_provider`: `if value:  # blank = keep existing`. Selecting a provider with nothing typed sends `settings: {}`, nothing is written, the response is `ok: true`, and the card reported "Set up" about a service with no account SID.

**I did not add a 400 for missing required fields.** *"We've decided on Twilio, the account is still being approved"* is how towns actually proceed, and a 400 makes that decision unrecordable. It would also reject later saves whose credentials live in an external vault, where an empty payload is correct.

The bug isn't that the save succeeds. **It's that success was read as readiness.** `save_provider` returns `configured` — from `_configured_map`, the same function the badge uses, not a second opinion that can drift — plus the missing fields by label.

## Durability

**Redis had no volume, and was allowed to evict the queue.** It holds every confirmation email, AI triage and govtech push that's been accepted and not yet run; with no volume all of it vanished on restart. Worse, `--maxmemory-policy allkeys-lru` lets Redis drop *any* key under memory pressure, queue entries included, with nothing raised and nothing logged. Now `noeviction`, so a full Redis refuses the write — which the app already handles, since `enqueue()` logs and lets the record stand. **A logged failure beats a silent loss.**

**Every `SystemSettings` column is now reachable both ways**, or listed with a reason. One is neither: `translations`, declared with a documented format and written by no code path. Recorded rather than quietly left, because a column that can't be set invites someone to build a UI for it.

## Smaller

| | |
|---|---|
| **"Eligible for Archival"** | Was a number with nothing behind it, beside a legal-hold count that opens the list it counts. Now opens the same preview the run uses: which records, how old, how far past due, click through to any. A count of records about to be purged is worth something only if it can be checked. |
| **Database Backups** | Moved below All State Policies, so the policy and what's eligible under it read as one sequence. |
| **"Integrations 0/0 Configured"** | Removed. On a town with nothing connected it read `0/0` in a **green** card — alarming and meaningless at once. |
| **Asset markers** | 22px hard-cornered diamonds with a solid offset shadow read as blocks of colour at map density. Now 20px, rounded, top-lit, soft contact shadow, thin inner keyline. Gradient ids derive from the fill — two `<defs>` sharing an id make every marker use whichever loaded last. |
| **"What gets cleared" grid** | The checkbox centred on the whole text block, so it sat beside the title on one-line cards and the description on two-line ones. Pinned to the title's cap height; `auto-rows-fr` so cards match the tallest in the row. |
| **Places library** | `loading=async` fires the callback when the *core* is ready; libraries named in `libraries=` aren't guaranteed present. `importLibrary` is awaited now. **This does not explain `ApiTargetBlockedMapError`** — that's an authorization answer, not a timing one. |
| **Domain change** | Now says the Auth0/Entra callback, logout and web-origin URLs need updating. Otherwise sign-in fails on the *provider's* error page, on the *provider's* domain, an hour after a change nobody connects it to — locking staff out of the tool they'd fix it with. |
| **Health recording** | Degrades mid-migration: counters and timestamps commit even when newer columns aren't there, with a log line naming the pending migration. |

## On #441 — it fixed a real defect of mine

My reload POSTed `json=None` with **no body**, which asks Caddy to load an *empty* config. The reload I'd "fixed" could have wiped the running configuration the first time it succeeded. It never did, only because the admin endpoint was unreachable until the same change that made it reachable.

Rebasing onto it also broke one of my tests, and the test was what was wrong: it asserted the name `caddyfile_content` was absent as a proxy for "builds a Caddyfile from a template". #441 legitimately *reads* the base file into that variable. Reading is fine; overwriting isn't. The assertion says that now.

## Verification

1036 backend + 203 frontend tests, typecheck clean (the 22 pre-existing errors are unchanged), build green. Caddyfile validated against a real Caddy binary, bare and with a generated snippet. Mutations checked: reverting the disk probe to `disk_usage("/")`, ignoring the cgroup limit, returning the first volume instead of the fullest, dropping the no-op audit skip rules, removing either Redis volume, restoring the eviction policy, adding an unclassified settings column — each fails a test.

An assertion tripped over its own explanatory prose twice more here (`shutil.disk_usage` matched the docstring saying why it was removed). The audit one is matched on the parsed syntax tree now, not the text.

## Before this helps anyone

- **Seven migrations** to run on deploy.
- **`docker compose restart caddy`** once, for `admin 0.0.0.0:2019`.
- Everything above is verified by test and by reading — **not against a running system**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd