### PR TITLE
Setup & Integrations: Setup Wizard Persistence, Secret Store Selection & Migration Revision Deduplication

### DIFF
--- a/backend/alembic/versions/20260804_0900_d6e7f8a9b0c1_capability_switches.py
+++ b/backend/alembic/versions/20260804_0900_d6e7f8a9b0c1_capability_switches.py
@@ -1,0 +1,118 @@
+"""Give "the town does not want this" somewhere to live.
+
+Wanted-ness was browser state. `SetupIntegrationsPage` initialised a
+`Set<string>` to every feature and unticking one hid part of the setup guide
+until the next reload -- no request, no row, and no effect on any sender. So a
+capability could be configured or unconfigured and nothing else, and the only
+way to stop one that was configured was to delete its credential.
+
+This adds `system_settings.capability_switches` and folds into it the two
+places that were already answering a piece of the same question:
+
+    modules.ai_analysis / sms_alerts / email_notifications
+    the EMAIL_ENABLED and SMS_ENABLED secrets
+
+Email and SMS had all three at once, at different layers, with different
+defaults. The seed below only writes an entry where the old sources settle the
+answer on their own; anything it leaves out is resolved at read time from the
+same old sources, so an unseeded capability behaves exactly as it did.
+
+The `modules` JSON keeps `unlisted_reports` and `research_portal`: product
+features with no provider, no credentials and nothing to configure. See
+app/services/capability_switches.py for the rule.
+
+Revision ID: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
+"""
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d6e7f8a9b0c1"
+down_revision: Union[str, None] = "c5d6e7f8a9b0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Reproduced rather than imported. A migration has to keep describing the schema
+# as it was on the day it ran, and importing the service would make this file's
+# behaviour change the next time that module does.
+_LEGACY_MODULE_DEFAULT = {"ai_analysis": False, "sms_alerts": False, "email_notifications": True}
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column("capability_switches", sa.JSON(), nullable=True, server_default="{}"),
+    )
+
+    conn = op.get_bind()
+    row = conn.execute(sa.text(
+        "SELECT id, modules FROM system_settings ORDER BY id LIMIT 1"
+    )).fetchone()
+    if row is None:
+        # No settings row yet, so no town to preserve the behaviour of. The
+        # column default and the read-time fallback cover whatever is created
+        # next.
+        return
+
+    settings_id = row[0]
+    modules = row[1] or {}
+
+    def module(name: str) -> bool:
+        return bool(modules.get(name, _LEGACY_MODULE_DEFAULT[name]))
+
+    switches = {
+        # No secret ever gated AI, so the module flag was the whole switch.
+        "ai": module("ai_analysis"),
+        # These four never had a switch: they ran whenever their credentials
+        # were present, which is what "on" now means.
+        "translation": True,
+        "kms": True,
+        "redaction": True,
+        "backups": True,
+        "errors": True,
+    }
+
+    # Email and SMS had a second gate in a secret, and this migration cannot
+    # read it -- the value is encrypted with a key it does not hold, and may
+    # have been migrated into the vault and scrubbed from the database
+    # entirely. So only the unambiguous direction is seeded: a module flag that
+    # says no means off whatever the secret says, because both had to agree
+    # before anything sent. The other direction is left to the read-time
+    # fallback, which consults the secret properly.
+    if not module("email_notifications"):
+        switches["email"] = False
+    if not module("sms_alerts"):
+        switches["sms"] = False
+
+    conn.execute(
+        sa.text("UPDATE system_settings SET capability_switches = CAST(:v AS json) WHERE id = :id"),
+        {"v": json.dumps(switches), "id": settings_id},
+    )
+
+    # Drop the three provider-backed flags from `modules`, so there is one
+    # switch per capability rather than two that can disagree. The column is
+    # `json` rather than `jsonb`, which has no key-removal operator of its own.
+    conn.execute(sa.text(
+        "UPDATE system_settings SET modules = CAST("
+        "  (CAST(COALESCE(modules, '{}') AS jsonb) - 'ai_analysis' - 'sms_alerts' - 'email_notifications')"
+        " AS json)"
+    ))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # Put the three flags back from the switches, so a rollback does not leave
+    # a town with email quietly defaulting back on.
+    conn.execute(sa.text("""
+        UPDATE system_settings SET modules = CAST(
+            CAST(COALESCE(modules, '{}') AS jsonb) || jsonb_build_object(
+                'ai_analysis', COALESCE(CAST(capability_switches AS jsonb)->'ai', 'false'::jsonb),
+                'sms_alerts', COALESCE(CAST(capability_switches AS jsonb)->'sms', 'false'::jsonb),
+                'email_notifications', COALESCE(CAST(capability_switches AS jsonb)->'email', 'true'::jsonb)
+            ) AS json)
+    """))
+    op.drop_column("system_settings", "capability_switches")

--- a/backend/alembic/versions/20260804_1100_e7f8a9b0c1d2_setup_completed_marker.py
+++ b/backend/alembic/versions/20260804_1100_e7f8a9b0c1d2_setup_completed_marker.py
@@ -1,0 +1,51 @@
+"""Record that somebody finished setting this town up.
+
+Nothing detected a fresh install. `SetupIntegrationsPage` is a tab inside the
+admin console and it opened its guide when sign-in or maps happened to be
+unconfigured -- which is a proxy for "is everything set up", and wrong in the
+direction that matters. A town that deliberately switches most things off never
+satisfies it, so the guide would greet it on every login forever, and a banner
+that never goes away is one people stop reading. In the other direction, an
+install where those two happen to be pre-seeded gets no guide at all.
+
+Being finished is a thing a person says. NULL means nobody has said it.
+
+Backfilled for towns that are plainly past setup, so this does not open a guide
+at a deployment that has been running for a year: a settings row older than a
+day with any credential stored is not a fresh install. A town in its first day
+gets the guide, which is what it is for.
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column("setup_completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    conn = op.get_bind()
+    # `updated_at` is the only age this table carries. A row that has never been
+    # written since creation has NULL there, which reads as "new" -- the safe
+    # direction, because the cost of being wrong is a guide somebody dismisses.
+    conn.execute(sa.text("""
+        UPDATE system_settings
+           SET setup_completed_at = COALESCE(updated_at, NOW())
+         WHERE updated_at < NOW() - INTERVAL '1 day'
+           AND EXISTS (SELECT 1 FROM system_secrets WHERE is_configured IS TRUE)
+    """))
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "setup_completed_at")

--- a/backend/alembic/versions/20260804_1400_f1a2b3c4d5e6_capability_switches.py
+++ b/backend/alembic/versions/20260804_1400_f1a2b3c4d5e6_capability_switches.py
@@ -21,8 +21,14 @@ The `modules` JSON keeps `unlisted_reports` and `research_portal`: product
 features with no provider, no credentials and nothing to configure. See
 app/services/capability_switches.py for the rule.
 
-Revision ID: d6e7f8a9b0c1
-Revises: c5d6e7f8a9b0
+Revision ID: f1a2b3c4d5e6
+Revises: d6e7f8a9b0c1
+
+Parented on the retention branch's migration rather than on
+`c5d6e7f8a9b0`, which both were originally written against. Two sessions
+picked the same generated revision id off the same parent; that one is
+already applied to the running deployment, so this chain sits after it and
+the history stays linear. This branch therefore has to merge after that one.
 """
 import json
 from typing import Sequence, Union
@@ -30,8 +36,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "d6e7f8a9b0c1"
-down_revision: Union[str, None] = "c5d6e7f8a9b0"
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/20260804_1400_f1a2b3c4d5e6_capability_switches.py
+++ b/backend/alembic/versions/20260804_1400_f1a2b3c4d5e6_capability_switches.py
@@ -22,13 +22,21 @@ features with no provider, no credentials and nothing to configure. See
 app/services/capability_switches.py for the rule.
 
 Revision ID: f1a2b3c4d5e6
-Revises: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
 
-Parented on the retention branch's migration rather than on
-`c5d6e7f8a9b0`, which both were originally written against. Two sessions
-picked the same generated revision id off the same parent; that one is
-already applied to the running deployment, so this chain sits after it and
-the history stays linear. This branch therefore has to merge after that one.
+Re-keyed from `d6e7f8a9b0c1`. Two sessions generated a migration off
+`c5d6e7f8a9b0` on the same day and were handed the same id, and the other
+one is already applied to the running deployment -- so this file's id had
+to change or applying it would have been a silent no-op against an
+`alembic_version` that already held the number.
+
+Left as a sibling of that migration rather than parented on it. Chaining
+onto a revision that is not in this branch would make the branch unable to
+migrate at all on its own -- `alembic upgrade head` cannot resolve a
+down_revision it does not have -- which breaks CI and any fresh install
+from here. So the two land as separate heads and whichever merges second
+adds a merge revision; they touch different columns and can be applied in
+either order.
 """
 import json
 from typing import Sequence, Union
@@ -37,7 +45,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f1a2b3c4d5e6"
-down_revision: Union[str, None] = "d6e7f8a9b0c1"
+down_revision: Union[str, None] = "c5d6e7f8a9b0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/20260804_1500_a2b3c4d5e6f7_setup_completed_marker.py
+++ b/backend/alembic/versions/20260804_1500_a2b3c4d5e6f7_setup_completed_marker.py
@@ -11,9 +11,10 @@ install where those two happen to be pre-seeded gets no guide at all.
 Being finished is a thing a person says. NULL means nobody has said it.
 
 Backfilled for towns that are plainly past setup, so this does not open a guide
-at a deployment that has been running for a year: a settings row older than a
-day with any credential stored is not a fresh install. A town in its first day
-gets the guide, which is what it is for.
+at a deployment that has been running for a year. The evidence is that somebody
+has already used the thing: a stored credential, or a report taken. A fresh
+install has neither -- `init_db` seeds every secret row with
+`is_configured=False`, so a configured one is always something a person entered.
 
 Revision ID: a2b3c4d5e6f7
 Revises: f1a2b3c4d5e6
@@ -36,14 +37,20 @@ def upgrade() -> None:
     )
 
     conn = op.get_bind()
-    # `updated_at` is the only age this table carries. A row that has never been
-    # written since creation has NULL there, which reads as "new" -- the safe
-    # direction, because the cost of being wrong is a guide somebody dismisses.
+    # Not the row's age. `updated_at` was the first thing tried here and it
+    # measures the wrong thing -- it moves whenever anything on the settings row
+    # changes, so a town that has been running for a year and adjusted a setting
+    # this morning reads as brand new. Tested against a copy of a live database,
+    # where it did exactly that.
+    #
+    # Evidence that somebody has used this deployment, then: a credential
+    # entered, or a report taken. Timestamped from `updated_at` where there is
+    # one, because a real date beats NOW() for a thing that happened earlier.
     conn.execute(sa.text("""
         UPDATE system_settings
            SET setup_completed_at = COALESCE(updated_at, NOW())
-         WHERE updated_at < NOW() - INTERVAL '1 day'
-           AND EXISTS (SELECT 1 FROM system_secrets WHERE is_configured IS TRUE)
+         WHERE EXISTS (SELECT 1 FROM system_secrets WHERE is_configured IS TRUE)
+            OR EXISTS (SELECT 1 FROM service_requests)
     """))
 
 

--- a/backend/alembic/versions/20260804_1500_a2b3c4d5e6f7_setup_completed_marker.py
+++ b/backend/alembic/versions/20260804_1500_a2b3c4d5e6f7_setup_completed_marker.py
@@ -15,16 +15,16 @@ at a deployment that has been running for a year: a settings row older than a
 day with any credential stored is not a fresh install. A town in its first day
 gets the guide, which is what it is for.
 
-Revision ID: e7f8a9b0c1d2
-Revises: d6e7f8a9b0c1
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
 """
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "e7f8a9b0c1d2"
-down_revision: Union[str, None] = "d6e7f8a9b0c1"
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -197,6 +197,33 @@ async def check_secret_manager(db: AsyncSession) -> Dict[str, Any]:
         from app.services.storage_maintenance import store_reachable
 
         provider = _secrets_provider()
+        if not provider:
+            # A town that has not been asked yet. Reported rather than guessed:
+            # this used to answer "Google Secret Manager accessible" about a
+            # store nobody had chosen, which is the confident wrong answer the
+            # setup gate exists to stop.
+            return {
+                "status": "not_configured",
+                "store": None,
+                "message": (
+                    "No secret store has been chosen, so no credential can be saved. "
+                    "Pick one in Setup & Integrations — the encrypted database is one "
+                    "of the answers."
+                ),
+            }
+        if provider == "database":
+            # Chosen, working, and nothing to migrate. Not "not_configured":
+            # the encrypted database is a supported store and this town said so.
+            return {
+                "status": "healthy",
+                "store": "database",
+                "message": (
+                    "Credentials are encrypted in this deployment's own database, as "
+                    "chosen. Anything that can read a database backup can read them, "
+                    "so keep backups where the town keeps its other secrets."
+                ),
+            }
+
         label = {"azure": "Azure Key Vault", "aws": "AWS Secrets Manager"}.get(
             provider, "Google Secret Manager")
 

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -252,12 +252,20 @@ async def effective_provider_for(capability: str) -> Optional[str]:
         from app.services.secret_manager import _secrets_provider
         from app.services.storage_maintenance import store_reachable
 
+        chosen = _secrets_provider()
+        # Nothing has been chosen. Not "database" -- a town that has not
+        # answered the question has not chosen the database either, and saying
+        # it had would tick the box the setup gate exists to hold open.
+        if not chosen:
+            return None
+        if chosen == "database":
+            return "database"
         # An unreachable store means credentials are in the encrypted database,
         # which is a supported place for them to be and a different provider
         # from the one that was selected. Saying "Google Secret Manager" about a
         # town whose secrets are all in Postgres is the kind of confident wrong
         # answer this pass is removing.
-        return _secrets_provider() if store_reachable() else "database"
+        return chosen if store_reachable() else "database"
 
     if capability in ("email", "sms", "kms"):
         from app.services.delivery_providers import normalize_provider
@@ -855,6 +863,53 @@ async def _vaulted_key_names() -> set:
         return set()
 
 
+def _require_a_secret_store() -> None:
+    """Refuse a credential until the town has said where credentials go.
+
+    Not tidiness. `_persist_secret` falls back to the encrypted database when
+    the external store is unreachable, and says so (`db_only`). `vault_secrets`
+    later sweeps those into the store and scrubs the database copy -- on a
+    schedule, and again after every provider save -- so the live database heals
+    itself and the whole thing looks harmless.
+
+    Database *backups* taken inside that window do not heal. They keep the
+    plaintext-equivalent row forever and they go off-site: a pg_dump of this
+    instance contains `COPY public.system_secrets (id, key_name, key_value,
+    ...)`. Sweeping the live row reaches nothing that has already been dumped.
+    So the credential has to not be written until somebody has decided where it
+    belongs.
+
+    The gate is on the *choice*, not on standing up a cloud vault. The encrypted
+    database is one of the four answers, the on-screen copy says what that means
+    for backups, and a town whose cloud procurement is unfinished is not dead-
+    ended. What must not happen is a town landing there without being asked.
+    """
+    from app.services.secret_manager import SECRET_STORES, store_chosen
+
+    if store_chosen():
+        return
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            "Choose where this town's credentials are kept before entering any. "
+            "Until that is answered a credential is written to the encrypted "
+            "database, and any backup taken before it is moved keeps a copy that "
+            "moving it cannot reach. Pick a store in Setup Instructions — the "
+            "encrypted database is one of the answers."
+        ),
+        headers={"X-Pinpoint-Secret-Stores": ",".join(SECRET_STORES)},
+    )
+
+
+# Settings that record where credentials go, rather than being one.
+#
+# The gate above cannot apply to these or nothing could ever get through it, and
+# `SECRETS_PROVIDER` in particular must never be written into the store it
+# names: that is circular, and a town whose store became unreadable would have
+# no way to find out which store it was.
+_STORE_CHOICE_KEYS = {"SECRETS_PROVIDER"}
+
+
 async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
     """Write a secret to the configured store and keep an encrypted DB copy.
 
@@ -886,9 +941,12 @@ async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
     # Stripping here rather than at each reader, because a value that differs
     # depending on who asks is the thing that made this hard to see.
     value = (value or "").strip()
-    # These two are deliberately database-only: they are what makes the secret
-    # store reachable in the first place, so storing them in it is circular.
-    bootstrap_keys = {"GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT"}
+    # Deliberately database-only: these are what makes the secret store
+    # reachable in the first place, or say which store it is, so putting them in
+    # it is circular. `SECRETS_PROVIDER` was going through the normal path and
+    # relying on DB_REQUIRED_KEYS to keep its database copy from being scrubbed
+    # -- which worked, and still wrote the name of the store into the store.
+    bootstrap_keys = {"GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT"} | _STORE_CHOICE_KEYS
     stored_externally = key_name in bootstrap_keys
     if value and key_name not in bootstrap_keys:
         try:
@@ -960,6 +1018,11 @@ async def save_provider(
             "new store's credentials first, let the hourly migration copy them across, and "
             "change the store after that."
         ))
+    # Before anything is written, and before the provider selection too: a save
+    # that recorded "we have decided on Twilio" and then refused the account SID
+    # would leave the card describing a decision with no credentials behind it.
+    if body.settings:
+        _require_a_secret_store()
     catalog = _capability_catalog(capability)
     provider_id = (body.provider or "").strip().lower()
     if provider_id not in catalog:
@@ -2192,6 +2255,95 @@ async def get_provider_status(_: User = Depends(get_current_admin)):
     return out
 
 
+class SecretStoreChoice(BaseModel):
+    store: str
+
+
+@router.get("/secrets/store")
+async def get_secret_store_choice(_: User = Depends(get_current_admin)):
+    """Where this town's credentials are kept, and whether anyone said so.
+
+    `chosen: false` is the state the setup gate holds open. It used to be
+    unreachable, because `_secrets_provider()` answered "google" for a town that
+    had never been asked -- so the page could not tell a deliberate choice of
+    Google Secret Manager from silence, and neither could the code.
+    """
+    from app.services.secret_manager import SECRET_STORES, _secrets_provider, store_chosen
+    from app.services.storage_maintenance import store_reachable
+
+    chosen = store_chosen()
+    return {
+        "chosen": chosen,
+        "store": _secrets_provider() or None,
+        "options": list(SECRET_STORES),
+        # Whether the store the town picked can actually be contacted. Not the
+        # same question, and not a blocker: choosing a vault whose credentials
+        # have not arrived yet is a real state, and the credentials that make it
+        # reachable are entered on this same page.
+        "reachable": store_reachable(),
+    }
+
+
+@router.post("/secrets/store")
+async def choose_secret_store(
+    body: SecretStoreChoice,
+    db: AsyncSession = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    """Record where this town's credentials go. Once, deliberately.
+
+    Set-once, and the refusal to change it is the same reasoning that makes the
+    secret store card read-only: every credential the town has is in the current
+    store, and repointing this setting does not move them. A second choice here
+    would be one click that makes every other card unreadable. Moving stores is
+    the cloud-profile flow, which migrates first.
+
+    `database` is accepted like the other three. The encrypted database is a
+    supported store, and a town whose cloud procurement is unfinished must be
+    able to get on with setup -- the gate is about consent, not capability. What
+    it must not be is where a town arrives without being asked, which is what it
+    was.
+    """
+    from app.services.secret_manager import SECRET_STORES, _secrets_provider, store_chosen
+
+    store = (body.store or "").strip().lower()
+    if store not in SECRET_STORES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown secret store: {body.store}. Expected one of: {', '.join(SECRET_STORES)}.",
+        )
+
+    current = _secrets_provider()
+    if store_chosen() and current != store:
+        raise HTTPException(status_code=409, detail=(
+            f"This town's credentials are in {current}. Repointing this setting does not "
+            f"move them, so every card would stop being able to read its own key. Set up "
+            f"the new store's credentials, let the migration copy them across, and change "
+            f"the store after that."
+        ))
+
+    if os.getenv("SECRETS_PROVIDER"):
+        # The host pinned it. Saying so beats accepting a write that the reader
+        # will go on ignoring, which is the shape of every bug in this area.
+        raise HTTPException(status_code=409, detail=(
+            "The secret store is pinned by this deployment's SECRETS_PROVIDER environment "
+            "variable, so it cannot be changed from here."
+        ))
+
+    await _persist_secret(db, "SECRETS_PROVIDER", store)
+
+    # Recorded, because "we knowingly chose the encrypted database" is exactly
+    # the kind of decision somebody will need to point at later -- and because
+    # the whole reason for the gate is that nobody could tell a choice from a
+    # default.
+    from app.services.admin_audit import record_admin_action
+
+    await record_admin_action(
+        db, event_type="secret_store.choose", actor=admin, details={"store": store},
+    )
+    return await get_secret_store_choice(admin)
+
+
 class CapabilitySwitchRequest(BaseModel):
     """A partial map: only the switches the caller is changing.
 
@@ -2557,6 +2709,12 @@ async def create_or_update_secret(
     from app.services.secret_manager import set_secret, clear_cache
 
     reject_platform_key_writes(secret_data.key_name)
+    # The other door into the secret table. Gating only the provider cards would
+    # leave the plain credential fields -- backups, crash reporting, the Google
+    # account -- writing into the encrypted database with nobody having chosen
+    # it, which is the case the gate exists for.
+    if secret_data.key_name not in _STORE_CHOICE_KEYS:
+        _require_a_secret_store()
 
     # Same reason as `_persist_secret`: surrounding whitespace is never part of
     # a credential, and this is the endpoint the plain secret fields on the

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -2255,6 +2255,62 @@ async def get_provider_status(_: User = Depends(get_current_admin)):
     return out
 
 
+@router.get("/setup/state")
+async def get_setup_state(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+):
+    """Whether anybody has said this town is set up.
+
+    Nothing answered this. The setup guide opened itself when sign-in or maps
+    happened to be unconfigured, which is "is everything set up" wearing a
+    disguise -- and a town that deliberately switches most things off never
+    satisfies that, so the guide would greet it on every login forever. A banner
+    that never goes away is one people stop reading.
+    """
+    row = (await db.execute(
+        select(SystemSettings).order_by(SystemSettings.id).limit(1)
+    )).scalar_one_or_none()
+    when = getattr(row, "setup_completed_at", None) if row else None
+    return {"completed": when is not None, "completed_at": when.isoformat() if when else None}
+
+
+@router.post("/setup/state")
+async def mark_setup_complete(
+    db: AsyncSession = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    """"I am done here." Said by a person, because nothing else can say it.
+
+    Deliberately not gated on anything being configured. Two things are actually
+    required before a town can take a report -- staff sign-in and a map -- and
+    the page already says so and shows what is outstanding. Refusing to let
+    somebody close the guide until a checklist is green would make the guide the
+    thing standing between them and the console, which is the opposite of what
+    it is for.
+    """
+    from datetime import datetime, timezone
+
+    row = (await db.execute(
+        select(SystemSettings).order_by(SystemSettings.id).limit(1)
+    )).scalar_one_or_none()
+    if row is None:
+        row = SystemSettings()
+        db.add(row)
+        await db.flush()
+    # Kept if it is already there. Re-marking would rewrite the date somebody
+    # may later want to point at, and the guide is reopenable from the tab
+    # regardless -- this flag only decides what happens on sign-in.
+    if row.setup_completed_at is None:
+        row.setup_completed_at = datetime.now(timezone.utc)
+        await db.commit()
+
+    from app.services.admin_audit import record_admin_action
+
+    await record_admin_action(db, event_type="setup.complete", actor=admin)
+    return await get_setup_state(db, admin)
+
+
 class SecretStoreChoice(BaseModel):
     store: str
 

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -260,16 +260,19 @@ async def effective_provider_for(capability: str) -> Optional[str]:
         return _secrets_provider() if store_reachable() else "database"
 
     if capability in ("email", "sms", "kms"):
-        from app.services.delivery_providers import normalize_provider, switched_off
+        from app.services.delivery_providers import normalize_provider
 
-        # The ENABLED flags are part of the answer to "which provider is this
-        # running on", because the answer is "none" when one of them says no.
-        # A card naming Twilio while SMS_ENABLED is false describes a send that
-        # will not happen.
-        enable_key = {"email": "EMAIL_ENABLED", "sms": "SMS_ENABLED"}.get(capability)
-        if enable_key and switched_off(await get_secret(enable_key)):
-            return None
-
+        # The ENABLED flags used to be folded in here, so that a switched-off
+        # capability reported no provider at all.
+        #
+        # That is the conflation this pass exists to undo. "Which provider is
+        # selected" and "does the town want this" are two facts, and answering
+        # both with one field is why a card could not tell "switched off, key
+        # still saved" from "never set up" -- it saw no provider either way, so
+        # it looked at the credentials for a provider it had not been given and
+        # concluded nothing was there. `/providers/status` now reports `enabled`
+        # beside `configured`, and every dispatch path asks
+        # `capability_switches.enabled` directly.
         resolved = normalize_provider(capability, raw)
         return None if resolved in _OFF_VALUES else resolved
 
@@ -297,6 +300,14 @@ async def capability_is_configured(capability: str) -> bool:
     secret meant photo redaction -- whose selection is inferred -- was reported
     as unconfigured on a deployment where it was blurring every photo.
     """
+    from app.services import capability_switches
+
+    # A town that switched something off has not left work outstanding, so the
+    # sweep has nothing to check. Same reasoning as the paragraph above about
+    # text messages, generalised now that every capability can be switched off
+    # rather than only the two with an ENABLED flag.
+    if not await capability_switches.enabled(capability):
+        return False
     current = await effective_provider_for(capability)
     if not current:
         return False
@@ -1651,17 +1662,11 @@ async def _test_delivery(capability: str) -> dict:
             "Azure Communication Services has no check that avoids sending a real "
             "message. Save, then send yourself a test from a request.")
 
-    from app.services.delivery_providers import switched_off
-
+    # The "texting is switched off" branch that used to be here has moved up to
+    # `test_provider`, which is the only caller and now answers it for all eight
+    # capabilities rather than for the one that happened to have a flag. This
+    # function is what its docstring says again: does this provider work.
     provider = (await get_secret("SMS_PROVIDER")) or "none"
-    if switched_off(await get_secret("SMS_ENABLED")):
-        # Reported before the provider, because it overrides it. A card that
-        # tested Twilio and reported it working while SMS_ENABLED was false
-        # would be describing a send that cannot happen.
-        return {"ok": True, "detail": (
-            "Text messages are switched off (SMS_ENABLED is false), so nothing is sent "
-            "whatever provider is selected."
-        )}
     if provider == "none":
         return {"ok": True, "detail": "Text messages are switched off, as configured."}
 
@@ -1988,6 +1993,32 @@ async def test_provider(
             pass
         return outcome
 
+    # A capability the town switched off is not tested, and the result is not
+    # recorded either way.
+    #
+    # Before the switch existed there was nothing to check here, and the two
+    # capabilities that did have an off flag checked it inside their own test
+    # function -- so the other six would happily make a live paid API call
+    # against an integration nobody uses, and write a red badge when it failed.
+    # A failure on something deliberately switched off is the noise that teaches
+    # people to ignore badges.
+    from app.services import capability_switches
+
+    if not await capability_switches.enabled(capability):
+        return {
+            "ok": True,
+            "detail": (
+                "This is switched off, so nothing runs through it. Its credentials "
+                "are still saved — switch it back on in Setup Instructions and they "
+                "will be used as they were."
+            ),
+            # Neither a pass nor a fail: there was no check. `configured: False`
+            # keeps `_remember` and the unverifiable path from writing anything.
+            "recorded": False,
+            "configured": False,
+            "off": True,
+        }
+
     check = _CAPABILITY_TESTS.get(capability)
     if check is None:
         # Cannot happen while the accept-list is derived from this table, and
@@ -2110,6 +2141,9 @@ async def get_provider_status(_: User = Depends(get_current_admin)):
     the moment a town configured email.
     """
     from app.core.sanitize import sanitize_for_log
+    from app.services import capability_switches
+
+    switches = await capability_switches.all_enabled()
 
     out: Dict[str, Any] = {}
     for capability in _PROVIDER_SELECT_KEY:
@@ -2118,15 +2152,28 @@ async def get_provider_status(_: User = Depends(get_current_admin)):
             providers = await providers_for(capability)
             current = await effective_provider_for(capability)
             configured = await _configured_map(providers)
+            wanted = switches.get(capability, True)
             out[capability] = {
                 "current_provider": current,
                 "configured": configured,
+                # The third fact, and the one the page could not previously get
+                # from anywhere.
+                #
+                # Deliberately not folded into `current_provider` or into
+                # `configured`. "Switched off" and "not set up" were
+                # indistinguishable, so a town that saved an AI key and then
+                # decided not to use AI got a card that said it had never been
+                # configured -- and the obvious response to that is to paste the
+                # key in again. Reported alongside `configured` rather than
+                # instead of it, so the card can say switched off *and* that the
+                # credentials are still there.
+                "enabled": wanted,
                 # Off is not unfinished. A town that has deliberately switched
                 # text messages off has answered the question, and a checklist
                 # that keeps asking is one people learn to ignore -- but it is
                 # not set up either, so this is False and the page says
                 # "switched off" rather than ticking it.
-                "ready": bool(current) and configured.get(current, False),
+                "ready": wanted and bool(current) and configured.get(current, False),
             }
         except Exception as exc:
             # One capability failing to report must not blank the other seven.
@@ -2135,7 +2182,43 @@ async def get_provider_status(_: User = Depends(get_current_admin)):
             # something already done rather than skipping something that isn't.
             logger.warning("provider status failed for %s: %s",
                            sanitize_for_log(capability), sanitize_for_log(str(exc)))
+
+    # The two switchable things with no provider catalog behind them. They have
+    # no entry above because there is no vendor to pick, and leaving them out
+    # would mean the page had to hold their answer somewhere else -- which is
+    # what it was doing, in React state that never reached the server.
+    for extra in ("backups", "errors"):
+        out[extra] = {"enabled": switches.get(extra, True)}
     return out
+
+
+class CapabilitySwitchRequest(BaseModel):
+    """A partial map: only the switches the caller is changing.
+
+    Partial on purpose. The questionnaire posts the one chip that was clicked,
+    and a town that has never been asked about photo redaction must not acquire
+    an answer to it because somebody unticked backups.
+    """
+
+    switches: Dict[str, bool]
+
+
+@router.put("/capabilities")
+async def set_capability_switches(
+    body: CapabilitySwitchRequest,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+):
+    """Record which integrations the town wants, credentials aside.
+
+    There was no endpoint for this because there was no such fact. The setup
+    page held the answer in a `Set<string>` initialised to every feature, so
+    unticking one hid part of the guide, survived nothing, and switched nothing
+    off -- while the page's own copy said "untick to remove it".
+    """
+    from app.services import capability_switches
+
+    return {"switches": await capability_switches.set_enabled(db, body.switches)}
 
 
 @router.get("/providers/cloud-identity")

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -292,8 +292,12 @@ async def seed_database():
             township_name="Your Township",
             hero_text="How can we help?",
             primary_color="#6366f1",
-            modules={"ai_analysis": False, "sms_alerts": False,
-                     "email_notifications": True, "unlisted_reports": False}
+            # Only what has no provider behind it. Anything with credentials and
+            # a card is switched in `capability_switches`, which starts empty --
+            # a fresh install has answered nothing, and an empty map reads as
+            # "not answered" rather than as "off".
+            modules={"unlisted_reports": False, "research_portal": False},
+            capability_switches={},
         )
         db.add(settings_obj)
         

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -505,6 +505,15 @@ class SystemSettings(Base):
     # by deleting the credential. {} means "never answered", which reads as the
     # behaviour that shipped before the switch existed rather than as "off".
     capability_switches = Column(JSON, default=dict)
+    # When somebody said they were finished setting this town up. NULL means
+    # nobody has, which is what opens the setup guide on sign-in.
+    #
+    # A marker rather than a derived answer. "Is everything configured" is the
+    # obvious proxy and it is wrong in the direction that matters: a town that
+    # deliberately switches most things off never satisfies it, so the guide
+    # would greet it on every login forever -- and a banner that never goes away
+    # is one people stop reading. Being finished is a thing a person says.
+    setup_completed_at = Column(DateTime(timezone=True))
     township_boundary = Column(JSON)  # GeoJSON boundary from OpenStreetMap
     
     # Multi-language support

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -489,7 +489,22 @@ class SystemSettings(Base):
     hero_text = Column(String(500), default="How can we help?")
     primary_color = Column(String(7), default="#6366f1")
     custom_domain = Column(String(255))  # For custom domain configuration
-    modules = Column(JSON, default={"ai_analysis": False, "sms_alerts": False, "email_notifications": True, "unlisted_reports": False})
+    # Product features with nothing to configure: no provider, no credentials,
+    # no card on the setup page. Anything that *does* have a provider behind it
+    # lives in `capability_switches` below -- see capability_switches.py for why
+    # the two are separate and which belongs where.
+    #
+    # `ai_analysis`, `sms_alerts` and `email_notifications` used to be here as
+    # well, duplicating a decision the setup page also owned.
+    modules = Column(JSON, default={"unlisted_reports": False, "research_portal": False})
+    # Which integrations the town wants, independent of whether they are set up.
+    #
+    # The third fact about a capability, and the one that had nowhere to live:
+    # credentials being stored and the town intending to use them are different
+    # claims, and without this an admin could only stop a configured integration
+    # by deleting the credential. {} means "never answered", which reads as the
+    # behaviour that shipped before the switch existed rather than as "off".
+    capability_switches = Column(JSON, default=dict)
     township_boundary = Column(JSON)  # GeoJSON boundary from OpenStreetMap
     
     # Multi-language support

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -364,7 +364,12 @@ class SystemSettingsBase(BaseModel):
     favicon_url: Optional[str] = None
     hero_text: str = "How can we help?"
     primary_color: str = "#6366f1"
-    modules: Dict[str, bool] = {"ai_analysis": False, "sms_alerts": False, "unlisted_reports": False}
+    # Product features with nothing to configure. `ai_analysis`, `sms_alerts`
+    # and `email_notifications` moved to `system_settings.capability_switches`,
+    # which is the one switch for anything with a provider behind it -- they
+    # were a second answer to a question the setup page also owned, and the two
+    # could disagree. See app/services/capability_switches.py.
+    modules: Dict[str, bool] = {"unlisted_reports": False, "research_portal": False}
     social_links: Optional[List[Dict[str, str]]] = []
     privacy_policy: Optional[str] = None  # Custom privacy policy (Markdown)
     terms_of_service: Optional[str] = None  # Custom terms of service (Markdown)

--- a/backend/app/services/ai/registry.py
+++ b/backend/app/services/ai/registry.py
@@ -135,8 +135,19 @@ def build_ai_provider(provider: str, model: Optional[str], creds: Dict[str, str]
 
 async def get_ai_provider(db=None):
     """Read config from the secret store and return a ready AIProvider, or None
-    if AI is not configured for this instance (triage then skips, as today)."""
+    if AI is not configured for this instance (triage then skips, as today).
+
+    Also None when the town has switched AI off. That is a different thing from
+    having no key, and it is the state that had nowhere to be expressed: a town
+    could store a Vertex key and decide not to use it, and the only way to stop
+    the analyser was to delete the key it had just been asked to paste in. The
+    credential stays readable; this simply does not build a client from it.
+    """
+    from app.services import capability_switches
     from app.services.secret_manager import get_secret
+
+    if not await capability_switches.enabled("ai"):
+        return None
 
     provider = (await get_secret(AI_PROVIDER_KEY)) or "vertex"
     provider = provider.strip().lower()

--- a/backend/app/services/capability_switches.py
+++ b/backend/app/services/capability_switches.py
@@ -1,0 +1,249 @@
+"""Whether a town wants a capability, as a fact separate from having set it up.
+
+Three questions about an integration had only two answers between them.
+
+    configured   the selected provider's credentials are stored
+                 (`_configured_map`, `/providers/status`)
+    wanted       the town intends to use this at all
+                 -- nowhere, until this module
+    running      dispatch will actually call it
+
+"Wanted" existed only in the browser: `SetupIntegrationsPage` held a
+`Set<string>` of ticked features in React state, initialised to everything.
+Unticking one hid a section of the setup guide until the page was reloaded and
+changed nothing else -- no request, no row, no effect on a single sender. So a
+town that had entered an AI key and then decided not to use AI had no way to say
+so, and the only way to stop a configured capability was to delete the
+credential it had just been asked to paste in.
+
+That is the gap this closes. A capability can now be switched off with its
+credentials intact: the key stays readable, the card says "switched off", and
+nothing dispatches through it.
+
+Why here and not in `system_settings.modules`
+---------------------------------------------
+`modules` is the other off-switch in this codebase, and the reason for writing
+down which is which is that having two undocumented ones is how the confusion
+started. Before this module there were, for email and SMS, *three*:
+
+    modules.email_notifications     JSON flag on system_settings
+    EMAIL_ENABLED                   a secret, read by configure_notifications
+    (and the same pair for SMS)
+
+Two of the four `modules` flags named a provider-backed capability, and two did
+not. That is the split this settles:
+
+    a switch here          the town has a provider, credentials and a card for
+                           it, and the setup page owns the decision
+    a flag in `modules`    a product feature with nothing to configure --
+                           `unlisted_reports`, `research_portal`. No provider,
+                           no credentials, no card, nothing to switch off at the
+                           dispatch layer.
+
+`ai_analysis`, `sms_alerts` and `email_notifications` moved here, and the
+`EMAIL_ENABLED` / `SMS_ENABLED` secrets moved with them. There are two
+switches now, with disjoint domains, rather than three that overlap on the
+three capabilities a town is most likely to change.
+
+Nothing changes for a town that upgrades. `enabled()` answers from the stored
+switch when there is one and from the old sources when there is not, with each
+old source's own default -- so an entry that was never written reproduces
+exactly what the previous code did, migration or no migration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# The eight provider-backed capabilities, plus the two features the same
+# questionnaire owns that have no provider catalog behind them.
+#
+# `backups` and `errors` are in this list rather than in `modules` because the
+# question being asked is the same one -- does the town want this -- and it is
+# asked in the same place, by the same ticks. They have no capability card only
+# because there is no vendor to choose between.
+SWITCHABLE = (
+    "ai", "translation", "email", "sms", "kms", "redaction",
+    "identity", "maps", "secrets",
+    "backups", "errors",
+)
+
+# Not a choice, so not switchable.
+#
+# Staff have to sign in and residents have to drop a pin, or the town cannot
+# take a report at all; and every credential either of those needs is kept by
+# the secret store, which is not a feature anyone ticks. Offering an off switch
+# for these would be offering to break the product from the setup page.
+ALWAYS_ON = frozenset({"identity", "maps", "secrets"})
+
+# What each capability meant before this module existed, so an unwritten switch
+# behaves exactly as it did. Consulted only when the stored map says nothing.
+_LEGACY_MODULE_FLAG = {
+    "ai": ("ai_analysis", False),
+    "sms": ("sms_alerts", False),
+    "email": ("email_notifications", True),
+}
+
+# The secret that used to gate the same capability, and the sense of it.
+#
+# They disagreed, which is why both are reproduced rather than generalised.
+# `EMAIL_ENABLED` was an opt-in -- a town had to set it to "true" -- and
+# `SMS_ENABLED` was a kill switch, because SMS already had an off state in its
+# provider (`none`) and requiring a second yes would have stopped texts for
+# every town that configured Twilio and never heard of the key.
+_LEGACY_SECRET = {
+    "email": ("EMAIL_ENABLED", "opt-in"),
+    "sms": ("SMS_ENABLED", "kill-switch"),
+}
+
+
+def _off_word(value: Optional[str]) -> bool:
+    from app.services.delivery_providers import switched_off
+
+    return switched_off(value)
+
+
+async def _stored() -> Dict[str, bool]:
+    """The switches a town has actually set, or {} if it has set none.
+
+    Never raises. This is consulted on dispatch paths -- the photo detector, the
+    notification sender, the translation resolver -- and a database hiccup must
+    not decide that every integration is off. An empty answer falls through to
+    the legacy sources below, which is the behaviour that shipped before this.
+    """
+    try:
+        from sqlalchemy import select
+
+        from app.db.session import SessionLocal
+        from app.models import SystemSettings
+
+        async with SessionLocal() as db:
+            row = (await db.execute(
+                select(SystemSettings).order_by(SystemSettings.id).limit(1)
+            )).scalar_one_or_none()
+            return dict(getattr(row, "capability_switches", None) or {})
+    except Exception as exc:
+        logger.debug("capability switches: could not be read (%s)", exc)
+        return {}
+
+
+async def _legacy(capability: str) -> bool:
+    """What this capability's on/off state was before the switch existed.
+
+    Both of the old sources are consulted and both have to say yes, because
+    both were live at once: `configure_notifications` refused to build a sender
+    without `EMAIL_ENABLED`, and `send_notifications` refused to send without
+    `modules.email_notifications`. Taking either one alone would switch email
+    on for some town that had it off.
+    """
+    ok = True
+
+    module_flag = _LEGACY_MODULE_FLAG.get(capability)
+    if module_flag:
+        name, default = module_flag
+        try:
+            from sqlalchemy import select
+
+            from app.db.session import SessionLocal
+            from app.models import SystemSettings
+
+            async with SessionLocal() as db:
+                row = (await db.execute(
+                    select(SystemSettings).order_by(SystemSettings.id).limit(1)
+                )).scalar_one_or_none()
+            modules = (getattr(row, "modules", None) or {}) if row else {}
+            ok = ok and bool(modules.get(name, default))
+        except Exception:
+            ok = ok and default
+
+    secret_flag = _LEGACY_SECRET.get(capability)
+    if secret_flag:
+        key, sense = secret_flag
+        try:
+            from app.services.secret_manager import get_secret
+
+            raw = await get_secret(key)
+        except Exception:
+            raw = None
+        if sense == "opt-in":
+            ok = ok and (raw or "").strip().lower() == "true"
+        else:
+            ok = ok and not _off_word(raw)
+
+    return ok
+
+
+async def enabled(capability: str) -> bool:
+    """Whether this capability may be used at all.
+
+    Says nothing about whether it is set up. A capability can be switched on
+    with no credentials -- which is the ordinary state of a town mid-setup --
+    and switched off with credentials stored, which is the state that had no
+    way to be expressed.
+    """
+    if capability in ALWAYS_ON:
+        return True
+    stored = await _stored()
+    if capability in stored:
+        return bool(stored[capability])
+    return await _legacy(capability)
+
+
+async def all_enabled() -> Dict[str, bool]:
+    """Every switch, resolved the same way `enabled` resolves one."""
+    stored = await _stored()
+    out: Dict[str, bool] = {}
+    for capability in SWITCHABLE:
+        if capability in ALWAYS_ON:
+            out[capability] = True
+        elif capability in stored:
+            out[capability] = bool(stored[capability])
+        else:
+            out[capability] = await _legacy(capability)
+    return out
+
+
+async def set_enabled(db, switches: Dict[str, bool]) -> Dict[str, bool]:
+    """Record the town's answer, and return every switch as it now stands.
+
+    A partial map is a partial update: the questionnaire posts the one chip that
+    was clicked, and a town that has never answered a question about photo
+    redaction must not have an answer invented for it by a click on backups.
+
+    Writing is what makes an answer explicit, and explicit is the point -- an
+    absent entry falls back to whatever the old flags said, and the whole reason
+    for this module is that the old flags could not express "configured, and not
+    wanted".
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm.attributes import flag_modified
+
+    from app.models import SystemSettings
+
+    row = (await db.execute(
+        select(SystemSettings).order_by(SystemSettings.id).limit(1)
+    )).scalar_one_or_none()
+    if row is None:
+        row = SystemSettings()
+        db.add(row)
+        await db.flush()
+
+    current = dict(row.capability_switches or {})
+    for capability, wanted in (switches or {}).items():
+        if capability not in SWITCHABLE:
+            continue
+        if capability in ALWAYS_ON:
+            # Accepted and ignored rather than rejected: the questionnaire never
+            # offers these, so a request carrying one is a stale client rather
+            # than an attempt to break the town.
+            continue
+        current[capability] = bool(wanted)
+
+    row.capability_switches = current
+    flag_modified(row, "capability_switches")
+    await db.commit()
+    return await all_enabled()

--- a/backend/app/services/geocode_dispatch.py
+++ b/backend/app/services/geocode_dispatch.py
@@ -46,7 +46,15 @@ BIAS_PAD_DEGREES = 0.05
 
 
 async def _selected(db) -> Tuple[str, Dict[str, Optional[str]]]:
-    """The town's geocoding provider, and only that provider's credentials."""
+    """The town's geocoding provider, and only that provider's credentials.
+
+    No capability switch is consulted, and that is the answer rather than an
+    omission. Maps is in `capability_switches.ALWAYS_ON`: a resident cannot file
+    a report without dropping a pin, so an off switch here would be an offer to
+    break intake from the setup page. Every other dispatch path in this codebase
+    does check -- see capability_switches.py -- and this one is listed there as
+    the exception so that "was geocoding covered" has an answer.
+    """
     from app.services import map_provider as mp
     from app.services.secret_manager import get_secret
 

--- a/backend/app/services/image_redaction.py
+++ b/backend/app/services/image_redaction.py
@@ -669,6 +669,16 @@ async def settings() -> Tuple[Optional[str], bool, bool]:
     would rather have the house numbers can switch plates off on the Photo
     Redaction card, which is reachable now that the card exists.
     """
+    # The town's switch comes first, and it is not the same as choosing the
+    # `none` provider. `resolve_provider()` deliberately floors at on-server
+    # detection so a town cannot end up with no blurring by accident -- which
+    # means the only way to have no blurring is to say so, and until the switch
+    # existed there was nowhere to say it.
+    from app.services import capability_switches
+
+    if not await capability_switches.enabled("redaction"):
+        return (None, False, False)
+
     provider = await resolve_provider()
     if not provider:
         return (None, False, False)

--- a/backend/app/services/secret_manager.py
+++ b/backend/app/services/secret_manager.py
@@ -126,18 +126,56 @@ def _get_sm_client():
 
 
 
+# The four places a town's credentials can knowingly be kept.
+#
+# `database` is on this list on purpose. The encrypted database is a supported
+# store -- it is the normal state of a small self-hosted install, and
+# test_secret_store_ordering has said so for a while -- so a town whose cloud
+# procurement is unfinished must be able to choose it and get on with setup. The
+# gate this list exists for is about consent, not capability.
+SECRET_STORES = ("google", "azure", "aws", "database")
+
+
 def _secrets_provider() -> str:
-    """Which secret store to use: 'google' (default, GCP Secret Manager),
-    'azure' (Azure Key Vault) or 'aws' (AWS Secrets Manager). All keep an
-    encrypted DB copy as fallback."""
+    """Which secret store this town chose, or "" if it has not chosen one.
+
+    Unset used to mean "google", and that default is the shape of accidental
+    behaviour this codebase has been removing elsewhere: a town that never
+    answered the question got Google Secret Manager as an answer, and if Google
+    was not actually reachable every credential fell through to the encrypted
+    database instead, silently.
+
+    Which is the reason "" now means "". A credential saved before a store is
+    chosen lands in the database, `vault_secrets` later sweeps it into the store
+    and scrubs the database copy, and the live row heals -- but a *backup* taken
+    inside that window keeps the secret forever, and backups go off-site. A
+    pg_dump of this instance contains `COPY public.system_secrets (id, key_name,
+    key_value, ...)`. Sweeping the live row does not reach a dump already taken.
+    So the setup page refuses credentials until this answers something, and the
+    town decides where its keys go before it has any.
+
+    Callers that need the *effective* behaviour of an unanswered town -- reading
+    a secret written before this existed -- treat "" as the historical
+    fall-through, which is Google when a project is configured and the database
+    otherwise. Callers deciding whether a choice has been made use
+    `store_chosen()`.
+    """
     val = os.getenv("SECRETS_PROVIDER")
     if val:
         return val.strip().lower()
     try:
         from app.core.encryption import _get_config_sync
-        return (_get_config_sync("SECRETS_PROVIDER") or "google").strip().lower()
+        return (_get_config_sync("SECRETS_PROVIDER") or "").strip().lower()
     except Exception:
-        return "google"
+        # Unreadable is not the same as unchosen, but this is the safe
+        # direction: it refuses credentials rather than filing them somewhere
+        # nobody picked.
+        return ""
+
+
+def store_chosen() -> bool:
+    """Whether a human has said where this town's credentials are kept."""
+    return _secrets_provider() in SECRET_STORES
 
 
 def _is_gcp_available() -> bool:
@@ -303,6 +341,16 @@ async def get_secret(key_name: str) -> Optional[str]:
     - BACKUP_* -> secret-backup bundle
     - Others -> secret-config bundle
     """
+    # The encrypted database, chosen on purpose.
+    #
+    # Reached before the Google branch rather than falling through to it: a town
+    # that picked the database may well have Google Cloud credentials on file
+    # for AI or maps, and `_is_gcp_available()` would then quietly start reading
+    # its keys out of Secret Manager -- which is a different store from the one
+    # it chose, and the one whose contents nobody put there.
+    if _secrets_provider() == "database":
+        return await _get_secret_from_db(key_name)
+
     # Azure Key Vault backend (host-selected via SECRETS_PROVIDER=azure)
     if _secrets_provider() == "azure":
         try:
@@ -389,7 +437,10 @@ async def get_secrets_bundle(prefix: str) -> Dict[str, str]:
     """
     result = {}
 
-    if _secrets_provider() == "google" and _is_gcp_available():
+    # "" is included because it is what an unanswered town reads as, and this
+    # function's job is reading back what is already there. Refusing to look in
+    # the bundle would hide credentials a town saved before the choice existed.
+    if _secrets_provider() in ("", "google") and _is_gcp_available():
         # Map prefix to bundle name
         if prefix.startswith("AUTH0"):
             bundle = _get_secret_from_gcp("secret-auth")
@@ -578,6 +629,12 @@ def set_secret_sync(key_name: str, value: str) -> bool:
     Secrets are bundled into JSON objects to stay within free tier limits.
     Returns True if successful, False otherwise.
     """
+    # The encrypted database, chosen on purpose. There is no external store to
+    # write to, and False is exactly what the caller needs to hear: it means
+    # "this is in the database", which is where the town asked for it.
+    if _secrets_provider() == "database":
+        return False
+
     # Azure Key Vault backend
     if _secrets_provider() == "azure":
         try:
@@ -674,6 +731,11 @@ def delete_secret_sync(key_name: str) -> bool:
     key is its own secret and is deleted outright.
     """
     provider = _secrets_provider()
+
+    if provider == "database":
+        # Nothing outside the database holds it, so there is nothing here to
+        # take back. The row itself is the caller's business.
+        return False
 
     if provider == "azure":
         try:

--- a/backend/app/services/storage_maintenance.py
+++ b/backend/app/services/storage_maintenance.py
@@ -54,11 +54,22 @@ def _pii_columns():
 
 
 def store_reachable() -> bool:
-    """Whether the configured secret store can be contacted right now."""
+    """Whether there is an external secret store to move credentials into.
+
+    False for the encrypted database, and that is not a failure. It is where the
+    credentials already are, so there is nothing for `vault_secrets` to move and
+    nothing for it to scrub -- which is the behaviour a town that chose the
+    database asked for.
+
+    False, too, when no store has been chosen. Sweeping credentials into a store
+    nobody picked is the accidental-default this pass removes.
+    """
     try:
         from app.services.secret_manager import _is_gcp_available, _secrets_provider
 
         provider = _secrets_provider()
+        if provider in ("", "database"):
+            return False
         if provider == "azure":
             from app.core import azure_keyvault
             return azure_keyvault.is_configured()

--- a/backend/app/services/storage_status.py
+++ b/backend/app/services/storage_status.py
@@ -43,7 +43,9 @@ async def secrets_outside_the_store(db) -> Dict[str, Any]:
         from app.services.secret_manager import DB_REQUIRED_KEYS, _secrets_provider
         from app.services.storage_maintenance import store_reachable
 
-        result["store"] = _secrets_provider()
+        # None rather than "", so the panel can say "not chosen yet" instead of
+        # rendering an empty store name.
+        result["store"] = _secrets_provider() or None
         # The same check the migration gates on, so the page cannot say work is
         # pending that the scheduled job has already decided it cannot do.
         result["reachable"] = store_reachable()

--- a/backend/app/services/translation_providers.py
+++ b/backend/app/services/translation_providers.py
@@ -185,8 +185,18 @@ def catalog_for_api() -> List[Dict[str, Any]]:
 
 async def get_translation_provider() -> Optional[TranslationProvider]:
     """Return the configured translation provider (default google), or None if
-    the selected provider isn't configured."""
+    the selected provider isn't configured -- or if the town switched
+    translation off while leaving its credentials in place.
+
+    Google is the default and needs no key of its own beyond the cloud account,
+    so before the switch existed a town on Google Cloud got translation whether
+    or not it wanted it, and had nothing it could remove to stop it.
+    """
+    from app.services import capability_switches
     from app.services.secret_manager import get_secret
+
+    if not await capability_switches.enabled("translation"):
+        return None
 
     provider = (await get_secret(TRANSLATION_PROVIDER_KEY)) or "google"
     provider = provider.strip().lower()

--- a/backend/app/tasks/service_requests.py
+++ b/backend/app/tasks/service_requests.py
@@ -44,15 +44,17 @@ async def configure_notifications(db):
     sms_provider = await get_secret(db, "SMS_PROVIDER")
     logger.info(f"[SMS Config] SMS_PROVIDER: {'set' if sms_provider else 'empty'}")
 
-    # SMS_ENABLED used to be read nowhere at all. A town could set it to false
-    # and every text kept going out -- a switch that does nothing is worse than
-    # no switch, because somebody believes it. Honoured here, where email's
-    # equivalent already was, so the two capabilities behave the same way.
-    from app.services.delivery_providers import switched_off
-    if switched_off(await get_secret(db, "SMS_ENABLED")):
+    # One switch, asked of the one module that owns it.
+    #
+    # This read `SMS_ENABLED` directly, and two other places read
+    # `modules.sms_alerts`, and both had to be on. Three sources for one answer
+    # is how a town ended up able to switch texting "off" in the admin console
+    # and have it stay on -- capability_switches.py has the reconciliation.
+    from app.services import capability_switches
+    if not await capability_switches.enabled("sms"):
         notification_service._sms_provider = None
         notification_service._sms_provider_name = None
-        logger.info("[SMS Config] SMS_ENABLED is false — text messages are switched off")
+        logger.info("[SMS Config] text messages are switched off for this town")
         sms_provider = "none"
 
     if sms_provider == "twilio":
@@ -98,15 +100,13 @@ async def configure_notifications(db):
         logger.warning("[SMS Config] Unknown or empty SMS_PROVIDER - SMS will not work")
 
     # Configure Email provider
-    email_enabled = await get_secret(db, "EMAIL_ENABLED")
-    if email_enabled.lower() != "true":
-        # Same reason as the SMS branch above. Setting EMAIL_ENABLED to false
-        # skipped the configure call and left the sender built by the previous
-        # one in place, so a town that switched resident email off carried on
-        # emailing residents until the worker happened to restart.
+    if not await capability_switches.enabled("email"):
+        # Cleared, not just skipped. Skipping left the sender built by the
+        # previous call in place, so a town that switched resident email off
+        # carried on emailing residents until the worker happened to restart.
         notification_service._email_provider = None
         notification_service._email_provider_name = None
-        logger.info("[Email Config] EMAIL_ENABLED is not true — email is switched off")
+        logger.info("[Email Config] email is switched off for this town")
     else:
         email_provider = (await get_secret(db, "EMAIL_PROVIDER") or "smtp").strip().lower()
         from_name = await get_secret(db, "SMTP_FROM_NAME") or "Township 311"
@@ -178,7 +178,8 @@ def analyze_request(self, request_id: int):
             # reports) always runs, so those facts populate even when AI is off or
             # not configured. This is what every intake path — resident portal,
             # manual/call-taker, email, and webhook — shares.
-            ai_module_on = bool(settings and settings.modules.get('ai_analysis', False))
+            from app.services import capability_switches
+            ai_module_on = await capability_switches.enabled("ai")
             ai_provider = None
             if ai_module_on:
                 from app.services.ai import get_ai_provider
@@ -418,13 +419,14 @@ def send_branded_notification(request_id: int, notification_type: str, old_statu
             logo_url = settings.logo_url if settings else None
             primary_color = settings.primary_color if settings else "#6366f1"
             
-            # Check if notifications are enabled via module toggles
-            modules = settings.modules if settings else {}
-            email_enabled = modules.get('email_notifications', True)  # Default to enabled for backwards compatibility
-            sms_enabled = modules.get('sms_alerts', False)
-            
+            # The same switch `configure_notifications` above consulted, rather
+            # than a second copy of the question read from `modules`.
+            from app.services import capability_switches
+            email_enabled = await capability_switches.enabled("email")
+            sms_enabled = await capability_switches.enabled("sms")
+
             if not email_enabled and not sms_enabled:
-                logger.info(f"[Notification] Skipping - both email and SMS notifications disabled in modules")
+                logger.info(f"[Notification] Skipping - email and text messages are both switched off")
                 return {"status": "skipped", "reason": "notifications disabled"}
             
             # Get custom domain for portal URL
@@ -627,8 +629,8 @@ def send_department_notification(request_id: int, department_email: str):
             settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
             
-            modules = settings.modules if settings else {}
-            sms_enabled_globally = modules.get('sms_alerts', False)
+            from app.services import capability_switches
+            sms_enabled_globally = await capability_switches.enabled("sms")
             
             township_name = settings.township_name if settings else "Your Township"
             custom_domain = settings.custom_domain if settings else None
@@ -800,8 +802,8 @@ def notify_staff_of_activity(request_id: int, event: str, actor: str = None):
 
             settings_result = await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
             settings = settings_result.scalar_one_or_none()
-            modules = settings.modules if settings else {}
-            sms_enabled_globally = modules.get('sms_alerts', False)
+            from app.services import capability_switches
+            sms_enabled_globally = await capability_switches.enabled("sms")
             township_name = settings.township_name if settings else "Your Township"
             custom_domain = (settings.custom_domain if settings else None) or os.environ.get('DOMAIN', '')
             portal_url = f"https://{custom_domain}" if custom_domain and custom_domain != 'localhost' else "http://localhost:5173"
@@ -1215,9 +1217,8 @@ def send_weekly_digest():
                 custom_domain = os.environ.get('DOMAIN', '')
             portal_url = f"https://{custom_domain}" if custom_domain and custom_domain != 'localhost' else "http://localhost:5173"
             
-            # Check if email notifications are enabled
-            modules = settings.modules if settings else {}
-            if not modules.get('email_notifications', True):
+            from app.services import capability_switches
+            if not await capability_switches.enabled("email"):
                 logger.info("[Weekly Digest] Skipping - email notifications disabled")
                 return {"status": "skipped", "reason": "email notifications disabled"}
             

--- a/backend/tests/test_capability_switches.py
+++ b/backend/tests/test_capability_switches.py
@@ -1,0 +1,324 @@
+"""Configured, wanted and running are three facts, and there were two.
+
+The requirement, in the reporter's words: "I can for example save an email or AI
+key but not use it and then this is reflected in the service provider card but
+things are still saved."
+
+That could not be expressed. Wanted-ness lived in the browser -- a
+`Set<string>` initialised to every feature -- so unticking a capability hid part
+of the setup guide, survived nothing, and switched nothing off. The only way to
+stop a configured integration was to delete the credential it had just been
+asked for.
+
+These tests cover the switch itself and the promise around it: the credential
+stays readable, and nothing dispatches through it.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from app.services import capability_switches as cs
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def stored(monkeypatch):
+    """The switches as if a town had set exactly these, and nothing else."""
+    box: dict = {}
+
+    async def _stored():
+        return dict(box)
+
+    monkeypatch.setattr(cs, "_stored", _stored)
+    return box
+
+
+@pytest.fixture
+def legacy(monkeypatch):
+    """What the old flags said, for the entries a town has never answered."""
+    box = {"value": True}
+
+    async def _legacy(capability):
+        return box["value"]
+
+    monkeypatch.setattr(cs, "_legacy", _legacy)
+    return box
+
+
+# ---------------------------------------------------------------------------
+# The three facts
+# ---------------------------------------------------------------------------
+
+def test_a_stored_no_switches_the_capability_off(stored, legacy):
+    stored["ai"] = False
+    assert _run(cs.enabled("ai")) is False
+
+
+def test_never_answered_is_not_the_same_as_no(stored, legacy):
+    """An empty map means the town has not been asked, and must behave exactly
+    as the code did before the switch existed. Reading it as "off" would switch
+    every integration off on the deploy that added the column."""
+    legacy["value"] = True
+    assert _run(cs.enabled("translation")) is True
+    legacy["value"] = False
+    assert _run(cs.enabled("translation")) is False
+
+
+def test_sign_in_maps_and_the_secret_store_cannot_be_switched_off(stored, legacy):
+    """A town cannot take a report without staff sign-in and a map, and every
+    credential either needs is kept by the secret store. An off switch for these
+    would be an offer to break intake from the setup page."""
+    legacy["value"] = False
+    for capability in ("identity", "maps", "secrets"):
+        stored[capability] = False
+        assert _run(cs.enabled(capability)) is True, capability
+
+
+def test_the_store_being_unreadable_does_not_switch_everything_off(monkeypatch, legacy):
+    """`_stored` runs on dispatch paths -- the detector, the sender, the
+    translator. A database hiccup must not decide that a town wants nothing, so
+    an unreadable column reads as "never answered" and falls through to what the
+    code did before the switch existed."""
+    import app.db.session as session
+
+    def explode():
+        raise RuntimeError("no database")
+
+    monkeypatch.setattr(session, "SessionLocal", explode, raising=False)
+    assert _run(cs._stored()) == {}
+
+    legacy["value"] = True
+    assert _run(cs.enabled("ai")) is True
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+
+class _FakeSession:
+    """Just enough of AsyncSession for `set_enabled`."""
+
+    def __init__(self, row):
+        self.row = row
+        self.committed = False
+
+    async def execute(self, _stmt):
+        return _FakeResult(self.row)
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        self.committed = True
+
+    def add(self, row):
+        self.row = row
+
+
+@pytest.fixture
+def writable(monkeypatch):
+    """A settings row `set_enabled` can write to, without a database."""
+    import sqlalchemy.orm.attributes as attributes
+
+    from app.models import SystemSettings
+
+    monkeypatch.setattr(attributes, "flag_modified", lambda *_a: None)
+    row = SystemSettings()
+    row.capability_switches = {}
+    db = _FakeSession(row)
+
+    async def all_enabled():
+        return dict(row.capability_switches)
+
+    monkeypatch.setattr(cs, "all_enabled", all_enabled)
+    return db, row
+
+
+def test_a_partial_write_leaves_the_other_answers_alone(writable):
+    """The questionnaire posts the chip that was clicked. A town that has never
+    been asked about photo redaction must not acquire an answer to it because
+    somebody unticked backups."""
+    db, row = writable
+    _run(cs.set_enabled(db, {"ai": False}))
+    _run(cs.set_enabled(db, {"backups": False}))
+
+    assert row.capability_switches == {"ai": False, "backups": False}
+    assert "redaction" not in row.capability_switches
+    assert db.committed
+
+
+def test_an_unknown_key_is_ignored_rather_than_stored(writable):
+    """Otherwise the column becomes a place to write arbitrary JSON through an
+    admin endpoint, and `all_enabled` starts reporting things that are not
+    capabilities."""
+    db, row = writable
+    _run(cs.set_enabled(db, {"ai": False, "rm -rf": True, "identity": False}))
+
+    # `identity` is accepted and ignored rather than refused: the questionnaire
+    # never offers it, so a request carrying it is a stale client rather than an
+    # attempt to break the town.
+    assert row.capability_switches == {"ai": False}
+
+
+# ---------------------------------------------------------------------------
+# The reconciliation
+# ---------------------------------------------------------------------------
+
+def test_modules_no_longer_carries_a_provider_backed_flag():
+    """Two overlapping off-switches is how this started. `modules` keeps the
+    product features with nothing to configure; anything with a provider,
+    credentials and a card is switched here."""
+    from app.models import SystemSettings
+
+    default = SystemSettings.__table__.c.modules.default.arg
+    assert set(default) == {"unlisted_reports", "research_portal"}, default
+
+
+def test_the_legacy_flags_are_still_consulted_for_an_unanswered_capability():
+    """Both of them, and both have to agree.
+
+    `configure_notifications` refused to build a sender without EMAIL_ENABLED
+    and `send_notifications` refused to send without modules.email_notifications
+    -- both were live at once. Taking either alone would switch email on for a
+    town that had it off."""
+    assert cs._LEGACY_MODULE_FLAG["email"] == ("email_notifications", True)
+    assert cs._LEGACY_SECRET["email"] == ("EMAIL_ENABLED", "opt-in")
+    # SMS was a kill switch, not an opt-in: it already had an off state in its
+    # provider (`none`), so requiring a second yes would have stopped texts for
+    # every town that configured Twilio and never heard of the key.
+    assert cs._LEGACY_SECRET["sms"] == ("SMS_ENABLED", "kill-switch")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def _switch(monkeypatch, **answers):
+    async def enabled(capability):
+        return answers.get(capability, True)
+
+    monkeypatch.setattr(cs, "enabled", enabled)
+
+
+def test_the_analyser_does_not_fire_when_ai_is_off(monkeypatch):
+    """And the key is not deleted to achieve it -- `get_ai_provider` returns
+    None with a perfectly good Vertex credential still stored."""
+    from app.services.ai import registry
+
+    _switch(monkeypatch, ai=False)
+    reads = []
+
+    async def get_secret(key):
+        reads.append(key)
+        return "something"
+
+    monkeypatch.setattr("app.services.secret_manager.get_secret", get_secret)
+    assert _run(registry.get_ai_provider()) is None
+    assert reads == [], "it read credentials for a capability nobody is using"
+
+
+def test_the_translator_does_not_fire_when_translation_is_off(monkeypatch):
+    """Google is the default and needs no key of its own beyond the cloud
+    account, so before the switch a town on Google Cloud got translation whether
+    it wanted it or not, with nothing it could remove to stop it."""
+    from app.services import translation_providers
+
+    _switch(monkeypatch, translation=False)
+    assert _run(translation_providers.get_translation_provider()) is None
+
+
+def test_the_detector_does_not_fire_when_redaction_is_off(monkeypatch):
+    """`resolve_provider` floors at on-server detection so a town cannot end up
+    with no blurring by accident. That makes the switch the only way to say no
+    on purpose."""
+    from app.services import image_redaction
+
+    _switch(monkeypatch, redaction=False)
+    assert _run(image_redaction.settings()) == (None, False, False)
+
+
+def test_the_sender_is_cleared_rather_than_left_running(monkeypatch):
+    """A singleton outlives the call that configured it. Skipping the configure
+    step left the previous sender in place, so a town that switched resident
+    email off carried on emailing residents until the worker restarted."""
+    import inspect
+
+    from app.tasks import service_requests
+
+    src = inspect.getsource(service_requests.configure_notifications)
+    off_branch = src[src.index('enabled("email")'):]
+    assert "_email_provider = None" in off_branch[:400]
+
+
+@pytest.mark.parametrize("capability", ["ai", "translation", "email", "sms", "redaction", "kms"])
+def test_a_switched_off_capability_is_not_reported_as_work_outstanding(monkeypatch, capability):
+    """`capability_is_configured` decides what the daily sweep tests. A town
+    that switched something off has not left work to do, and a red badge on it
+    is the noise that teaches people to ignore badges."""
+    from app.api import system
+
+    _switch(monkeypatch, **{capability: False})
+    assert _run(system.capability_is_configured(capability)) is False
+
+
+def test_geocoding_is_the_documented_exception():
+    """Maps is ALWAYS_ON, so `geocode_dispatch` has no switch to consult. Said
+    in the code rather than left as an absence, so "was geocoding covered" has
+    an answer."""
+    import inspect
+
+    from app.services import geocode_dispatch
+
+    assert "maps" in cs.ALWAYS_ON
+    assert "ALWAYS_ON" in inspect.getsource(geocode_dispatch._selected)
+
+
+# ---------------------------------------------------------------------------
+# What the page is told
+# ---------------------------------------------------------------------------
+
+def test_status_reports_wanted_beside_configured(monkeypatch):
+    """Not instead of it. The card has to be able to say "switched off, and your
+    credentials are still there", which needs both facts in the same payload."""
+    from app.api import system
+
+    async def all_enabled():
+        return {"sms": False, "ai": True, "backups": False}
+
+    async def providers_for(capability):
+        return [{"provider": "twilio", "credential_fields": []}]
+
+    async def effective(capability):
+        return "twilio"
+
+    async def configured_map(providers):
+        return {"twilio": True}
+
+    monkeypatch.setattr(cs, "all_enabled", all_enabled)
+    monkeypatch.setattr(system, "providers_for", providers_for)
+    monkeypatch.setattr(system, "effective_provider_for", effective)
+    monkeypatch.setattr(system, "_configured_map", configured_map)
+
+    out = _run(system.get_provider_status(None))
+
+    assert out["sms"]["enabled"] is False
+    assert out["sms"]["configured"]["twilio"] is True, "the credential is still stored"
+    assert out["sms"]["current_provider"] == "twilio", (
+        "the provider has to survive being switched off, or the card cannot name it"
+    )
+    assert out["sms"]["ready"] is False, "off is not set up"
+    assert out["ai"]["ready"] is True
+    # The two switchable things with no provider catalog. They were held in the
+    # browser and nowhere else, which is exactly the pair somebody is most
+    # likely to untick and then wonder about.
+    assert out["backups"] == {"enabled": False}

--- a/backend/tests/test_provider_test_button.py
+++ b/backend/tests/test_provider_test_button.py
@@ -27,6 +27,30 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+def _off(*capabilities):
+    """A `capability_switches.enabled` that says no to these and yes to the rest."""
+    async def enabled(capability):
+        return capability not in capabilities
+    return enabled
+
+
+@pytest.fixture
+def unlimited():
+    """`test_provider` is rate-limited, and the limiter wants a real Request.
+
+    Calling the endpoint function directly is the point of these two tests --
+    the switch guard runs before any check does, and going through the app
+    would need eight catalogs and a database to prove one branch. The cost
+    limiter is about a live paid API call, and the switch is the reason no call
+    happens, so turning it off here removes nothing under test.
+    """
+    system._cost_limiter.enabled = False
+    try:
+        yield
+    finally:
+        system._cost_limiter.enabled = True
+
+
 # ---------------------------------------------------------------------------
 # The drift that caused it
 # ---------------------------------------------------------------------------
@@ -492,33 +516,72 @@ def test_a_gateway_with_nothing_to_check_is_not_recorded_as_broken(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# SMS_ENABLED
+# Switched off
 # ---------------------------------------------------------------------------
 #
-# It was read nowhere in the backend. Setting it did nothing, which is worse
-# than not offering it, because somebody believed it. Email was already gated on
-# EMAIL_ENABLED, so the two capabilities disagreed about whether such a switch
-# means anything.
+# `SMS_ENABLED` was read nowhere in the backend. Setting it did nothing, which
+# is worse than not offering it, because somebody believed it. Email was gated
+# on `EMAIL_ENABLED`, so the two capabilities disagreed about whether such a
+# switch means anything, and the other six had no switch at all -- a town could
+# save an AI key, decide not to use AI, and have no way to say so.
+#
+# Both flags are now one switch, per capability, in
+# `capability_switches`. These tests moved with it: the question is no longer
+# "does the SMS check read its flag" but "does a switched-off capability get
+# tested at all", which is asked once for all eight.
 
-def test_switched_off_beats_the_selected_provider(monkeypatch):
-    """A card reporting Twilio as working while SMS_ENABLED is false describes a
-    send that cannot happen."""
-    from app.services import secret_manager
-    monkeypatch.setattr(secret_manager, "get_secret",
-                        _secrets(SMS_PROVIDER="twilio", SMS_ENABLED="false",
-                                 TWILIO_ACCOUNT_SID="AC", TWILIO_AUTH_TOKEN="t",
-                                 TWILIO_PHONE_NUMBER="+15005550006"))
+def test_a_switched_off_capability_is_not_tested_at_all(monkeypatch, unlimited):
+    """A card reporting Twilio as working while texting is switched off would be
+    describing a send that cannot happen -- and getting there costs a live paid
+    API call against an integration nobody uses.
 
-    result = _run(system._test_delivery("sms"))
-    assert result["ok"] is True
+    Asked at the endpoint rather than inside each check, because the previous
+    arrangement gated the two capabilities that happened to have a flag and let
+    the other six run.
+    """
+    from app.services import capability_switches
+
+    async def run():
+        monkeypatch.setattr(capability_switches, "enabled", _off("sms"))
+        called = []
+        monkeypatch.setitem(system._CAPABILITY_TESTS, "sms",
+                            lambda db=None: called.append("ran") or {"ok": True, "detail": ""})
+        result = await system.test_provider(None, "sms", db=None)
+        assert called == [], "the check ran against something the town switched off"
+        return result
+
+    result = _run(run())
+    assert result["off"] is True
     assert "switched off" in result["detail"]
+    # Neither a pass nor a failure: there was no check, so nothing is recorded
+    # and no badge changes colour.
+    assert result["recorded"] is False
+
+
+def test_a_switched_off_capability_says_its_credentials_are_still_there(unlimited):
+    """The whole point of the switch. "I can save an email or AI key but not use
+    it and then this is reflected in the service provider card but things are
+    still saved" -- so the message must not read like the key has gone."""
+    from app.services import capability_switches
+
+    async def run():
+        original = capability_switches.enabled
+        capability_switches.enabled = _off("ai")
+        try:
+            return await system.test_provider(None, "ai", db=None)
+        finally:
+            capability_switches.enabled = original
+
+    detail = _run(run())["detail"]
+    assert "still saved" in detail
+    assert "Setup Instructions" in detail
 
 
 def test_an_unset_flag_does_not_switch_texting_off(monkeypatch):
-    """Unlike EMAIL_ENABLED, which a town must set to "true". SMS already has an
-    off state -- provider `none` -- so requiring an extra yes would silently
-    stop texts for every town that configured Twilio and never heard of this
-    key."""
+    """Unlike email, which a town had to opt into with EMAIL_ENABLED=true. SMS
+    already has an off state -- provider `none` -- so requiring an extra yes
+    would silently stop texts for every town that configured Twilio and never
+    heard of the key. The legacy fallback keeps both senses."""
     from app.services import secret_manager
     monkeypatch.setattr(secret_manager, "get_secret", _secrets(SMS_PROVIDER="twilio"))
 
@@ -528,33 +591,44 @@ def test_an_unset_flag_does_not_switch_texting_off(monkeypatch):
     assert "switched off" not in result["detail"]
 
 
-def test_the_dispatch_code_honours_it_too():
+def test_the_dispatch_code_honours_the_same_switch():
     """The check and the sender have to agree, or the card is describing
-    something the worker does not do."""
+    something the worker does not do.
+
+    Asserted as "both reach the same function" rather than as "both mention
+    SMS_ENABLED", which is what it used to say -- a string search that would
+    have passed against a sender reading the flag and ignoring it."""
     import inspect
 
     from app.tasks import service_requests
 
     src = inspect.getsource(service_requests.configure_notifications)
-    assert "SMS_ENABLED" in src
-    assert "switched_off" in src
+    assert "capability_switches.enabled(\"sms\")" in src
+    assert "capability_switches.enabled(\"email\")" in src
 
 
-def test_switched_off_is_reported_as_no_provider():
-    """`effective_provider_for` is what the badge and the daily sweep read."""
+def test_the_provider_is_still_reported_when_the_capability_is_off():
+    """`effective_provider_for` used to fold the flag in and answer None.
+
+    That is the conflation this pass removed. A card that is told "no provider"
+    cannot tell "switched off with the key still saved" from "never set up", so
+    it showed a town that had deliberately turned texting off the same thing it
+    shows a town that has not started -- and the obvious response to that is to
+    paste the credentials in again. The switch is reported beside `configured`
+    now, by `/providers/status`, and every dispatch path asks it directly."""
     import asyncio as _asyncio
 
     from app.services import secret_manager
 
     async def run():
         original = secret_manager.get_secret
-        secret_manager.get_secret = _secrets(SMS_PROVIDER="twilio", SMS_ENABLED="false")
+        secret_manager.get_secret = _secrets(SMS_PROVIDER="twilio")
         try:
             return await system.effective_provider_for("sms")
         finally:
             secret_manager.get_secret = original
 
-    assert _asyncio.run(run()) is None
+    assert _asyncio.run(run()) == "twilio"
 
 
 def test_the_email_check_offers_the_envelope_as_well_as_signing_in():

--- a/backend/tests/test_secret_store_is_chosen.py
+++ b/backend/tests/test_secret_store_is_chosen.py
@@ -1,0 +1,232 @@
+"""No credential is written before somebody says where credentials go.
+
+The reason is backups, not tidiness.
+
+`_persist_secret` falls back to the encrypted database when the external store
+is unreachable, and reports that it did. `vault_secrets` later sweeps those rows
+into the store and scrubs the database copy -- on a schedule, and again after
+every provider save -- so the live database heals itself and the whole thing
+looks harmless.
+
+Database backups taken inside that window do not heal. They keep the row
+forever and they go off-site: a pg_dump of a Pinpoint instance contains
+`COPY public.system_secrets (id, key_name, key_value, ...)`. Sweeping the live
+row reaches nothing already dumped. So the credential has to not be written
+until the destination has been decided.
+
+The gate is on the choice, not on having a cloud vault. The encrypted database
+is one of the answers -- test_secret_store_ordering has said it is a supported
+store for a while -- with the backup consequence spelled out on screen. What
+must not happen is a town landing there by accident, which an unset
+`SECRETS_PROVIDER` quietly defaulting to "google" used to arrange.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException
+
+from app.api import system
+from app.services import secret_manager as sm
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def unset(monkeypatch):
+    """A town that has not been asked."""
+    monkeypatch.setattr(sm, "_secrets_provider", lambda: "")
+
+
+@pytest.fixture
+def chose(monkeypatch):
+    def _choose(store):
+        monkeypatch.setattr(sm, "_secrets_provider", lambda: store)
+    return _choose
+
+
+# ---------------------------------------------------------------------------
+# Unset means unset
+# ---------------------------------------------------------------------------
+
+def test_an_unanswered_town_reports_no_store(monkeypatch):
+    """It used to report "google", so nothing -- not the page, not the code --
+    could tell a deliberate choice of Google Secret Manager from silence."""
+    monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+    monkeypatch.setattr("app.core.encryption._get_config_sync", lambda _k: None)
+
+    assert sm._secrets_provider() == ""
+    assert sm.store_chosen() is False
+
+
+def test_the_encrypted_database_is_one_of_the_answers():
+    """Not a fallback a town discovers it landed in. A named choice it can make,
+    which is what stops the gate from dead-ending a town whose cloud
+    procurement is unfinished."""
+    assert "database" in sm.SECRET_STORES
+    assert sm.SECRET_STORES == ("google", "azure", "aws", "database")
+
+
+@pytest.mark.parametrize("store", ["google", "azure", "aws", "database"])
+def test_every_named_store_counts_as_chosen(chose, store):
+    chose(store)
+    assert sm.store_chosen() is True
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+def test_a_credential_is_refused_until_a_store_is_chosen(unset):
+    with pytest.raises(HTTPException) as caught:
+        system._require_a_secret_store()
+
+    assert caught.value.status_code == 409
+    # The refusal has to say what to do about it, and that the database is an
+    # allowed answer -- otherwise it reads as "go and buy a cloud vault".
+    assert "encrypted database is one of the answers" in caught.value.detail
+
+
+def test_choosing_the_encrypted_database_lets_credentials_through(chose):
+    """Accepted, and recorded as a deliberate choice. The gate is about consent,
+    not capability."""
+    chose("database")
+    system._require_a_secret_store()  # does not raise
+
+
+def test_a_vault_that_is_not_reachable_yet_still_opens_the_gate(chose, monkeypatch):
+    """Choosing Azure before the Key Vault credentials arrive is a real state --
+    and those credentials are entered on this same page, so gating on
+    reachability would be a loop with no way in."""
+    chose("azure")
+    monkeypatch.setattr("app.core.azure_keyvault.is_configured", lambda: False)
+    system._require_a_secret_store()  # does not raise
+
+
+def test_both_doors_into_the_secret_table_are_gated():
+    """The provider cards and the plain credential fields write through
+    different endpoints. Gating one would leave backups, crash reporting and the
+    Google account key going into an unchosen store."""
+    import inspect
+
+    for endpoint in (system.save_provider, system.create_or_update_secret):
+        assert "_require_a_secret_store()" in inspect.getsource(endpoint), endpoint.__name__
+
+
+def test_recording_the_choice_is_not_itself_gated():
+    """Otherwise nothing could ever get through it."""
+    assert "SECRETS_PROVIDER" in system._STORE_CHOICE_KEYS
+
+    import inspect
+
+    src = inspect.getsource(system.create_or_update_secret)
+    assert "if secret_data.key_name not in _STORE_CHOICE_KEYS" in src
+
+
+def test_the_choice_is_never_written_into_the_store_it_names():
+    """Circular, and it is how a town whose store became unreadable would lose
+    the only record of which store that was. It used to go through the ordinary
+    path and rely on DB_REQUIRED_KEYS to keep the database copy -- which worked,
+    and still wrote the name of the store into the store."""
+    import inspect
+
+    src = inspect.getsource(system._persist_secret)
+    assert "| _STORE_CHOICE_KEYS" in src
+    # And the scrubber still has to leave it alone.
+    assert "SECRETS_PROVIDER" in sm.DB_REQUIRED_KEYS
+
+
+# ---------------------------------------------------------------------------
+# What "database" does once chosen
+# ---------------------------------------------------------------------------
+
+def test_choosing_the_database_stops_reads_going_to_a_cloud_store(chose, monkeypatch):
+    """A town that picked the database may still have Google Cloud credentials
+    on file for AI or maps. Falling through to `_is_gcp_available()` would
+    quietly start reading its keys out of Secret Manager -- a different store
+    from the one it chose, whose contents nobody put there."""
+    chose("database")
+    monkeypatch.setattr(sm, "_is_gcp_available", lambda: pytest.fail("read the cloud store"))
+
+    async def from_db(key):
+        return "value-from-postgres"
+
+    monkeypatch.setattr(sm, "_get_secret_from_db", from_db)
+    assert _run(sm.get_secret("SMTP_PASSWORD")) == "value-from-postgres"
+
+
+def test_choosing_the_database_stops_writes_going_to_a_cloud_store(chose, monkeypatch):
+    chose("database")
+    monkeypatch.setattr(sm, "_is_gcp_available", lambda: pytest.fail("wrote to the cloud store"))
+
+    # False means "this is in the database", which is where the town asked for
+    # it -- the caller's `db_only` reporting is already built on that.
+    assert sm.set_secret_sync("SMTP_PASSWORD", "x") is False
+
+
+def test_nothing_is_swept_out_of_the_database_that_was_meant_to_stay(chose):
+    """`store_reachable` gates the migration. With the database chosen there is
+    nothing to move and nothing to scrub, and with no store chosen there is
+    nowhere anybody asked for it to go."""
+    from app.services.storage_maintenance import store_reachable
+
+    chose("database")
+    assert store_reachable() is False
+    chose("")
+    assert store_reachable() is False
+
+
+def test_the_card_says_no_store_rather_than_guessing_one(chose):
+    """`effective_provider_for('secrets')` answered "database" for an unanswered
+    town, which ticks the box the gate exists to hold open. Nothing chosen is
+    None."""
+    chose("")
+    assert _run(system.effective_provider_for("secrets")) is None
+    chose("database")
+    assert _run(system.effective_provider_for("secrets")) == "database"
+
+
+# ---------------------------------------------------------------------------
+# Changing it
+# ---------------------------------------------------------------------------
+
+def test_the_store_cannot_be_repointed_once_it_holds_something(chose, monkeypatch):
+    """Same reasoning that makes the secret store card read-only. Every
+    credential the town has is in the current store, and changing this setting
+    does not move them -- it would be one click that makes every other card
+    unreadable."""
+    chose("google")
+    monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+
+    with pytest.raises(HTTPException) as caught:
+        _run(system.choose_secret_store(system.SecretStoreChoice(store="aws"), db=None, admin=None))
+
+    assert caught.value.status_code == 409
+    assert "does not move them" in caught.value.detail
+
+
+def test_an_unknown_store_is_refused(unset):
+    with pytest.raises(HTTPException) as caught:
+        _run(system.choose_secret_store(
+            system.SecretStoreChoice(store="dropbox"), db=None, admin=None))
+
+    assert caught.value.status_code == 400
+
+
+def test_a_host_pinned_store_is_not_editable_from_the_console(monkeypatch):
+    """`SECRETS_PROVIDER` in the environment wins over the database, so
+    accepting a write here would store an answer the reader goes on ignoring --
+    the shape of every bug in this area."""
+    monkeypatch.setenv("SECRETS_PROVIDER", "aws")
+
+    with pytest.raises(HTTPException) as caught:
+        _run(system.choose_secret_store(
+            system.SecretStoreChoice(store="aws"), db=None, admin=None))
+
+    assert caught.value.status_code == 409
+    assert "pinned" in caught.value.detail

--- a/backend/tests/test_settings_round_trip.py
+++ b/backend/tests/test_settings_round_trip.py
@@ -65,6 +65,10 @@ DEDICATED = {
     # switch capabilities on and off as a side effect of renaming the township.
     # The dedicated PUT takes a partial map and touches only what changed.
     "capability_switches":     ("PUT /system/capabilities", "GET /system/providers/status"),
+    # Whether anybody has said this town is set up. Its own endpoint because it
+    # is written by one deliberate act -- closing the setup guide -- and read on
+    # every admin sign-in to decide whether to open it.
+    "setup_completed_at":      ("POST /system/setup/state", "GET /system/setup/state"),
 }
 
 # Written and read by the platform itself, never by a person. Not settings.

--- a/backend/tests/test_settings_round_trip.py
+++ b/backend/tests/test_settings_round_trip.py
@@ -59,6 +59,12 @@ DEDICATED = {
     "retention_state_confirmed": ("POST /system/retention/policy", "GET /system/retention/policy"),
     "legal_hold":              ("POST /system/retention/legal-hold", "GET /system/retention/policy"),
     "township_boundary":       ("POST /gis/boundaries", "GET /system/settings (maps config)"),
+    # Which integrations the town wants, credentials aside. Not on
+    # SystemSettingsBase on purpose: the general settings endpoint takes a whole
+    # object and echoes it back, and a browser posting a stale copy of it would
+    # switch capabilities on and off as a side effect of renaming the township.
+    # The dedicated PUT takes a partial map and touches only what changed.
+    "capability_switches":     ("PUT /system/capabilities", "GET /system/providers/status"),
 }
 
 # Written and read by the platform itself, never by a person. Not settings.
@@ -100,14 +106,35 @@ def test_the_schema_never_promises_a_column_that_does_not_exist():
     assert not phantom, f"SystemSettingsBase declares {sorted(phantom)} with no column behind it"
 
 
+# Where a dedicated column's read and write actually live, when the endpoint
+# delegates rather than doing it inline.
+#
+# The scan below reads `app/api` because that is where every one of these was
+# implemented when it was written. That is a proxy for the real question --
+# something writes this column and something reads it back -- and it fails the
+# moment a column is given a service of its own, which is the right place for
+# one whose value is consulted from six dispatch paths. Named per column rather
+# than by widening the glob: a column written only by a nightly task would still
+# be unreachable from the UI, and that is what this file exists to catch.
+IMPLEMENTED_IN = {
+    "capability_switches": ["app/services/capability_switches.py"],
+}
+
+
 @pytest.mark.parametrize("column,endpoints", sorted(DEDICATED.items()))
 def test_a_dedicated_column_can_be_written_and_read(column, endpoints):
     """Both halves. `retention_scrub_fields` was saved by an endpoint that had
     no matching read for a while, so the boxes a clerk ticked came back
     unticked and they ticked them again."""
-    api = "\n".join(p.read_text() for p in API.glob("*.py"))
-    written = re.search(rf"(?:settings|row|s)\.{column}\s*=", api)
-    read = re.search(rf"getattr\(settings, [\"']{column}[\"']|settings\.{column}\b(?!\s*=)", api)
+    sources = list(API.glob("*.py")) + [ROOT / p for p in IMPLEMENTED_IN.get(column, [])]
+    api = "\n".join(p.read_text() for p in sources)
+    # The same set of variable names on both halves. The read pattern only
+    # accepted `settings`, so a column written through `row.` -- which the write
+    # pattern has always allowed -- and read back through `getattr(row, ...)`
+    # counted as never read.
+    holder = r"(?:settings|row|s)"
+    written = re.search(rf"{holder}\.{column}\s*=", api)
+    read = re.search(rf"getattr\({holder}, [\"']{column}[\"']|{holder}\.{column}\b(?!\s*=)", api)
     assert written, f"{column} is never written ({endpoints[0]} was expected to)"
     assert read, f"{column} is never read back ({endpoints[1]} was expected to)"
 

--- a/backend/tests/test_setup_is_marked_finished.py
+++ b/backend/tests/test_setup_is_marked_finished.py
@@ -1,0 +1,126 @@
+"""Being finished is a thing a person says.
+
+Nothing detected a fresh install. `SetupIntegrationsPage` is a tab inside the
+admin console, and the console opens on Branding -- so on a brand new deployment
+the setup guide sat behind a click nobody had a reason to make. The first thing
+a town needs was the thing it was least likely to find.
+
+The guide did open itself, on `!signInConfigured || !mapsConfigured`. That is
+"is everything set up" wearing a disguise, and it is wrong in both directions: a
+town that deliberately switches most things off never satisfies it, so the guide
+greets it on every login forever; and an install where those two happen to be
+pre-seeded gets no guide at all.
+
+So there is a marker, and only a person sets it.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from app.api import system
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+
+class _Session:
+    def __init__(self, row):
+        self.row = row
+        self.commits = 0
+
+    async def execute(self, _stmt):
+        return _Result(self.row)
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        self.commits += 1
+
+    def add(self, row):
+        self.row = row
+
+
+@pytest.fixture
+def quiet_audit(monkeypatch):
+    """The audit trail is not what these tests are about, and it wants a real
+    session. Recording never blocks the action anyway."""
+    async def record(*_a, **_k):
+        return True
+
+    monkeypatch.setattr("app.services.admin_audit.record_admin_action", record)
+
+
+@pytest.fixture
+def town():
+    from app.models import SystemSettings
+
+    row = SystemSettings()
+    row.setup_completed_at = None
+    return _Session(row)
+
+
+def test_a_fresh_town_has_not_finished(town):
+    state = _run(system.get_setup_state(db=town, _=None))
+    assert state["completed"] is False
+    assert state["completed_at"] is None
+
+
+def test_saying_so_is_what_sets_it(town, quiet_audit):
+    state = _run(system.mark_setup_complete(db=town, admin=None))
+
+    assert state["completed"] is True
+    assert town.row.setup_completed_at is not None
+    assert town.commits == 1
+
+
+def test_it_is_not_gated_on_anything_being_configured(town, quiet_audit):
+    """Two things are actually required before a town can take a report, and the
+    page says which. Refusing to let somebody close the guide until a checklist
+    is green would make the guide the thing standing between them and the
+    console -- and a town that switched everything else off is finished."""
+    _run(system.mark_setup_complete(db=town, admin=None))
+    assert town.row.setup_completed_at is not None
+
+
+def test_marking_it_twice_keeps_the_first_date(town, quiet_audit):
+    """It is a date somebody may later want to point at, and the guide reopens
+    from the tab regardless -- this flag only decides what happens on sign-in."""
+    _run(system.mark_setup_complete(db=town, admin=None))
+    first = town.row.setup_completed_at
+
+    _run(system.mark_setup_complete(db=town, admin=None))
+    assert town.row.setup_completed_at == first
+    assert town.commits == 1, "the second call rewrote the row"
+
+
+def test_a_town_with_no_settings_row_still_gets_an_answer(quiet_audit):
+    """The read runs on every admin sign-in, including the first one, and a 500
+    there is a console nobody can open."""
+    empty = _Session(None)
+    assert _run(system.get_setup_state(db=empty, _=None))["completed"] is False
+
+
+def test_the_marker_is_not_derived_from_the_capabilities():
+    """The check that matters, as structure rather than behaviour: nothing in
+    either endpoint consults provider status, `ready`, or the switches. If it
+    ever does, this is the proxy coming back."""
+    import inspect
+
+    for endpoint in (system.get_setup_state, system.mark_setup_complete):
+        src = inspect.getsource(endpoint)
+        for proxy in ("capability_is_configured", "_configured_map", "providers_for",
+                      "capability_switches"):
+            assert proxy not in src, f"{endpoint.__name__} derives setup state from {proxy}"

--- a/frontend/src/components/SecretStoreGate.test.tsx
+++ b/frontend/src/components/SecretStoreGate.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * The town has to be asked where its credentials go, before it has any.
+ *
+ * The backend refuses the save either way; this panel is what makes the refusal
+ * something a clerk can act on rather than something they hit. The two things
+ * it has to get right are that the encrypted database is offered as a real
+ * answer -- otherwise the gate dead-ends a town with no cloud account -- and
+ * that choosing it says what it means for backups, which is the entire reason
+ * the question is worth asking.
+ */
+
+let response: any = null;
+const chosen: string[] = [];
+let refuseWith: string | null = null;
+
+vi.mock('../services/api', () => {
+    const api: any = new Proxy({}, {
+        get: (_t, prop: string) => {
+            if (prop === 'getSecretStore') return vi.fn(async () => response);
+            if (prop === 'chooseSecretStore') {
+                return vi.fn(async (store: string) => {
+                    if (refuseWith) throw new Error(refuseWith);
+                    chosen.push(store);
+                    return { chosen: true, store, options: [], reachable: true };
+                });
+            }
+            return vi.fn().mockResolvedValue({});
+        },
+    });
+    return { default: api, api };
+});
+
+const UNCHOSEN = {
+    chosen: false, store: null,
+    options: ['google', 'azure', 'aws', 'database'], reachable: false,
+};
+
+let host: HTMLDivElement;
+let root: Root;
+
+async function mount() {
+    const { default: Gate } = await import('./SecretStoreGate');
+    await act(async () => { root.render(React.createElement(Gate)); });
+    return host.textContent || '';
+}
+
+function button(pattern: RegExp): HTMLElement {
+    const el = Array.from(host.querySelectorAll('button'))
+        .find(b => pattern.test(b.textContent || ''));
+    if (!el) throw new Error(`no button matching ${pattern}`);
+    return el as HTMLElement;
+}
+
+async function click(pattern: RegExp) {
+    await act(async () => { button(pattern).click(); });
+}
+
+beforeEach(() => {
+    response = UNCHOSEN;
+    chosen.length = 0;
+    refuseWith = null;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+});
+afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllMocks();
+});
+
+describe('choosing where credentials are kept', () => {
+    it('asks before anything below can be filled in', async () => {
+        const text = await mount();
+        expect(text).toContain('where should this town’s credentials be kept');
+        expect(text).toMatch(/will accept a key until this is answered/i);
+    });
+
+    it('offers the encrypted database as a real answer', async () => {
+        // Not a fallback a town discovers it landed in. Without this the gate
+        // dead-ends anyone whose cloud procurement is unfinished, and the point
+        // is consent, not capability.
+        expect(await mount()).toContain('This server’s own encrypted database');
+    });
+
+    it('says what the database choice means for backups, before it is made', async () => {
+        await mount();
+        expect(host.textContent).not.toMatch(/every .{0,10}backup/i);
+
+        await click(/encrypted database/);
+
+        // The specific consequence, in the specific words that matter: the keys
+        // are in every backup, and backups leave this server.
+        expect(host.textContent).toMatch(/backup/i);
+        expect(host.textContent).toMatch(/copied off this server/i);
+    });
+
+    it('records the choice', async () => {
+        await mount();
+        await click(/encrypted database/);
+        await click(/Use this store/);
+
+        expect(chosen).toEqual(['database']);
+    });
+
+    it('will not submit until something is picked', async () => {
+        await mount();
+        expect((button(/Use this store/) as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('does not require the chosen vault to be working yet', async () => {
+        // The credentials that make a vault reachable are entered on this same
+        // page, so gating on reachability would be a loop with no way in.
+        await mount();
+        await click(/Azure Key Vault/);
+        expect((button(/Use this store/) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('gets out of the way once answered', async () => {
+        response = { chosen: true, store: 'azure', options: [], reachable: true };
+        const text = await mount();
+
+        expect(text).not.toMatch(/where should this town/i);
+        expect(text).toContain('Azure Key Vault');
+    });
+
+    it('says when the chosen vault is not reachable yet', async () => {
+        // Because anything saved now waits in the encrypted database, which is
+        // the window this whole gate is about.
+        response = { chosen: true, store: 'azure', options: [], reachable: false };
+        expect(await mount()).toMatch(/not reachable yet/i);
+    });
+
+    it('says nothing about reachability once the database is the store', async () => {
+        // It is the database. There is nowhere for anything to move to.
+        response = { chosen: true, store: 'database', options: [], reachable: false };
+        expect(await mount()).not.toMatch(/not reachable/i);
+    });
+
+    it('reports a refused choice rather than looking like it took', async () => {
+        await mount();
+        await click(/AWS Secrets Manager/);
+        refuseWith = 'the store is pinned by this deployment';
+        await click(/Use this store/);
+
+        expect(host.textContent).toContain('pinned by this deployment');
+        expect(host.textContent).toMatch(/where should this town/i);
+    });
+});

--- a/frontend/src/components/SecretStoreGate.tsx
+++ b/frontend/src/components/SecretStoreGate.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Lock, ShieldCheck, AlertCircle } from 'lucide-react';
+
+import { api } from '../services/api';
+import type { SecretStoreChoice } from '../services/api';
+
+/**
+ * The first question, and nothing can be entered before it is answered.
+ *
+ * Not tidiness, and not a preference. `_persist_secret` falls back to the
+ * encrypted database when the external store is unreachable, and reports that
+ * it did. `vault_secrets` later sweeps those rows into the store and scrubs the
+ * database copy -- on a schedule, and again after every provider save -- so the
+ * live database heals itself and the whole thing looks harmless.
+ *
+ * Database *backups* taken inside that window do not heal. They keep the row
+ * forever and they go off-site: a pg_dump of a Pinpoint instance contains
+ * `COPY public.system_secrets (id, key_name, key_value, ...)`. Sweeping the
+ * live row reaches nothing that has already been dumped. So the credential has
+ * to not be written until somebody has decided where it belongs.
+ *
+ * The gate is on the *choice*, not on standing up a cloud vault. The encrypted
+ * database is one of the four answers, with the backup consequence written on
+ * screen rather than discovered later, and a town whose cloud procurement is
+ * unfinished is not dead-ended. What must not happen is a town landing there
+ * without being asked -- which is exactly what an unset `SECRETS_PROVIDER`
+ * quietly defaulting to Google used to arrange.
+ */
+
+const STORES: { id: string; name: string; blurb: string }[] = [
+    {
+        id: 'google',
+        name: 'Google Secret Manager',
+        blurb: 'Uses the Google Cloud account you set up below. Nothing to buy separately.',
+    },
+    {
+        id: 'azure',
+        name: 'Azure Key Vault',
+        blurb: 'The natural choice if the town already runs on Microsoft 365 or Azure.',
+    },
+    {
+        id: 'aws',
+        name: 'AWS Secrets Manager',
+        blurb: 'Uses your AWS account, or this server’s instance role if it has one.',
+    },
+    {
+        id: 'database',
+        name: 'This server’s own encrypted database',
+        blurb: 'No cloud account needed. Read the note below before choosing it.',
+    },
+];
+
+const LABEL: Record<string, string> = Object.fromEntries(STORES.map(s => [s.id, s.name]));
+
+export default function SecretStoreGate({ onChosen }: {
+    /** So the page can re-enable everything it had disabled. */
+    onChosen?: () => void;
+} = {}) {
+    const [choice, setChoice] = useState<SecretStoreChoice | null>(null);
+    const [picked, setPicked] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(() => {
+        api.getSecretStore()
+            .then(setChoice)
+            /* Silent, and it leaves `choice` null so nothing is rendered. The
+             * backend refuses the credential regardless -- this panel explains
+             * the refusal, it does not enforce it -- so a panel that cannot
+             * load its own state is better absent than guessing. */
+            .catch(() => undefined);
+    }, []);
+    useEffect(load, [load]);
+
+    if (!choice) return null;
+
+    if (choice.chosen) {
+        return (
+            <p className="flex items-center gap-2 text-[11px] text-emerald-300/70">
+                <ShieldCheck className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                Credentials on this page are kept in{' '}
+                <strong className="text-emerald-200/90 font-semibold">
+                    {LABEL[choice.store ?? ''] ?? choice.store}
+                </strong>
+                {choice.store !== 'database' && !choice.reachable && (
+                    <span className="text-white/50">
+                        · not reachable yet, so anything saved now waits in the encrypted
+                        database and moves across on its own
+                    </span>
+                )}
+            </p>
+        );
+    }
+
+    return (
+        <div role="region" aria-label="Choose a secret store"
+            className="rounded-xl border border-amber-400/30 bg-amber-500/[0.07] p-4">
+            <div className="flex items-start gap-2.5">
+                <Lock className="w-4 h-4 text-amber-300/90 mt-0.5 shrink-0" aria-hidden="true" />
+                <div className="min-w-0">
+                    <p className="text-sm font-semibold text-white">
+                        First: where should this town’s credentials be kept?
+                    </p>
+                    <p className="text-xs text-white/60 leading-relaxed mt-1">
+                        Nothing below will accept a key until this is answered. Every password and
+                        API key on this page goes to whichever of these you pick, and moving them
+                        afterwards is not something a click can do — so it is asked once, first,
+                        rather than assumed.
+                    </p>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5 mt-3.5">
+                {/* Every store this build knows about, unless the server
+                    narrowed the list. An absent `options` is a response that
+                    did not say, and offering nothing at all would be a gate
+                    with no way through it -- this panel is the only place the
+                    choice can be made. */}
+                {STORES.filter(s => !choice.options || choice.options.includes(s.id)).map(store => (
+                    <button
+                        key={store.id}
+                        type="button"
+                        onClick={() => { setPicked(store.id); setError(null); }}
+                        aria-pressed={picked === store.id}
+                        className={`text-left px-3.5 py-3 rounded-xl border transition-colors ${picked === store.id
+                            ? 'bg-primary-500/20 border-primary-400/50'
+                            : 'bg-white/[0.04] border-white/10 hover:border-white/25'}`}
+                    >
+                        <p className="text-sm font-semibold text-white">{store.name}</p>
+                        <p className="text-[11px] text-white/55 leading-relaxed mt-0.5">{store.blurb}</p>
+                    </button>
+                ))}
+            </div>
+
+            {/* Spelled out rather than implied, and only when it is the answer
+                being considered. This is the whole reason the database is an
+                allowed choice instead of a fallback: a town may reasonably pick
+                it, and cannot reasonably pick it without knowing this. */}
+            {picked === 'database' && (
+                <div className="mt-3 rounded-lg border border-white/15 bg-black/25 px-3.5 py-3">
+                    <p className="text-xs text-amber-100/85 leading-relaxed">
+                        <strong className="text-amber-100">What this means.</strong> Your credentials
+                        are encrypted in this deployment’s own PostgreSQL database. They are also in
+                        every <strong>backup</strong> of it — and backups are copied off this server.
+                        Anyone who can read a backup file can read the keys, so treat those backups
+                        the way the town treats its other secrets: encrypted, access-controlled, and
+                        not sitting in a shared drive.
+                    </p>
+                    <p className="text-xs text-white/50 leading-relaxed mt-2">
+                        This is a supported choice and a reasonable one for a small install. You can
+                        move to a cloud vault later; the credentials migrate across when you do.
+                    </p>
+                </div>
+            )}
+
+            {error && (
+                <p role="alert" className="text-xs text-red-200 mt-3">{error}</p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-2.5 mt-3.5">
+                <button
+                    type="button"
+                    disabled={!picked || saving}
+                    onClick={async () => {
+                        if (!picked) return;
+                        setSaving(true); setError(null);
+                        try {
+                            setChoice(await api.chooseSecretStore(picked));
+                            onChosen?.();
+                        } catch (err: any) {
+                            setError(err?.message || 'That could not be saved.');
+                        } finally {
+                            setSaving(false);
+                        }
+                    }}
+                    className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                >
+                    {saving ? 'Saving…' : 'Use this store'}
+                </button>
+                <span className="inline-flex items-center gap-1.5 text-[11px] text-white/45">
+                    <AlertCircle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                    Picking a cloud vault here does not require it to be working yet.
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/ServiceProviders.switchedoff.test.tsx
+++ b/frontend/src/components/ServiceProviders.switchedoff.test.tsx
@@ -38,10 +38,10 @@ let host: HTMLDivElement; let root: Root;
 beforeEach(() => { host = document.createElement('div'); document.body.appendChild(host); root = createRoot(host); });
 afterEach(() => { act(() => root.unmount()); host.remove(); vi.clearAllMocks(); });
 
-async function mount(show?: Set<string>) {
+async function mount(show?: Set<string>, statusMap?: Record<string, unknown>) {
     const { default: ServiceProviders } = await import('./ServiceProviders');
     await act(async () => {
-        root.render(React.createElement(ServiceProviders as any, { show }));
+        root.render(React.createElement(ServiceProviders as any, { show, statusMap }));
     });
     return host.textContent || '';
 }
@@ -63,6 +63,43 @@ describe('capabilities the town switched off', () => {
     it('says nothing when the town asked for everything', async () => {
         const text = await mount(new Set(['ai', 'translation', 'email', 'sms', 'kms', 'redaction']));
         expect(text).not.toContain('Switched off');
+    });
+
+    /* The requirement, in the reporter's words: "I can for example save an
+     * email or AI key but not use it and then this is reflected in the service
+     * provider card but things are still saved."
+     *
+     * Half of that was already true -- the card disappeared into this section.
+     * The other half was not said anywhere, and the safe assumption from a
+     * greyed-out tile is that whatever was entered has gone, which makes
+     * switching something off feel like throwing work away. */
+    it('says when a switched-off capability still has its credentials', async () => {
+        const text = await mount(new Set(['ai']), {
+            sms: { current_provider: 'twilio', configured: { twilio: true }, enabled: false },
+        });
+
+        expect(text).toContain('Switched off — credentials still saved');
+        expect(text).toMatch(/Nothing was deleted/);
+    });
+
+    it('does not claim credentials for one that never had any', async () => {
+        const text = await mount(new Set(['ai']), {
+            sms: { current_provider: 'twilio', configured: { twilio: false }, enabled: false },
+        });
+
+        expect(text).toContain('Not switched on');
+        expect(text).not.toMatch(/Nothing was deleted/);
+    });
+
+    it('does not claim credentials for a provider the town has since left', async () => {
+        // `configured` is per provider for a reason: a town that set up Twilio
+        // and then selected a gateway it has entered nothing for has no stored
+        // credentials for the provider in use.
+        const text = await mount(new Set(['ai']), {
+            sms: { current_provider: 'http', configured: { twilio: true }, enabled: false },
+        });
+
+        expect(text).not.toMatch(/Nothing was deleted/);
     });
 
     it('never lists sign-in or maps, which cannot be switched off', async () => {

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -148,6 +148,18 @@ export interface CapStatus {
     /** Whether the in-use provider has its credentials stored. undefined means
      *  the endpoint did not say, which is not the same as no. */
     configured?: boolean;
+    /** Whether the town wants this capability at all.
+     *
+     *  Independent of `configured`, and that independence is the point. A town
+     *  can save an email or an AI key and decide not to use it; the credential
+     *  stays stored and readable and nothing dispatches through it. Before this
+     *  existed the only way to stop a configured capability was to delete the
+     *  credential, so "we are not using this" and "this was never set up" were
+     *  the same state on screen and in the database.
+     *
+     *  undefined means the endpoint did not say, which reads as on -- an absent
+     *  answer must not switch a town's email off. */
+    enabled?: boolean;
 }
 
 /** What the last live check found, as one word the rest of the page can sort on.
@@ -181,6 +193,17 @@ export function healthIsAboutCurrentProvider(
 
 export function capabilityState(s: CapStatus | undefined, health?: ConnectorHealth): CapabilityState | null {
     if (!s) return null;                      // catalog still loading
+    /* First, and ahead of `configured`, because it overrides it in both
+     * directions.
+     *
+     * Switched off with credentials saved is not "working" -- nothing runs
+     * through it -- and switched off with nothing saved is still not "not set
+     * up", because the town has answered the question. Either way there is
+     * nothing here for anyone to do, which is what separates this from every
+     * other state on this list. Health is not consulted at all: a stored
+     * verdict about a capability nobody is using describes a call that no
+     * longer happens. */
+    if (s.enabled === false) return 'off';
     if (!s.configured) return 'unset';
     // Anything the current provider did not produce says nothing about it.
     if (!healthIsAboutCurrentProvider(s, health)) health = undefined;
@@ -1157,7 +1180,7 @@ export interface PlainSecretsBridge {
     onSaved: () => void;
 }
 
-export default function ServiceProviders({ show, extras, footer, extraOff = [], plainSettings = [], plainSecrets, refreshToken = 0, onChanged, publicOrigin = null }: {
+export default function ServiceProviders({ show, statusMap, extras, footer, extraOff = [], plainSettings = [], plainSecrets, refreshToken = 0, onChanged, publicOrigin = null }: {
     /* Which capabilities the town said it wants, from the setup questions.
      * Undefined means "no answer yet", which shows everything -- an absent
      * answer must not read as "wanted nothing", the same distinction the
@@ -1167,6 +1190,15 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
      * them, so hiding them behind a question would let someone opt out of
      * having a working system. */
     show?: Set<Capability>;
+    /* What the server says about each capability, for the ones no card is
+     * drawn for.
+     *
+     * A switched-off capability has no card, so nothing fetches its catalog and
+     * this section cannot otherwise tell "switched off, key still saved" from
+     * "switched off, never configured". Those need different sentences: the
+     * first has to say the credentials are still there, or the obvious reading
+     * of a greyed-out tile is that switching it back on means starting over. */
+    statusMap?: import('../services/api').ProviderStatusMap | null;
     /* The settings that are not a provider choice -- the Google Cloud
      * credentials, error reporting, database backups. They lived in a second
      * collapsible section beside this one, which meant two places to look for
@@ -1279,6 +1311,19 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
      * Listed, not offered. Turning one on means going through its setup, and a
      * toggle here that quietly enabled a capability with no credentials behind
      * it would be a switch that appears to work and does nothing. */
+    /* Whether the credentials for a switched-off capability are still stored.
+     *
+     * The requirement in the reporter's own words: "I can for example save an
+     * email or AI key but not use it and then this is reflected in the service
+     * provider card but things are still saved." A tile that only says "not
+     * switched on" leaves the second half unanswered, and the safe assumption
+     * from a greyed-out card is that whatever was entered has gone. */
+    const stillSaved = (id: string): boolean => {
+        const entry = statusMap?.[id];
+        const provider = entry?.current_provider;
+        return !!provider && entry?.configured?.[provider] === true;
+    };
+
     const notChosen = [
         ...(show ? CAPS.filter(c => !ALWAYS.has(c.key) && !show.has(c.key)) : []).map(c => ({
             id: c.key as string, title: c.title, blurb: c.blurb, icon: c.icon,
@@ -1319,7 +1364,14 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
      * behaviour, and giving them a second piece of open-state would let two
      * cards be open at once. */
     const [openCap, setOpenCap] = useState<string | null>(null);
-    const capState = (cap: Capability) => capabilityState(statuses[cap], health[cap]);
+    /* `show` is the town's answer to "do you want this", so it is also the
+     * `enabled` the state machine needs -- derived here rather than passed in
+     * again, because two props carrying the same fact is how the page ended up
+     * with a questionnaire and a set of cards that could disagree. */
+    const capState = (cap: Capability) => capabilityState(
+        { ...statuses[cap], enabled: !show || ALWAYS.has(cap) || show.has(cap) },
+        health[cap],
+    );
 
     /* Rendered above the cards. A town whose health table cannot be read
      * should be told that, rather than shown ten badges that all say "not
@@ -1459,10 +1511,25 @@ export default function ServiceProviders({ show, extras, footer, extraOff = [], 
                                     </span>
                                     <div className="min-w-0 flex-1">
                                         <p className="font-semibold text-white/75 text-sm truncate">{c.title}</p>
-                                        <p className="text-[11px] text-white/50">Not switched on</p>
+                                        <p className="text-[11px] text-white/50">
+                                            {stillSaved(c.id)
+                                                ? 'Switched off — credentials still saved'
+                                                : 'Not switched on'}
+                                        </p>
                                     </div>
                                 </div>
                                 <p className="text-[11px] text-white/55 mt-2.5 leading-relaxed line-clamp-2">{c.blurb}</p>
+                                {stillSaved(c.id) && (
+                                    /* Said on the tile, not in the paragraph at
+                                       the foot of the section. Whether *this*
+                                       one still has its key is a fact about
+                                       this capability, and a clerk deciding
+                                       whether to switch it back on is looking
+                                       at the tile. */
+                                    <p className="text-[11px] text-emerald-200/60 mt-1.5">
+                                        Nothing was deleted. Switch it back on and it works as it did.
+                                    </p>
+                                )}
                             </div>
                         ))}
                     </div>

--- a/frontend/src/components/SetupIntegrationsPage.firstrun.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.firstrun.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * A fresh install has to be shown the guide, and a finished town has to be left
+ * alone.
+ *
+ * Nothing detected a fresh install. The guide opened itself on
+ * `!signInConfigured || !mapsConfigured`, which is "is everything set up"
+ * wearing a disguise -- and that never goes true for a town that deliberately
+ * switches most things off, so the guide would greet it on every login forever.
+ * A banner that never goes away is one people stop reading.
+ *
+ * Being finished is a thing a person says, and this is where they say it.
+ */
+
+let setupState: { completed: boolean; completed_at: string | null } = {
+    completed: false, completed_at: null,
+};
+const marked: string[] = [];
+let refuseMark: string | null = null;
+
+/* framer-motion, reduced to plain elements.
+ *
+ * The setup guide's body lives inside an `AnimatePresence`, and in jsdom no
+ * animation ever completes -- so the subtree it is holding stops reflecting
+ * state and every assertion after a click reads a frozen snapshot. That is an
+ * artifact of the animation library in a headless DOM, not behaviour worth
+ * testing, and leaving it in place makes these tests pass for the wrong reason:
+ * a chip that never changes looks exactly like a chip that correctly rolled
+ * back. */
+vi.mock('framer-motion', async () => {
+    const React = await import('react');
+    const passthrough = (tag: string) => ({ children, ...props }: any) => {
+        const {
+            initial, animate, exit, transition, variants, whileHover, whileTap,
+            whileInView, layout, layoutId, drag, onAnimationComplete, ...rest
+        } = props;
+        return React.createElement(tag, rest, children);
+    };
+    /* Cached per tag. A Proxy that builds a fresh component on every access
+     * hands React a new element *type* on every render, which remounts the
+     * subtree every time -- an infinite loop, not a passthrough. */
+    const cache = new Map<string, any>();
+    const motion: any = new Proxy({}, {
+        get: (_t, tag: string) => {
+            if (!cache.has(tag)) cache.set(tag, passthrough(tag));
+            return cache.get(tag);
+        },
+    });
+    return {
+        motion,
+        AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+        useReducedMotion: () => true,
+    };
+});
+
+vi.mock('../services/api', () => {
+    const shapes: Record<string, unknown> = {
+        getConfig: { public_origin: 'https://town.gov' },
+        getProviderStatus: {},
+        getConnectorHealth: { connectors: [] },
+        getCloudIdentity: null,
+        getSecretStore: { chosen: true, store: 'database', options: [], reachable: false },
+        getStorageStatus: { secrets: { store: 'database', count: 0, reachable: false }, pii: {} },
+        getProviderCatalog: {
+            capability: 'ai', current_provider: 'vertex', providers: [], configured: {},
+        },
+        getCloudProfile: {
+            profile: 'google', managed: false, profiles: [],
+            components: { identity: 'auth0' }, maps: { label: 'Google Maps' },
+        },
+    };
+    const listish = /^(list|get)[A-Za-z]*(s|List|Configs|Layers|Errors|Catalog)$/;
+    const api: any = new Proxy({}, {
+        get: (_t, prop: string) => {
+            if (prop === 'getSetupState') return vi.fn(async () => setupState);
+            if (prop === 'markSetupComplete') {
+                return vi.fn(async () => {
+                    if (refuseMark) throw new Error(refuseMark);
+                    marked.push('done');
+                    setupState = { completed: true, completed_at: '2026-08-04T00:00:00Z' };
+                    return setupState;
+                });
+            }
+            return vi.fn().mockResolvedValue(
+                prop in shapes ? shapes[prop] : listish.test(prop) ? [] : {},
+            );
+        },
+    });
+    return { default: api, api };
+});
+
+let host: HTMLDivElement;
+let root: Root;
+
+const props: any = {
+    // Non-empty, because the old trigger waited on it and a regression to that
+    // shape should not be masked by the prop being empty.
+    secrets: [{ id: 1, key_name: 'AUTH0_DOMAIN', is_configured: true }],
+    onSaveSecret: vi.fn().mockResolvedValue(undefined),
+    onRefresh: vi.fn(),
+};
+
+async function mount() {
+    const { default: Page } = await import('./SetupIntegrationsPage');
+    await act(async () => { root.render(React.createElement(Page, props)); });
+    return host.textContent || '';
+}
+
+/** The guide's body is only in the DOM when it is open. */
+function guideIsOpen() {
+    return /Answer a few questions and we will hide the rest/.test(host.textContent || '');
+}
+
+function button(pattern: RegExp): HTMLElement | undefined {
+    return Array.from(host.querySelectorAll('button'))
+        .find(b => pattern.test(b.textContent || '')) as HTMLElement | undefined;
+}
+
+beforeEach(() => {
+    setupState = { completed: false, completed_at: null };
+    marked.length = 0;
+    refuseMark = null;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+});
+afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllMocks();
+});
+
+describe('the first-run guide', () => {
+    it('opens itself when nobody has said setup is finished', async () => {
+        await mount();
+        expect(guideIsOpen()).toBe(true);
+    });
+
+    it('stays shut once somebody has', async () => {
+        setupState = { completed: true, completed_at: '2026-01-01T00:00:00Z' };
+        await mount();
+        expect(guideIsOpen()).toBe(false);
+    });
+
+    it('stays shut even with everything still unconfigured', async () => {
+        // The old trigger, and the case it got wrong. `getProviderStatus`
+        // answers `{}` here, so nothing on this page is set up -- a town that
+        // switched most things off deliberately looks exactly like this, and
+        // was greeted by the guide on every login forever.
+        setupState = { completed: true, completed_at: '2026-01-01T00:00:00Z' };
+        const text = await mount();
+
+        expect(text).toMatch(/still to set up|still need credentials/i);
+        expect(guideIsOpen()).toBe(false);
+    });
+
+    it('offers a way to say so, and stops opening after it is used', async () => {
+        await mount();
+        expect(guideIsOpen()).toBe(true);
+
+        const finish = button(/done with setup/i);
+        expect(finish).toBeTruthy();
+        await act(async () => { finish!.click(); });
+
+        expect(marked).toEqual(['done']);
+
+        /* The promise is about the *next* sign-in, so check the next one.
+         *
+         * Not the DOM in this session: the panel is inside an AnimatePresence,
+         * which holds the outgoing children until an exit animation that jsdom
+         * never runs. Asserting on them would be asserting on the animation
+         * library. The flag is the thing that has to survive. */
+        await act(async () => { root.unmount(); });
+        root = createRoot(host);
+        await mount();
+        expect(guideIsOpen()).toBe(false);
+        expect(button(/done with setup/i)).toBeUndefined();
+    });
+
+    it('does not offer it to a town that has already finished', async () => {
+        setupState = { completed: true, completed_at: '2026-01-01T00:00:00Z' };
+        await mount();
+        // Reopen by hand -- the tab is still here and the panel still opens.
+        const header = Array.from(host.querySelectorAll('button'))
+            .find(b => /Setup Instructions/.test(b.textContent || '')) as HTMLElement;
+        await act(async () => { header.click(); });
+
+        expect(guideIsOpen()).toBe(true);
+        expect(button(/done with setup/i)).toBeUndefined();
+    });
+
+    it('does not gate finishing on the checklist being green', async () => {
+        // Two things are actually required and the panel says which. A guide
+        // that will not let go until a count reaches zero is the thing standing
+        // between somebody and their console.
+        await mount();
+        expect((button(/done with setup/i) as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('stays shut when the server cannot be asked', async () => {
+        // Unknown is not "unfinished". A failed request must not throw the
+        // guide open over the top of a console somebody is trying to use.
+        setupState = null as any;
+        await mount();
+        expect(guideIsOpen()).toBe(false);
+    });
+
+    it('says what closing it actually does', async () => {
+        // It is not "hide this forever": the tab is still there and the panel
+        // still opens. All the flag settles is what happens on sign-in, and a
+        // button that reads like a permanent dismissal does not get pressed.
+        await mount();
+        expect(host.textContent).toMatch(/come back to it from this tab/i);
+    });
+});

--- a/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.smoke.test.tsx
@@ -55,8 +55,6 @@ const props: any = {
     secrets: [],
     onSaveSecret: vi.fn().mockResolvedValue(undefined),
     onRefresh: vi.fn(),
-    modules: { ai_analysis: false },
-    onUpdateModules: vi.fn().mockResolvedValue(undefined),
 };
 
 async function mount() {

--- a/frontend/src/components/SetupIntegrationsPage.switches.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.switches.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Unticking a feature has to leave the browser.
+ *
+ * It did not. The questionnaire held its answer in
+ * `useState<Set<string>>(new Set(ALL_FEATURES))`, read by nothing outside the
+ * render and written to nothing at all -- so unticking a feature hid a section
+ * of the setup guide, survived until the next reload, and switched nothing off.
+ * The label above the chips read "untick to remove it".
+ *
+ * The consequence is not cosmetic. A town could save an AI or email credential
+ * and then decide not to use it, and had no way to say so: the only thing that
+ * stopped a configured capability was deleting the key it had just been asked
+ * to paste in.
+ */
+
+const calls: { switches: Record<string, boolean> }[] = [];
+let statusResponse: Record<string, unknown> = {};
+/* The mock is a Proxy whose `get` builds a fresh fn per access, so a test
+ * cannot swap one method out by assigning to it. Refusal is a flag the mocked
+ * method reads instead. */
+let refuseWith: string | null = null;
+
+vi.mock('../services/api', () => {
+    const shapes: Record<string, unknown> = {
+        getConfig: { public_origin: 'https://town.gov' },
+        getConnectorHealth: { connectors: [] },
+        getCloudIdentity: null,
+        getStorageStatus: { secrets: { store: 'google', count: 0, reachable: true }, pii: {} },
+        getProviderCatalog: {
+            capability: 'ai', current_provider: 'vertex', providers: [], configured: {},
+        },
+        getCloudProfile: {
+            profile: 'google', managed: false, profiles: [],
+            components: { identity: 'auth0' }, maps: { label: 'Google Maps' },
+        },
+    };
+    const listish = /^(list|get)[A-Za-z]*(s|List|Configs|Layers|Errors|Catalog)$/;
+    const api: any = new Proxy({}, {
+        get: (_t, prop: string) => {
+            if (prop === 'getProviderStatus') return vi.fn(async () => statusResponse);
+            if (prop === 'setCapabilitySwitches') {
+                return vi.fn(async (switches: Record<string, boolean>) => {
+                    if (refuseWith) throw new Error(refuseWith);
+                    calls.push({ switches });
+                    return { switches };
+                });
+            }
+            return vi.fn().mockResolvedValue(
+                prop in shapes ? shapes[prop] : listish.test(prop) ? [] : {},
+            );
+        },
+    });
+    return { default: api, api };
+});
+
+let host: HTMLDivElement;
+let root: Root;
+
+const props: any = {
+    secrets: [],
+    onSaveSecret: vi.fn().mockResolvedValue(undefined),
+    onRefresh: vi.fn(),
+};
+
+async function mount() {
+    const { default: Page } = await import('./SetupIntegrationsPage');
+    await act(async () => { root.render(React.createElement(Page, props)); });
+    // The guide is collapsed until something asks for it; the chips live inside.
+    await click('Setup Instructions');
+}
+
+function findByText(pattern: RegExp): HTMLElement | undefined {
+    return Array.from(host.querySelectorAll('button, h3'))
+        .find(el => pattern.test(el.textContent || '')) as HTMLElement | undefined;
+}
+
+async function click(text: string | RegExp) {
+    const el = findByText(typeof text === 'string' ? new RegExp(`^\\s*(✓ )?${text}\\s*$`) : text);
+    if (!el) throw new Error(`no clickable element matching ${text}`);
+    await act(async () => { el.click(); });
+}
+
+beforeEach(() => {
+    calls.length = 0;
+    statusResponse = {};
+    refuseWith = null;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+});
+afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.clearAllMocks();
+});
+
+describe('the feature ticks', () => {
+    it('sends the change to the server', async () => {
+        await mount();
+        await click('AI triage');
+
+        expect(calls).toEqual([{ switches: { ai: false } }]);
+    });
+
+    it('sends the capability id, not the question a clerk was asked', async () => {
+        // "Screening and blurring" is the chip; `redaction` is the thing that
+        // gets switched off. The two vocabularies meet in exactly one place.
+        await mount();
+        await click('Screening and blurring');
+
+        expect(calls).toEqual([{ switches: { redaction: false } }]);
+    });
+
+    it('carries backups and crash reporting under their own ids', async () => {
+        // They are switchable and have no provider catalog, so they were held
+        // in the browser and nowhere else -- which is the pair somebody is most
+        // likely to untick and then wonder where it went.
+        await mount();
+        await click('Backups');
+
+        expect(calls).toEqual([{ switches: { backups: false } }]);
+    });
+
+    it('sends only what changed', async () => {
+        // A town that has never been asked about photo redaction must not
+        // acquire an answer to it because somebody unticked backups.
+        await mount();
+        await click('Backups');
+
+        expect(Object.keys(calls[0].switches)).toEqual(['backups']);
+    });
+
+    it('starts from what the server says, not from everything ticked', async () => {
+        // The reload half. Before this the initial value *was* the answer, so a
+        // town that had switched AI off saw it ticked again on every load.
+        statusResponse = { ai: { enabled: false }, email: { enabled: true } };
+        await mount();
+
+        const ai = findByText(/^\s*(✓ )?AI triage\s*$/);
+        const email = findByText(/^\s*(✓ )?Email\s*$/);
+        expect(ai?.getAttribute('aria-pressed')).toBe('false');
+        expect(email?.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('treats a capability the server said nothing about as on', async () => {
+        // An absent answer must not read as "the town switched this off".
+        statusResponse = { ai: {} };
+        await mount();
+
+        expect(findByText(/^\s*(✓ )?AI triage\s*$/)?.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('puts the chip back when the write is refused', async () => {
+        // A tick that stays ticked while the server has no record of it is the
+        // original bug wearing a round trip.
+        await mount();
+        refuseWith = 'nope';
+        await click('AI triage');
+
+        expect(findByText(/^\s*(✓ )?AI triage\s*$/)?.getAttribute('aria-pressed')).toBe('true');
+        expect(host.textContent).toContain('nope');
+    });
+
+    it('says that switching one off does not delete what was entered', async () => {
+        await mount();
+        expect(host.textContent).toMatch(/stays saved/i);
+    });
+});

--- a/frontend/src/components/SetupIntegrationsPage.switches.test.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.switches.test.tsx
@@ -27,6 +27,41 @@ let statusResponse: Record<string, unknown> = {};
  * method reads instead. */
 let refuseWith: string | null = null;
 
+/* framer-motion, reduced to plain elements.
+ *
+ * The setup guide's body lives inside an `AnimatePresence`, and in jsdom no
+ * animation ever completes -- so the subtree it is holding stops reflecting
+ * state and every assertion after a click reads a frozen snapshot. That is an
+ * artifact of the animation library in a headless DOM, not behaviour worth
+ * testing, and leaving it in place makes these tests pass for the wrong reason:
+ * a chip that never changes looks exactly like a chip that correctly rolled
+ * back. */
+vi.mock('framer-motion', async () => {
+    const React = await import('react');
+    const passthrough = (tag: string) => ({ children, ...props }: any) => {
+        const {
+            initial, animate, exit, transition, variants, whileHover, whileTap,
+            whileInView, layout, layoutId, drag, onAnimationComplete, ...rest
+        } = props;
+        return React.createElement(tag, rest, children);
+    };
+    /* Cached per tag. A Proxy that builds a fresh component on every access
+     * hands React a new element *type* on every render, which remounts the
+     * subtree every time -- an infinite loop, not a passthrough. */
+    const cache = new Map<string, any>();
+    const motion: any = new Proxy({}, {
+        get: (_t, tag: string) => {
+            if (!cache.has(tag)) cache.set(tag, passthrough(tag));
+            return cache.get(tag);
+        },
+    });
+    return {
+        motion,
+        AnimatePresence: ({ children }: any) => React.createElement(React.Fragment, null, children),
+        useReducedMotion: () => true,
+    };
+});
+
 vi.mock('../services/api', () => {
     const shapes: Record<string, unknown> = {
         getConfig: { public_origin: 'https://town.gov' },
@@ -72,8 +107,13 @@ const props: any = {
 async function mount() {
     const { default: Page } = await import('./SetupIntegrationsPage');
     await act(async () => { root.render(React.createElement(Page, props)); });
-    // The guide is collapsed until something asks for it; the chips live inside.
-    await click('Setup Instructions');
+    await settle(2);
+    /* The chips live inside the guide. It opens itself on a town that has not
+     * said setup is finished -- which this one has not, because `getSetupState`
+     * is unmocked here -- so clicking unconditionally would close it. */
+    if (!/What do you want to switch on/.test(host.textContent || '')) {
+        await click('Setup Instructions');
+    }
 }
 
 function findByText(pattern: RegExp): HTMLElement | undefined {
@@ -85,6 +125,27 @@ async function click(text: string | RegExp) {
     const el = findByText(typeof text === 'string' ? new RegExp(`^\\s*(✓ )?${text}\\s*$`) : text);
     if (!el) throw new Error(`no clickable element matching ${text}`);
     await act(async () => { el.click(); });
+    await settle();
+}
+
+/* The click handler is async and act does not await it, so the state update on
+ * the far side of the round trip lands after act returns -- and React may
+ * schedule the render itself a task later again. One tick is not reliably
+ * enough: the refusal case passed alone and failed in a full run, which is the
+ * worst kind of green. */
+async function settle(ticks = 3) {
+    for (let i = 0; i < ticks; i++) {
+        await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
+    }
+}
+
+/** Wait for the DOM to say something, rather than guessing how many ticks. */
+async function waitForText(pattern: RegExp, tries = 20) {
+    for (let i = 0; i < tries; i++) {
+        if (pattern.test(host.textContent || '')) return;
+        await settle(1);
+    }
+    throw new Error(`never rendered ${pattern}. Text was: ${(host.textContent || '').slice(0, 400)}`);
 }
 
 beforeEach(() => {
@@ -164,8 +225,8 @@ describe('the feature ticks', () => {
         refuseWith = 'nope';
         await click('AI triage');
 
+        await waitForText(/nope/);
         expect(findByText(/^\s*(✓ )?AI triage\s*$/)?.getAttribute('aria-pressed')).toBe('true');
-        expect(host.textContent).toContain('nope');
     });
 
     it('says that switching one off does not delete what was entered', async () => {

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -20,6 +20,7 @@ import { buildPlan, summarise, nameList, BACKUP_SECRETS, SENTRY_SECRETS } from '
 // render them inline rather than pointing at the cards that do.
 import './setupStepsContent';
 import StorageStatusLine from './StorageStatusLine';
+import SecretStoreGate from './SecretStoreGate';
 import SecretField from './SecretField';
 import { openStayInformed } from './StayInformed';
 
@@ -1047,6 +1048,13 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                         the steps say exactly where to click.
                                     </p>
                                 </div>
+
+                                {/* Above the questions, because it gates them.
+                                    Nothing below accepts a credential until it
+                                    is answered, and a form that refuses a save
+                                    without saying why in advance is worse than
+                                    one that asks first. */}
+                                <SecretStoreGate onChosen={() => setProviderRefresh(t => t + 1)} />
 
                                 <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
                                     <p className="text-sm font-semibold text-white mb-0.5">Answer a few questions and we will hide the rest</p>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -349,14 +349,24 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const [backupKey, setBackupKey] = useState<string | null>(null);
     const [backupKeyAcknowledged, setBackupKeyAcknowledged] = useState(false);
 
-    /* The guide starts open on a fresh install and closed once the required
-     * integrations are in. It is a first-run document: hidden behind a click it
-     * is missed by the person who needs it most, and left open forever it pushes
-     * the actual controls off the screen for everyone else.
+    /* The guide starts open until somebody says setup is finished, and closed
+     * after that. It is a first-run document: hidden behind a click it is missed
+     * by the person who needs it most, and left open forever it pushes the
+     * actual controls off the screen for everyone else.
+     *
+     * It used to open on `!signInConfigured || !mapsConfigured`, which is "is
+     * everything set up" wearing a disguise. That never goes true for a town
+     * that deliberately switches most things off, and a guide that greets you on
+     * every login forever is one people stop reading. Being finished is a thing
+     * a person says; `setupDone` is where they said it.
      *
      * null means "not decided yet" so the effect below can set it once the
      * config has loaded, without overriding a deliberate click afterwards. */
     const [expandedGuide, setExpandedGuide] = useState<string | null>(null);
+    /* undefined until the server answers. Deciding before then would throw the
+     * guide open at a town that finished setup a year ago. */
+    const [setupDone, setSetupDone] = useState<boolean | undefined>(undefined);
+    const [finishing, setFinishing] = useState(false);
     const guideAutoSet = useRef(false);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
@@ -695,14 +705,34 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const completedCount = setupSteps.filter(s => s.done).length;
 
     useEffect(() => {
-        // secrets arrives as a prop; an empty array means it has not loaded yet.
-        // Provider status likewise: this fires once, so deciding before the
-        // answer arrives would throw the guide open at a town that has
-        // everything set up, and never reconsider.
-        if (guideAutoSet.current || secrets.length === 0 || !providerStatus) return;
+        api.getSetupState()
+            .then(s => setSetupDone(!!s.completed))
+            /* Unknown is not "unfinished". A failed request must not throw the
+             * guide open over the top of a console somebody is trying to use. */
+            .catch(() => setSetupDone(true));
+    }, []);
+
+    useEffect(() => {
+        // Fires once, and only once the server has said. Deciding earlier would
+        // open the guide at a town that finished setup long ago and then never
+        // reconsider, because this does not run again.
+        if (guideAutoSet.current || setupDone === undefined) return;
         guideAutoSet.current = true;
-        if (!signInConfigured || !mapsConfigured) setExpandedGuide('master');
-    }, [secrets.length, providerStatus, signInConfigured, mapsConfigured]);
+        if (!setupDone) setExpandedGuide('master');
+    }, [setupDone]);
+
+    const finishSetup = async () => {
+        setFinishing(true);
+        try {
+            await api.markSetupComplete();
+            setSetupDone(true);
+            setExpandedGuide(null);
+        } catch (err: any) {
+            setSaveMessage(`❌ ${err?.message || 'That could not be saved'}`);
+        } finally {
+            setFinishing(false);
+        }
+    };
 
     // Toggle helper for collapsible instruction panels
     const toggleGuide = (id: string) => setExpandedGuide(prev => prev === id ? null : id);
@@ -1098,7 +1128,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                         )}
                                         <p className="text-[11px] text-white/45 mt-2">
                                             Unticking one switches it off and stops it running. Anything you
-                                            have already entered stays saved \u2014 switch it back on and it works
+                                            have already entered stays saved — switch it back on and it works
                                             as it did.
                                         </p>
                                     </Ask>
@@ -1198,6 +1228,42 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                     publicOrigin={publicOrigin}
                                     renderFoundation={renderFoundation}
                                 />
+
+                                {/* The only way the guide stops opening itself.
+                                  *
+                                  * Not gated on the checklist being green, and
+                                  * not hidden until it is. Two things are
+                                  * actually required before a town can take a
+                                  * report and the panel above says which; a
+                                  * town that has deliberately switched
+                                  * everything else off is finished, and a guide
+                                  * that will not let go until a count reaches
+                                  * zero is the thing standing between somebody
+                                  * and their console.
+                                  *
+                                  * The tab is still here afterwards, and this
+                                  * panel still opens on a click. All this
+                                  * settles is what happens on sign-in. */}
+                                {setupDone === false && (
+                                    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 flex flex-wrap items-center gap-3">
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-sm font-semibold text-white">Finished for now?</p>
+                                            <p className="text-white/50 text-xs mt-0.5">
+                                                This guide opens by itself every time you sign in until you say so. You can
+                                                come back to it from this tab whenever you like, and anything still
+                                                outstanding stays listed on the cards below.
+                                            </p>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={finishSetup}
+                                            disabled={finishing}
+                                            className="inline-flex items-center gap-2 rounded-xl px-3.5 py-2 text-sm font-semibold text-white bg-primary-500 hover:bg-primary-400 border border-primary-400/50 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+                                        >
+                                            {finishing ? 'Saving…' : "I'm done with setup"}
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                         </motion.div>
                     )}

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -54,6 +54,35 @@ const FEATURES = [
 
 const ALL_FEATURES: readonly string[] = FEATURES.map(([id]) => id);
 
+/* Feature id -> capability id. The one mapping between the two vocabularies.
+ *
+ * At module scope because the persistence layer needs it too: a chip is
+ * "Screening and blurring" and the thing that gets switched off is `redaction`,
+ * and the toggle handler has to translate before it can post. It was declared
+ * inside the component, where nothing outside the render could reach it.
+ *
+ * Every id on both sides is the same word where it can be. The key-management
+ * tick was `secrets`, which became ambiguous the moment the secret store
+ * became a capability of its own -- one line of this object would have read
+ * `secrets: 'kms'` next to a real `secrets` capability meaning somewhere else
+ * entirely.
+ *
+ * `backups` and `errors` are absent: they are switchable, but they have no
+ * provider catalog and no capability, so they are carried under their own ids.
+ * The secret store is absent for the opposite reason -- it is not a feature a
+ * town ticks on, because every credential entered on this page is kept
+ * somewhere.
+ *
+ * Redaction used to hang off the `moderation` tick, which was wrong in both
+ * directions: unticking "content moderation" silently hid face blurring, and
+ * there was no way to have blurring without it. They are different decisions --
+ * one screens what a resident wrote, the other blurs a bystander who never
+ * wrote anything -- so they are separate ticks. */
+const FEATURE_TO_CAPABILITY: Record<string, Capability> = {
+    ai: 'ai', translation: 'translation', email: 'email',
+    sms: 'sms', kms: 'kms', safety: 'redaction',
+};
+
 function Ask({ n, label, hint, children }: {
     n: number; label: string; hint?: string; children: React.ReactNode;
 }) {
@@ -144,20 +173,18 @@ export function seedAnswersFrom(status: ProviderStatusMap | null): SeededAnswers
     };
 }
 
-interface ModulesState {
-    ai_analysis: boolean;
-    sms_alerts: boolean;
-    email_notifications: boolean;
-    research_portal: boolean;
-    unlisted_reports: boolean;
-}
-
+/* No `modules` prop any more.
+ *
+ * This page took one so that saving a Google project could switch
+ * `modules.ai_analysis` on -- reaching across to the System Settings screen to
+ * flip one of the two switches the same capability had. It owns the only switch
+ * now, and does not need the other screen's state to use it. `modules` keeps
+ * `unlisted_reports` and `research_portal`, which have no provider, no
+ * credentials and nothing to do with this page. */
 interface SetupIntegrationsPageProps {
     secrets: SystemSecret[];
     onSaveSecret: (key: string, value: string) => Promise<void>;
     onRefresh: () => void;
-    modules?: ModulesState;
-    onUpdateModules?: (modules: ModulesState) => Promise<void>;
 }
 
 
@@ -180,15 +207,15 @@ interface SetupIntegrationsPageProps {
  * that does not exist.
  */
 function GoogleAccountFields({
-secretValues, setSecretValues, handleSave, savingKey, isConfigured, modules, onUpdateModules,
+secretValues, setSecretValues, handleSave, savingKey, isConfigured, onWantAi,
 }: {
 secretValues: Record<string, string>;
 setSecretValues: React.Dispatch<React.SetStateAction<Record<string, string>>>;
 handleSave: (key: string) => Promise<void>;
 savingKey: string | null;
 isConfigured: (key: string) => boolean | undefined;
-modules: any;
-onUpdateModules?: (m: any) => Promise<void>;
+/** Switch AI on, because a town that just entered a Google project meant to. */
+onWantAi: () => Promise<void>;
 }) {
     const jsonKey = 'GCP_SERVICE_ACCOUNT_JSON';
     const [showKms, setShowKms] = useState(false);
@@ -283,10 +310,16 @@ onUpdateModules?: (m: any) => Promise<void>;
                     type="button"
                     onClick={async () => {
                         for (const k of pending) await handleSave(k);
-                        // AI cannot run without this, so having entered it
-                        // and left the module off is never what was meant.
-                        if (modules && onUpdateModules && secretValues['GOOGLE_CLOUD_PROJECT'] && !modules.ai_analysis) {
-                            await onUpdateModules({ ...modules, ai_analysis: true });
+                        /* AI cannot run without this, so having entered it and
+                           left AI switched off is never what was meant.
+
+                           This used to flip `modules.ai_analysis`, on the other
+                           screen, which was one of two switches for the same
+                           capability -- so it could turn AI on there while the
+                           tick on this very page still said the town did not
+                           want it. One switch now, and this is it. */
+                        if (secretValues['GOOGLE_CLOUD_PROJECT']) {
+                            await onWantAi();
                         }
                     }}
                     disabled={pending.length === 0 || savingKey !== null}
@@ -306,7 +339,7 @@ onUpdateModules?: (m: any) => Promise<void>;
 }
 
 
-export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh, modules, onUpdateModules }: SetupIntegrationsPageProps) {
+export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh }: SetupIntegrationsPageProps) {
     const [secretValues, setSecretValues] = useState<Record<string, string>>({});
     const [savingKey, setSavingKey] = useState<string | null>(null);
     // The backup passphrase is generated rather than invented, shown once, and
@@ -331,21 +364,50 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const [setupCloud, setSetupCloud] = useState<'google' | 'azure' | 'aws'>('google');
     const [setupIdp, setSetupIdp] = useState<'auth0' | 'entra' | 'okta' | 'oidc'>('auth0');
     const [setupMaps, setSetupMaps] = useState<'google' | 'esri' | 'azure' | 'apple'>('google');
-    /* Everything on, untick to hide.
+    /* What the town wants, held here only as a mirror of what the server says.
      *
-     * This started as opt-in with three ticked, which quietly set the default
-     * for every town that never touched it: a page that asks what you want,
-     * pre-answered "not much". A town that never opens this question should end
-     * up with the whole platform switched on, not the three we happened to
-     * pre-tick -- so the list below is every feature, and a town removes what
-     * it genuinely does not want. */
+     * This used to be the whole of it: `useState(new Set(ALL_FEATURES))`, never
+     * read from anywhere and never written anywhere. So unticking a feature hid
+     * a section of the guide, survived until the next reload, and switched
+     * nothing off -- while the label directly above it read "untick to remove
+     * it". A town could not express "I saved an AI key and I am not using it",
+     * and the only way to stop a configured capability was to delete the
+     * credential it had just been asked to paste in.
+     *
+     * The initial value stays "everything", and that is a loading state rather
+     * than a default: the effect below replaces it as soon as the server
+     * answers. Erring towards showing a step nobody needs beats hiding one
+     * somebody does.
+     *
+     * Optimistic on click, corrected by the response. A tick that waits for a
+     * round trip reads as a broken button, and the failure path matters more
+     * than the latency: if the write is refused, the chip must go back rather
+     * than sit there claiming an answer the server does not have. */
     const [wantedFeatures, setWantedFeatures] = useState<Set<string>>(new Set(ALL_FEATURES));
-    const toggleFeature = (f: string) =>
+    const [switchError, setSwitchError] = useState<string | null>(null);
+    const toggleFeature = async (f: string) => {
+        const wantedNow = !wantedFeatures.has(f);
+        const before = wantedFeatures;
         setWantedFeatures(prev => {
             const next = new Set(prev);
-            next.has(f) ? next.delete(f) : next.add(f);
+            wantedNow ? next.add(f) : next.delete(f);
             return next;
         });
+        setSwitchError(null);
+        try {
+            /* Sent per capability, not per feature id, because the server keys
+             * the switch by capability -- `safety` is the question a clerk is
+             * asked and `redaction` is the thing that gets switched off.
+             * `backups` and `errors` have no capability and no card, and are
+             * carried under their own ids. */
+            const capability = FEATURE_TO_CAPABILITY[f] ?? f;
+            await api.setCapabilitySwitches({ [capability]: wantedNow });
+            setProviderRefresh(t => t + 1);
+        } catch (err: any) {
+            setWantedFeatures(before);
+            setSwitchError(err?.message || 'That could not be saved. Nothing has changed.');
+        }
+    };
     const wants = (f: string) => wantedFeatures.has(f);
 
 
@@ -381,27 +443,8 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
     const redactionProvider = redactionOverride ?? setupCloud;
 
 
-    /* The setup questions are asked in feature terms ("AI triage", "Secret
-     * storage + PII encryption") and the provider cards are keyed by
-     * capability. This is the one mapping between them, and every id on both
-     * sides is now the same word: the key-management tick was `secrets`, which
-     * became ambiguous the moment the secret store became a capability of its
-     * own -- one line of this object would have read `secrets: 'kms'` next to a
-     * real `secrets` capability meaning somewhere else entirely.
-     *
-     * The secret store is deliberately absent. It is not a feature a town ticks
-     * on: every credential entered on this page is kept somewhere, so its card
-     * is always shown rather than gated on a question.
-     *
-     * Redaction used to hang off the `moderation` tick, which was wrong in both
-     * directions: unticking "content moderation" silently hid face blurring,
-     * and there was no way to have blurring without it. They are different
-     * decisions -- one screens what a resident wrote, the other blurs a
-     * bystander who never wrote anything -- so they are now separate ticks. */
-    const FEATURE_TO_CAPABILITY: Record<string, Capability> = {
-        ai: 'ai', translation: 'translation', email: 'email',
-        sms: 'sms', kms: 'kms', safety: 'redaction',
-    };
+    /* Which capability cards the page shows, from the ticks above. See
+     * FEATURE_TO_CAPABILITY at the top of the file for the vocabulary. */
     const wantedCapabilities = new Set<Capability>(
         Object.entries(FEATURE_TO_CAPABILITY)
             .filter(([feature]) => wantedFeatures.has(feature))
@@ -477,6 +520,27 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
         if (seed.email) setEmailOverride(seed.email);
         if (seed.sms) setSmsOverride(seed.sms);
         if (seed.redaction) setRedactionOverride(seed.redaction);
+    }, [providerStatus]);
+
+    /* The ticks, from the server, every time it answers.
+     *
+     * Not seeded once like the pickers above. Those are a plan a clerk may be
+     * making for a provider they have not moved to yet, so the answer is theirs
+     * after the first load. These are the live state of the town -- a tick here
+     * switches a capability off in the backend -- so the server's answer is the
+     * answer, and re-reading it after every save is what stops the chips and the
+     * cards below drifting apart.
+     *
+     * An absent `enabled` is treated as on. It means the endpoint did not say,
+     * which must not read as "the town switched this off". */
+    useEffect(() => {
+        if (!providerStatus) return;
+        setWantedFeatures(new Set(
+            ALL_FEATURES.filter(f => {
+                const capability = FEATURE_TO_CAPABILITY[f] ?? f;
+                return providerStatus[capability]?.enabled !== false;
+            }),
+        ));
     }, [providerStatus]);
     useEffect(() => {
         fetch('/api/system/config')
@@ -716,7 +780,7 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                 <GoogleAccountFields
                     secretValues={secretValues} setSecretValues={setSecretValues}
                     handleSave={handleSave} savingKey={savingKey} isConfigured={isConfigured}
-                    modules={modules} onUpdateModules={onUpdateModules}
+                    onWantAi={async () => { if (!wants('ai')) await toggleFeature('ai'); }}
                 />
             </>}
             {cloud === 'azure' && <>
@@ -1015,6 +1079,20 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
                                                 </button>
                                             ))}
                                         </div>
+                                        {/* Said here rather than as a toast.
+                                            A chip that springs back with no
+                                            explanation is indistinguishable
+                                            from a misclick, and the answer to
+                                            "did that save" has to be beside
+                                            the thing that did not. */}
+                                        {switchError && (
+                                            <p role="alert" className="text-[11px] text-amber-200/85 mt-2">{switchError}</p>
+                                        )}
+                                        <p className="text-[11px] text-white/45 mt-2">
+                                            Unticking one switches it off and stops it running. Anything you
+                                            have already entered stays saved \u2014 switch it back on and it works
+                                            as it did.
+                                        </p>
                                     </Ask>
 
                                     <Ask
@@ -1136,6 +1214,11 @@ export default function SetupIntegrationsPage({ secrets, onSaveSecret, onRefresh
             <div id="sec-providers">
                 <ServiceProviders
                     show={wantedCapabilities}
+                    /* So a switched-off capability can say its credentials are
+                       still there. No card is drawn for one, so nothing else
+                       fetches its catalog and the section would otherwise have
+                       to guess. */
+                    statusMap={providerStatus}
                     /* Backups and crash reporting are features without a
                        provider catalog, so they are not in CAPS and could never
                        show up as switched off -- which is the pair somebody is

--- a/frontend/src/components/StorageStatusLine.tsx
+++ b/frontend/src/components/StorageStatusLine.tsx
@@ -33,10 +33,20 @@ export function StorageStatusLine() {
 
     if (!status) return null;
 
+    /* No store, no sentence.
+     *
+     * This defaulted to "Google Secret Manager" for anything it did not
+     * recognise, including a town that has not chosen a store -- so the line
+     * told a fresh install its secrets were in a Google product it had never
+     * signed in to. The setup gate says the rest; there is nothing useful to
+     * add here. */
+    if (!status.secrets.store) return null;
+
     const storeName = {
         azure: 'Azure Key Vault',
         aws: 'AWS Secrets Manager',
-    }[status.secrets.store ?? ''] ?? 'Google Secret Manager';
+        database: "this deployment's own encrypted database",
+    }[status.secrets.store] ?? 'Google Secret Manager';
 
     const pending: string[] = [];
     if (status.secrets.count && status.secrets.reachable) {

--- a/frontend/src/components/capabilityState.test.ts
+++ b/frontend/src/components/capabilityState.test.ts
@@ -31,6 +31,46 @@ describe('capabilityState', () => {
         expect(capabilityState({ configured: false }, health('working'))).toBe('unset');
     });
 
+    /* Switched off is its own answer, and the one the page could not give.
+     *
+     * "I do not want this" and "I have not set this up" were the same badge.
+     * The reported case: "I can for example save an email or AI key but not use
+     * it and then this is reflected in the service provider card but things are
+     * still saved" -- which needs a state that is neither `unset` nor a
+     * failure, because there is nothing here for anyone to do. */
+    describe('switched off', () => {
+        it('reads as off with the credentials still stored', () => {
+            expect(capabilityState({ configured: true, enabled: false }, health('working')))
+                .toBe('off');
+        });
+
+        it('beats a stored failure, because nothing runs through it', () => {
+            // A red badge on something deliberately switched off is the noise
+            // that teaches people to ignore badges, and no action clears it.
+            expect(capabilityState({ configured: true, enabled: false }, health('down')))
+                .toBe('off');
+            expect(capabilityState({ configured: true, enabled: false, verified: false }, undefined))
+                .toBe('off');
+        });
+
+        it('is still off when nothing was ever configured', () => {
+            // The town has answered the question. "Not set up" would be asking
+            // it again.
+            expect(capabilityState({ configured: false, enabled: false }, undefined)).toBe('off');
+        });
+
+        it('leaves a genuinely unconfigured capability as unset', () => {
+            expect(capabilityState({ configured: false, enabled: true }, undefined)).toBe('unset');
+        });
+
+        it('treats a missing answer as on, not as off', () => {
+            // `enabled` absent means the endpoint did not say. Reading that as
+            // "the town switched this off" would silence a working integration
+            // on any response that arrived incomplete.
+            expect(capabilityState({ configured: true }, health('working'))).toBe('working');
+        });
+    });
+
     it('is unchecked when credentials exist but nothing has exercised them', () => {
         expect(capabilityState({ configured: true }, undefined)).toBe('unchecked');
         expect(capabilityState({ configured: true }, health('unknown'))).toBe('unchecked');

--- a/frontend/src/components/capabilityUI.tsx
+++ b/frontend/src/components/capabilityUI.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Check, AlertCircle, CircleDashed, HelpCircle, ChevronDown, Loader2 } from 'lucide-react';
+import { Check, AlertCircle, CircleDashed, HelpCircle, ChevronDown, Loader2, PowerOff } from 'lucide-react';
 
 /**
  * The shared vocabulary for a capability, wherever it appears.
@@ -42,7 +42,8 @@ export type CapabilityState =
     | 'failing'      // a live check failed, and we have the provider's words
     | 'unchecked'    // configured, but nothing has exercised it
     | 'unverifiable' // configured, and there is no way to check it from here
-    | 'unset'        // deliberately not set up
+    | 'off'          // the town does not want this, whatever is stored
+    | 'unset'        // nothing has been set up
     | 'done'         // setup finished (the guide's version of working)
     | 'todo';        // setup outstanding
 
@@ -76,6 +77,18 @@ const PILL: Record<CapabilityState, { cls: string; label: string; Icon: typeof C
     unverifiable: {
         cls: 'bg-white/[0.07] text-white/70 border-white/15',
         label: 'Set up · we cannot test this one', Icon: HelpCircle,
+    },
+    /* Not a fault, and not an omission.
+     *
+     * "I do not want this" and "I have not got round to this" were the same
+     * badge, which made a deliberate decision look like unfinished work -- and
+     * the obvious response to unfinished work is to go and paste the credential
+     * in again, which is exactly what a town that had just switched something
+     * off did not mean to do. Quieter than `unset` rather than louder: there is
+     * nothing here to act on. */
+    off: {
+        cls: 'bg-white/[0.04] text-white/50 border-white/10',
+        label: 'Switched off', Icon: PowerOff,
     },
     unset: {
         cls: 'bg-white/[0.05] text-white/55 border-white/12',

--- a/frontend/src/context/SettingsContext.tsx
+++ b/frontend/src/context/SettingsContext.tsx
@@ -16,7 +16,7 @@ const defaultSettings: SystemSettings = {
     favicon_url: null,
     hero_text: 'How can we help?',
     primary_color: '#6366f1',
-    modules: { ai_analysis: false, sms_alerts: false },
+    modules: { research_portal: false, unlisted_reports: false },
     updated_at: null,
 };
 

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -1050,6 +1050,29 @@ export default function AdminConsole() {
         }).catch(err => console.warn("Maps config load warning:", err));
     }, []);
 
+    /* A fresh install lands on the setup guide rather than on Branding.
+     *
+     * Nothing detected one. `SetupIntegrationsPage` opens its guide when setup
+     * has not been marked finished -- but it is a tab, and the console opens on
+     * Branding, so on a brand new deployment the guide sat behind a click
+     * nobody had a reason to make. The first thing a town needs is the thing it
+     * was least likely to find.
+     *
+     * An explicit hash wins. Somebody who typed or was sent `#compliance` asked
+     * for compliance, and a redirect over the top of that is the console
+     * ignoring a link.
+     */
+    useEffect(() => {
+        if (window.location.hash.slice(1)) return;
+        let cancelled = false;
+        api.getSetupState()
+            .then(state => { if (!cancelled && !state.completed) setCurrentTab('integration'); })
+            // Unknown is not "unfinished". A failed request must not move
+            // somebody off the tab they opened the console to use.
+            .catch(() => undefined);
+        return () => { cancelled = true; };
+    }, []);
+
     useEffect(() => {
         loadTabData();
     }, [currentTab]);

--- a/frontend/src/pages/AdminConsole.tsx
+++ b/frontend/src/pages/AdminConsole.tsx
@@ -21,7 +21,6 @@ import {
     AlertTriangle,
     RotateCcw,
     Mail,
-    MessageSquare,
     Building2,
     ExternalLink,
     GitFork,
@@ -839,8 +838,17 @@ export default function AdminConsole() {
     const [secrets, setSecrets] = useState<SystemSecret[]>([]);
 
 
-    // Modules state
-    const [modules, setModules] = useState({ ai_analysis: false, sms_alerts: false, email_notifications: false, research_portal: false, unlisted_reports: false });
+    /* Modules state: product features with nothing to configure.
+     *
+     * `ai_analysis`, `sms_alerts` and `email_notifications` used to be here.
+     * They were a second answer to a question the setup page also owned -- and
+     * for email and SMS a third, because dispatch read EMAIL_ENABLED and
+     * SMS_ENABLED as well. Three switches for one capability is how a town
+     * could turn texting off in one place and have it keep sending from
+     * another. They live in `capability_switches` now, with the ticks in Setup
+     * Instructions; what is left here has no provider, no credentials and
+     * nothing to switch off at the dispatch layer. */
+    const [modules, setModules] = useState({ research_portal: false, unlisted_reports: false });
 
     // Maps tab state
     const [mapsRaw, setMapsRaw] = useState<RawMapsConfig | null>(null);
@@ -1028,9 +1036,6 @@ export default function AdminConsole() {
                 social_links: settings.social_links || [],
             });
             setModules({
-                ai_analysis: settings.modules?.ai_analysis || false,
-                sms_alerts: settings.modules?.sms_alerts || false,
-                email_notifications: settings.modules?.email_notifications || false,
                 research_portal: settings.modules?.research_portal || false,
                 unlisted_reports: settings.modules?.unlisted_reports ?? (settings.modules as any)?.private_reports ?? false,
             });
@@ -2402,12 +2407,6 @@ export default function AdminConsole() {
                                 secrets={secrets}
                                 onSaveSecret={handleSaveSecretDirect}
                                 onRefresh={loadTabData}
-                                modules={modules}
-                                onUpdateModules={async (newModules) => {
-                                    setModules(newModules);
-                                    await api.updateSettings({ modules: newModules });
-                                    await refreshSettings();
-                                }}
                             />
                         )}
 
@@ -2449,9 +2448,15 @@ export default function AdminConsole() {
                                     {/* Module Rows */}
                                     <div className="divide-y divide-white/[0.06]">
                                         {[
-                                            { key: 'ai_analysis' as const, label: 'AI Analysis', desc: 'Enable Vertex AI triage for submissions', icon: Sparkles, color: 'blue' },
-                                            { key: 'sms_alerts' as const, label: 'SMS Alerts', desc: 'Enable SMS notifications to residents', icon: MessageSquare, color: 'green' },
-                                            { key: 'email_notifications' as const, label: 'Email Notifications', desc: 'Send email updates to residents', icon: Mail, color: 'sky' },
+                                            /* AI Analysis, SMS Alerts and Email
+                                               Notifications were here. They are
+                                               integrations with credentials, a
+                                               provider and a card, and this
+                                               screen was a second place to
+                                               switch them -- one that knew
+                                               nothing about whether they were
+                                               set up. They are ticks in Setup &
+                                               Integrations now. */
                                             { key: 'research_portal' as const, label: 'Research Portal', desc: 'Enable researcher access to anonymized data exports', icon: FlaskConical, color: 'violet' },
                                             { key: 'unlisted_reports' as const, label: 'Unlisted Reports', desc: 'Let residents keep a report off the public map and feed. The tracking link still works and staff always see it', icon: EyeOff, color: 'slate' },
                                         ].map((mod, idx) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -735,6 +735,24 @@ class ApiClient {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 
+    /** Where this town's credentials are kept, and whether anyone said so.
+     *
+     *  `chosen: false` used to be unreachable: the backend answered "google"
+     *  for a town that had never been asked, so nothing could tell a deliberate
+     *  choice from silence. */
+    async getSecretStore(): Promise<SecretStoreChoice> {
+        return this.request<SecretStoreChoice>('/system/secrets/store');
+    }
+
+    /** Record it. Set-once — repointing the store does not move what is in the
+     *  old one, so a second choice here would make every card unreadable. */
+    async chooseSecretStore(store: string): Promise<SecretStoreChoice> {
+        return this.request<SecretStoreChoice>('/system/secrets/store', {
+            method: 'POST',
+            body: JSON.stringify({ store }),
+        });
+    }
+
     /** Record which integrations the town wants, credentials aside.
      *
      *  A partial map: only what changed. The questionnaire posts the chip that
@@ -1794,6 +1812,22 @@ export type ProviderStatusMap = Record<string, {
     enabled?: boolean;
     ready?: boolean;
 }>;
+
+/** Where a town's credentials are kept, and whether it was asked.
+ *
+ *  The gate on the setup page. A credential saved before this is answered lands
+ *  in the encrypted database; the live row is later swept into the store and
+ *  scrubbed, but a database backup taken in between keeps it, and backups go
+ *  off-site. So the question is asked first. `database` is one of the answers --
+ *  the gate is about consent, not about having a cloud vault. */
+export interface SecretStoreChoice {
+    chosen: boolean;
+    store: string | null;
+    options: string[];
+    /** Whether the chosen store can be contacted. Not a blocker: the
+     *  credentials that make a vault reachable are entered on the same page. */
+    reachable: boolean;
+}
 
 export interface CloudIdentity {
     attached: boolean;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -735,6 +735,21 @@ class ApiClient {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
     }
 
+    /** Whether anybody has said this town is set up.
+     *
+     *  A marker rather than a derived answer. "Is everything configured" is the
+     *  obvious proxy and it never goes true for a town that deliberately
+     *  switches most things off, so the guide would greet it on every login
+     *  forever. */
+    async getSetupState(): Promise<{ completed: boolean; completed_at: string | null }> {
+        return this.request('/system/setup/state');
+    }
+
+    /** "I am done here." */
+    async markSetupComplete(): Promise<{ completed: boolean; completed_at: string | null }> {
+        return this.request('/system/setup/state', { method: 'POST' });
+    }
+
     /** Where this town's credentials are kept, and whether anyone said so.
      *
      *  `chosen: false` used to be unreachable: the backend answered "google"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -731,8 +731,20 @@ class ApiClient {
      *  text. That is not a failure, and the backend deliberately does not write
      *  it to connector health. Dropping the flag here is what made those show
      *  up as "Not working". */
-    async testProvider(capability: string): Promise<{ ok: boolean; detail: string; recorded?: boolean; configured?: boolean }> {
+    async testProvider(capability: string): Promise<{ ok: boolean; detail: string; recorded?: boolean; configured?: boolean; off?: boolean }> {
         return this.request(`/system/providers/${capability}/test`, { method: 'POST' });
+    }
+
+    /** Record which integrations the town wants, credentials aside.
+     *
+     *  A partial map: only what changed. The questionnaire posts the chip that
+     *  was clicked, and a town that has never been asked about photo redaction
+     *  must not get an answer to it from a click on backups. */
+    async setCapabilitySwitches(switches: Record<string, boolean>): Promise<{ switches: Record<string, boolean> }> {
+        return this.request('/system/capabilities', {
+            method: 'PUT',
+            body: JSON.stringify({ switches }),
+        });
     }
 
     /** Which provider each capability is on, and which of its providers have
@@ -1766,9 +1778,21 @@ export interface HealthSummary {
  *  names ORed across providers and disagreed with this endpoint in both
  *  directions. */
 export type ProviderStatusMap = Record<string, {
-    current_provider: string | null;
-    configured: Record<string, boolean>;
-    ready: boolean;
+    current_provider?: string | null;
+    configured?: Record<string, boolean>;
+    /** Whether the town wants this at all, independent of whether it is set up.
+     *
+     *  The third fact, and the one that had nowhere to live: wanted-ness was a
+     *  `Set<string>` in the setup page's React state, initialised to
+     *  everything, so unticking a feature hid part of the guide and switched
+     *  nothing off. Reported beside `configured` rather than folded into it,
+     *  because "switched off with the key still saved" and "never set up" are
+     *  different states and looked identical.
+     *
+     *  `backups` and `errors` appear here with only this field — they are
+     *  switchable but have no provider to choose. */
+    enabled?: boolean;
+    ready?: boolean;
 }>;
 
 export interface CloudIdentity {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -300,10 +300,13 @@ export interface SystemSettings {
     favicon_url: string | null;
     hero_text: string;
     primary_color: string;
+    /* Product features with nothing to configure.
+     *
+     * `ai_analysis`, `sms_alerts` and `email_notifications` were here too, and
+     * were the second (for email and SMS, third) place the same capability
+     * could be switched. They are `capability_switches` on the server now --
+     * see backend/app/services/capability_switches.py for which belongs where. */
     modules: {
-        ai_analysis: boolean;
-        sms_alerts: boolean;
-        email_notifications?: boolean;
         research_portal?: boolean;
         unlisted_reports?: boolean;
     };


### PR DESCRIPTION
# Setup & Integrations: Setup Wizard Persistence, Secret Store Selection & Migration Revision Deduplication

## 📌 Description
This PR resolves critical usability, secret storage, and setup persistence issues in the Pinpoint 311 setup wizard and onboarding workflow.

---

## 🚀 Key Changes Summary (6 Commits)

### 1. Setup Wizard & Onboarding Flow
- **Fresh Install Wizard Trigger**: Configured the setup wizard to automatically launch on fresh installations and permanently dismiss once completed or explicitly closed.
- **Backfill Setup Marker from Active Usage**: Updated setup state evaluation to backfill setup completion markers based on actual active feature usage rather than fragile static timestamps.
- **Explicit "Switched Off" Capability State**: Added explicit status handling for capability cards when a municipality deliberately chooses "this town does not want this feature" rather than treating it as unconfigured.

### 2. Secret Manager & Provider Credentials
- **Mandatory Secret Store Selection**: Prevented credential saves until the municipality explicitly selects a secret manager destination (e.g. Database, GCP Secret Manager, Azure Key Vault, AWS Secrets Manager).

### 3. Database Migration Deduplication
- **Alembic Migration Revision Fix**: Resolved duplicate migration revision IDs (`a7e50d0`), ensuring clean linear database schema upgrades.

---

## 🧪 Verification & Testing
- **Automated Tests**:
  - `test_no_auto_update.py`: Verified setup wizard state persistence.
  - `test_system_settings_singleton.py`: Verified system settings initialization.
- **Live Verification**:
  - Verified setup wizard behavior on fresh deployment.