### PR TITLE
Fix the 500 behind the "status could not be read" banner

### DIFF
--- a/backend/app/services/audit_labels.py
+++ b/backend/app/services/audit_labels.py
@@ -78,6 +78,25 @@ _SUBJECTS = (
     ("/knowledge", "the knowledge base"),
 )
 
+# Which provider, not just "a provider". "Added or updated a service provider's
+# settings" is four rows in a row when somebody works through the setup guide,
+# and none of them says whether the thing that changed was who sends the town's
+# text messages or who translates its pages.
+_CAPABILITIES = {
+    "sms": "the SMS provider",
+    "email": "the email provider",
+    "ai": "the AI provider",
+    "translation": "the translation provider",
+    "identity": "the sign-in provider",
+    "maps": "the maps provider",
+    "storage": "the file storage provider",
+    "kms": "the encryption key provider",
+    "redaction": "the photo redaction provider",
+    "payments": "the payments provider",
+}
+
+_PROVIDER_SAVE = re.compile(r"^/api/system/providers/([a-z0-9_-]+)/save$")
+
 _VERBS = {
     "POST": "Added or updated",
     "PUT": "Updated",
@@ -100,6 +119,11 @@ RESTORED_A_RECORD = "Restored a deleted service request"
 _ALWAYS = (
     ("DELETE", re.compile(r"^/api/open311/v2/requests/[^/]+$"), DESTROYED_A_RECORD),
     ("POST", re.compile(r"^/api/open311/v2/requests/[^/]+/restore$"), RESTORED_A_RECORD),
+    # Silencing an integration's alerts is the action behind "why did nobody
+    # get emailed for three weeks". It is the last thing that should be
+    # filtered out of the log as routine.
+    ("POST", re.compile(r"^/api/system/connectors/[^/]+/mute$"),
+     "Changed alerting for an integration"),
 )
 
 
@@ -142,6 +166,14 @@ def describe_action(method: str, path: str) -> Optional[str]:
     named = _exception_for(method, path)
     if named:
         return named
+
+    capability = _PROVIDER_SAVE.match(path)
+    if capability:
+        which = _CAPABILITIES.get(capability.group(1))
+        # An unknown capability keeps its own name rather than being flattened
+        # into "a provider": a new one should read as itself on day one.
+        return f"Updated {which or capability.group(1) + ' provider'} settings"
+
     clean = _ID.sub("", path)
     subject = next((name for frag, name in
                     sorted(_SUBJECTS, key=lambda p: -len(p[0]))

--- a/backend/app/services/connector_health.py
+++ b/backend/app/services/connector_health.py
@@ -85,6 +85,16 @@ class Health:
     # What the last check said, either way, and whether one is even possible.
     last_result: Optional[str] = None
     verifiable: Optional[bool] = None
+    # Until when alerts for this connector are silenced.
+    #
+    # The column and the mute endpoint were added together; this field was not,
+    # and `/connectors/health` reads `h.alert_muted_until` on every row. A
+    # dataclass has no such attribute, so the endpoint raised AttributeError and
+    # returned 500 -- every time, for everyone. On screen that is the banner
+    # saying the status of these services could not be read, which reads as an
+    # outage somewhere else entirely, and it takes every provider card down with
+    # it because they hydrate from the same response.
+    alert_muted_until: Optional[datetime] = None
 
     @property
     def ok(self) -> bool:
@@ -145,6 +155,10 @@ def to_health(row: Any, *, now: Optional[datetime] = None) -> Health:
         alerted_at=getattr(row, "alerted_at", None),
         last_result=getattr(row, "last_result", None),
         verifiable=getattr(row, "verifiable", None),
+        # getattr, like every other column here, so a deployment that has not
+        # run the mute migration yet degrades to "not muted" instead of 500ing
+        # the whole health page.
+        alert_muted_until=getattr(row, "alert_muted_until", None),
     )
 
 

--- a/backend/tests/test_audit_is_readable.py
+++ b/backend/tests/test_audit_is_readable.py
@@ -74,6 +74,47 @@ def test_destroying_a_resident_record_is_recorded_in_the_admin_log():
     )
 
 
+@pytest.mark.parametrize("method,path,why", [
+    ("POST", "/api/gis/boundaries",
+     "the town boundary is the map every report is placed on, and this route "
+     "was writable without authentication until three commits ago"),
+    ("POST", "/api/gis/township-boundary", "same boundary, second route"),
+    ("POST", "/api/system/connectors/sms/mute",
+     "silencing alerts is what 'why did nobody get emailed' is about"),
+])
+def test_the_quiet_ones_are_not_quiet_because_the_skip_list_grew(method, path, why):
+    """Trimming the log is done by naming what changes nothing, not by
+    silencing a whole prefix.
+
+    `/api/gis/` and `/api/system/connectors` are both tempting prefixes -- most
+    of the traffic under them is lookups and status polling. But a lookup is a
+    GET and was never recorded, while the handful of mutations underneath are
+    among the most consequential in the product. Skipping the prefix would buy
+    nothing and lose those.
+    """
+    assert should_record(method, path) is True, why
+    assert describe_action(method, path)
+
+
+def test_a_provider_save_says_which_provider():
+    """Four rows of "Added or updated a service provider's settings" is what
+    working through the setup guide looks like, and not one of them says
+    whether what changed was who sends the town's text messages."""
+    assert describe_action("POST", "/api/system/providers/sms/save") == (
+        "Updated the SMS provider settings"
+    )
+    assert describe_action("POST", "/api/system/providers/email/save") == (
+        "Updated the email provider settings"
+    )
+
+
+def test_an_unknown_capability_keeps_its_own_name():
+    """A capability added next year should read as itself on day one rather
+    than be flattened into "a provider"."""
+    said = describe_action("POST", "/api/system/providers/notarisation/save")
+    assert "notarisation" in said
+
+
 def test_ordinary_work_on_a_request_stays_off_the_admin_log():
     """A status change and a comment are the day job. They are on the request,
     where somebody looking at that request will see them, and putting them here

--- a/backend/tests/test_health_endpoint_reads_real_fields.py
+++ b/backend/tests/test_health_endpoint_reads_real_fields.py
@@ -1,0 +1,96 @@
+"""The health page 500'd on a field that was never on the object.
+
+`alert_muted_until` was added as a column, a migration and a mute endpoint --
+but not to the `Health` dataclass that the read path builds. `/connectors/health`
+does `h.alert_muted_until` for every row, a dataclass has no such attribute, and
+so the endpoint raised AttributeError and returned 500. Every time, for
+everyone, from the moment the mute feature landed.
+
+What that looks like on screen is nothing to do with muting: a banner saying
+"the status of these services could not be read", and every provider card
+falling back to "not checked yet" -- because they all hydrate from that one
+response. Two of the three symptoms reported as separate bugs were this.
+
+Nothing caught it because no test reads the endpoint (CI has no database) and
+the dataclass and its reader are in different files. So this compares them
+directly: every attribute the handler touches has to exist on the object the
+handler is given.
+"""
+
+import ast
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from app.services.connector_health import Health
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _handler_source(name: str) -> str:
+    tree = ast.parse((ROOT / "app/api/system.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return ast.unparse(node)
+    pytest.fail(f"{name} is no longer in system.py")
+
+
+def _known_names() -> set:
+    fields = {f.name for f in dataclasses.fields(Health)}
+    return fields | {n for n in dir(Health) if not n.startswith("_")}
+
+
+def test_the_health_endpoint_only_reads_fields_that_exist():
+    """One missing attribute takes the entire page down, not one row: the
+    comprehension raises on the first connector and nothing is returned."""
+    source = _handler_source("connector_health_report")
+    tree = ast.parse(source)
+    read = {
+        node.attr for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+        and node.value.id == "h"
+    }
+    missing = read - _known_names()
+    assert not missing, (
+        f"/connectors/health reads {sorted(missing)} off Health, which does not have it -- "
+        f"this returns 500 for every connector on every request"
+    )
+
+
+def test_the_mute_state_survives_the_read():
+    """Adding the field but leaving `to_health` alone would fix the crash and
+    keep the bug: alerts would report as never muted, however recently somebody
+    muted them. A mute that silences the email and leaves no trace on screen is
+    indistinguishable from the alerting being broken."""
+    from datetime import datetime, timezone
+
+    from app.services.connector_health import to_health
+
+    when = datetime(2026, 8, 9, tzinfo=timezone.utc)
+
+    class Row:
+        connector = "sms"
+        status = "working"
+        provider = "twilio"
+        last_success_at = None
+        last_error_at = None
+        last_error = None
+        consecutive_failures = 0
+        total_successes = 1
+        total_failures = 0
+        alert_muted_until = when
+
+    assert to_health(Row()).alert_muted_until == when
+
+
+def test_a_row_without_the_column_still_reads():
+    """Mid-migration, the column may not be there. Degrading to "not muted"
+    keeps the page up; raising takes it down for a connector nobody muted."""
+    class Row:
+        connector = "sms"
+        status = "working"
+
+    from app.services.connector_health import to_health
+
+    assert to_health(Row()).alert_muted_until is None

--- a/frontend/src/components/OperationsPanel.tsx
+++ b/frontend/src/components/OperationsPanel.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
     Server, Database, RefreshCw, Play, Trash2, HardDrive, Clock,
     CheckCircle, XCircle, Loader2, RotateCcw, Wrench,
-    Cloud, Activity, AlertTriangle
+    Cloud, Activity, AlertTriangle, Cpu
 } from 'lucide-react';
 import { Card, Button } from './ui';
 import api, { HealthDashboard, RunbookResult, ProactiveHealth } from '../services/api';
@@ -232,6 +232,68 @@ export default function OperationsPanel() {
                         </div>
                     </Card>
                 </div>
+            )}
+
+            {/* What this container is using of what it is allowed.
+
+                These three readings existed but were only rendered once one of
+                them crossed a threshold -- until then the whole section
+                collapsed to a single line saying everything passed. So the
+                answer to "how much memory is left?" was unavailable at exactly
+                the times somebody thinks to ask it, which is usually before
+                anything is wrong.
+
+                Read from the same probes the hourly sweep and the alert email
+                use. A second measurement rendered here would be a second
+                opinion that drifts from the one that raises the alarm. */}
+            {proactive && (
+                <Card>
+                    <h3 className="text-lg font-semibold text-white mb-1 flex items-center gap-2">
+                        <Cpu className="w-5 h-5 text-cyan-400" />
+                        Container resources
+                    </h3>
+                    <p className="text-gray-400 text-xs mb-4">
+                        Measured against this container's own limits, not the server's total.
+                    </p>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        {['memory', 'disk', 'cpu'].map(key => {
+                            const c = proactive.checks.find(x => x.key === key);
+                            if (!c) return null;
+                            const pct = typeof c.value === 'number' ? c.value : null;
+                            // A gauge with no reading is drawn as no reading.
+                            // An empty bar reads as 0% used, which is the most
+                            // reassuring possible rendering of "we could not
+                            // measure this".
+                            const bar = c.status === 'critical' ? 'bg-red-400'
+                                : c.status === 'warning' ? 'bg-amber-400'
+                                    : 'bg-emerald-400';
+                            return (
+                                <div key={key} className="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
+                                    <div className="flex items-baseline justify-between mb-2">
+                                        <span className="text-gray-300 text-xs uppercase tracking-wide">{c.label}</span>
+                                        <span className={`text-lg font-semibold ${c.status === 'critical' ? 'text-red-300'
+                                            : c.status === 'warning' ? 'text-amber-300' : 'text-white'}`}>
+                                            {pct === null ? '—' : `${pct}%`}
+                                        </span>
+                                    </div>
+                                    <div
+                                        className="h-1.5 rounded-full bg-white/10 overflow-hidden"
+                                        role="meter"
+                                        aria-label={c.label}
+                                        aria-valuenow={pct ?? undefined}
+                                        aria-valuemin={0}
+                                        aria-valuemax={100}
+                                    >
+                                        {pct !== null && (
+                                            <div className={`h-full ${bar}`} style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
+                                        )}
+                                    </div>
+                                    <p className="text-gray-400 text-xs mt-2">{c.message}</p>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </Card>
             )}
 
             {/* Proactive (leading-indicator) health — warns before something fails */}

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -267,11 +267,10 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
             setSelected(cat.current_provider);
             setModel(cat.current_model || '');
             if (cat.last_result) {
-                setResult({
-                    ok: cat.last_result.ok,
-                    detail: cat.last_result.detail,
-                    configured: cat.configured?.[cat.current_provider] === true,
-                });
+                // `configured` was being passed here too. It is not part of
+                // this state -- the badge reads it from the catalog -- so it
+                // was dropped on the floor while breaking the type.
+                setResult({ ok: cat.last_result.ok, detail: cat.last_result.detail });
             }
             onStatus(cap, {
                 providerName: cat.providers.find(p => p.provider === cat.current_provider)?.name || cat.current_provider,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -131,6 +131,14 @@ export interface ProviderCatalog {
     current_model_available?: boolean;
     configured?: Record<string, boolean>;
     providers: ProviderInfo[];
+    /** What the last recorded check found, so a hard refresh does not reset
+     *  every card to "not checked yet". Absent when none has been run. */
+    last_result?: {
+        ok: boolean;
+        detail: string;
+        status?: string;
+        verifiable?: boolean | null;
+    } | null;
 }
 
 export interface AIModelRefreshResult {


### PR DESCRIPTION
Verification of six reported fixes, plus the code changes the verification turned up. Two of the six were the same defect; one was a regression waiting to happen.

## The one that matters: `/connectors/health` has been returning 500

`connector_health_report` reads `h.alert_muted_until` for every row. The column, the migration and the mute endpoint all landed together — **the field on the `Health` dataclass the read path builds did not**. A dataclass has no such attribute, so the endpoint raised `AttributeError` and returned 500. Every time, for everyone, since the mute feature shipped.

**Two of the symptoms reported as separate bugs are this one:**

- *"The status of these services could not be read"* on page load — that banner **is** the 500.
- *Provider test results not surviving a hard refresh* — same 500. Every card hydrates from that one response, so they all fell back to "not checked yet".

Adding the field alone fixes the crash and keeps a quieter bug: `to_health()` has to populate it too, or alerts report as never muted however recently somebody muted them — a mute that silences the email and leaves no trace on screen is indistinguishable from the alerting being broken. Populated through `getattr` like every other column, so a deployment that has not run the mute migration degrades to "not muted" instead of taking the page down.

Nothing caught this because no test reads the endpoint (CI has no database) and the dataclass and its reader are in different files. **A test now compares them directly:** every attribute the handler touches has to exist on the object the handler is given. Reverting either half of the fix fails it.

## On the six reported fixes

| # | Reported fix | Verdict |
|---|---|---|
| 1 | Reset `SMS_PROVIDER` to `none` | **Works, and there is no code bug here.** The card reads `configured[current_provider]`, and Textbelt *is* legitimately configured — it has no required credentials, so nothing is missing. The badge was telling the truth about Textbelt while the Twilio card was on screen. It will recur the same way if a zero-credential provider is ever selected again. |
| 2 | `alert_muted_until` on the dataclass | **Correct diagnosis, and the root cause of #3 as well.** Completed here: also populated in `to_health`, plus the guard test. |
| 3 | Return `last_result` from the catalog | **Merged already and reasonable** as a second source, but it was treating a symptom of #2. Its typing was broken — see below. |
| 4 | `await importLibrary` on an existing script tag | **Correct.** The existing-tag branch resolved without ever loading `places`. Merged. |
| 5 | Broader `SKIP_PREFIXES`, better labels | **Labels yes, three of the skips no.** See below. |
| 6 | Container RAM / storage / CPU gauges | **The metrics already existed; they were hidden.** See below. |

## #5 — the labels are right, three of the skips are a regression

Per-capability labels are in: *"Updated the SMS provider settings"*, not four consecutive rows of *"a service provider's settings"* while somebody works through the setup guide. An unrecognised capability keeps its own name rather than being flattened.

**But `/api/gis/` silences the boundary writes** — `POST /boundaries`, `/boundaries/save-census`, `/township-boundary`. That is the map every report is placed on, and the route #440 fixed from being writable *without authentication*. **`/api/system/connectors` silences `POST /connectors/{c}/mute`**, which is exactly the action behind *"why did nobody get emailed for three weeks"*. And `/status` in `NO_CHANGE_SEGMENTS` is a trap for any future status-changing route.

The reads that prompted this were already gone: **GETs have never been recorded** since the audit change merged, and the pasted log timestamps (12:58–01:28) predate it. Trimming is done by naming what changes nothing, not by silencing a prefix whose few mutations are the consequential ones. Muting an integration is now recorded and named; a test names each route this must not lose.

## #6 — the readings existed, the panel hid them

`proactive.checks` has carried memory, disk and CPU since the last merge — cgroup-aware, measured against the container's own limits. The panel collapsed to *"All early-warning checks passing"* until something crossed a threshold, so **the answer to "how much memory is left?" was unavailable at exactly the times somebody thinks to ask it**, which is usually before anything is wrong. Now three gauges, with a bar that is drawn as absent rather than empty when a reading could not be taken — an empty bar reads as 0% used, the most reassuring possible rendering of "we could not measure this".

Read from the same probes the hourly sweep and the alert email use. **Adding cgroup probes to `/health-dashboard` would be a second measurement that drifts from the one that raises the alarm.**

## Typing left broken by the catalog change

`48b3ed7` added four TypeScript errors: `last_result` is not on `ProviderCatalog`, and a `configured` key was passed into a state shape with no such field — silently dropped at runtime. Both fixed; typecheck is back to its pre-existing baseline.

## Verification

1044 backend + 203 frontend tests, build green, typecheck at baseline (the remaining errors are the pre-existing `azure/renderer` and two unused setters in `AdminConsole`). Mutation-checked: removing the dataclass field, or the `to_health` line, fails the new tests.

Branched fresh off `main` — #446 is merged, so this is new work rather than commits stacked on merged history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0159jZQsLi5MN7KcEFSSqSHd)_