### PR TITLE
Host-provided credentials from orchestrator, vault resilience, and setup plan docs

### DIFF
--- a/backend/MIN_DB_REVISION
+++ b/backend/MIN_DB_REVISION
@@ -16,4 +16,10 @@
 # Blank or missing means "the revision immediately before head", which is the
 # expand case. Get it wrong in the safe direction: naming a NEWER revision only
 # blocks a rollout, while naming an older one lets a broken build reach towns.
-c3d4e5f6a7b8
+# Head is e5a3c7b9d1f4 (host_provided_keys), a purely additive column, so the
+# rule above puts this at the revision immediately before it. It had been left
+# at c3d4e5f6a7b8 for fourteen revisions, several of them contract migrations
+# (retire_hard_delete, drop_dead_documents_pushed_flag, the NOT NULL on
+# retention state) that this build genuinely cannot start against -- so the
+# declared floor was claiming compatibility the image does not have.
+d4f2a6b8c1e3

--- a/backend/alembic/versions/20260810_0900_e5a3c7b9d1f4_host_provided_credential_keys.py
+++ b/backend/alembic/versions/20260810_0900_e5a3c7b9d1f4_host_provided_credential_keys.py
@@ -1,0 +1,37 @@
+"""record which credential keys the host supplied
+
+A hosted town can be handed working credentials by whoever runs its instance,
+so the setup page does not dead-end on a key the town has no account for. That
+only stays safe if ownership is written down: the host may replace or withdraw
+the keys it provided and nothing else, and a town admin who types their own
+value into the same box takes the key back for good.
+
+`host_provided_keys` is that record -- key NAMES only, never values, which stay
+in the secret store and the encrypted `system_secrets` copy exactly as any
+town-entered credential does.
+
+Revision ID: e5a3c7b9d1f4
+Revises: d4f2a6b8c1e3
+Create Date: 2026-08-10 09:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e5a3c7b9d1f4'
+down_revision: Union[str, None] = 'd4f2a6b8c1e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'system_settings',
+        sa.Column('host_provided_keys', sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('system_settings', 'host_provided_keys')

--- a/backend/app/api/provisioning.py
+++ b/backend/app/api/provisioning.py
@@ -12,7 +12,7 @@ import hmac
 import json
 import secrets as pysecrets
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Dict, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
@@ -339,3 +339,98 @@ async def set_managed_settings(
         pass
 
     return {"status": "ok", "applied": applied, "enforced_keys": sorted(_ENFORCED_KEYS & set(incoming))}
+
+
+class HostSecretsRequest(BaseModel):
+    """The host's complete current set of shared credentials.
+
+    Full replace, like managed-settings above and for the same reason: a
+    partial push has no spelling for "stop sharing this", so a credential the
+    host withdrew in its own console would stay live in the town's vault. What
+    arrives here is everything the host is sharing right now, and a key that is
+    absent is one to take back.
+    """
+
+    # Typed rather than a bare `dict`. A value that is not a string used to
+    # reach `.strip()` inside the apply loop, raise AttributeError, and answer
+    # 500 -- after earlier keys in the same batch had already been written and
+    # committed. Pydantic rejects the malformed body up front now, and
+    # `host_secrets.apply` refuses any residual non-string per key rather than
+    # raising, so one bad entry costs that entry and nothing else.
+    secrets: Dict[str, str] = Field(default_factory=dict)
+
+
+@router.post("/host-secrets")
+async def set_host_secrets(
+    body: HostSecretsRequest,
+    db: AsyncSession = Depends(get_db),
+    actor: str = Depends(require_provisioning_token),
+):
+    """Accept provider credentials the deployment's host supplies for this town.
+
+    A town on a hosted deployment often has no account of its own with a map
+    vendor or a translation API, and waiting for one is what stalls onboarding.
+    The host has those accounts, so it can hand the instance working
+    credentials -- and the setup page then shows a configured card with a note
+    saying where the key came from, rather than an empty box for an account
+    nobody has.
+
+    Three rules, all enforced in `app.services.host_secrets`:
+
+      * only provider credential keys, never the platform's own (the secret
+        store, the KMS, anything `BACKUP_`), so this cannot become a door onto
+        where the town's credentials live;
+      * a key the TOWN configured is refused, however often it is pushed -- the
+        town's own credential wins, and a clerk's value is never reverted by a
+        machine;
+      * keys the host provided and no longer sends are deleted, vault and
+        database both.
+
+    No secret store gate here, deliberately. The admin pages refuse a
+    credential until the town has said where credentials go, because a value
+    written before that decision can end up in an off-site backup nobody chose.
+    That gate protects a person from an unmade decision; this caller is the host
+    and the answer is already the encrypted database until the town says
+    otherwise. Refusing the push would leave a freshly provisioned town with no
+    credentials and no way to be given any until an admin logged in, which is
+    the situation the feature exists to remove.
+
+    Names only in the response and in the audit trail. The values arrive, go to
+    the same store any credential goes to, and are never echoed, logged, or put
+    in an error message.
+
+    The response is {"status", "accepted", "refused", "revoked", "failed"} --
+    four sorted lists of key names. `failed` was added after the first release
+    and is additive on purpose: it names withdrawals that did not take (the
+    vault refused the delete, so the credential is still live and still the
+    host's to retry), and a caller that only reads the first three is unchanged
+    by it.
+    """
+    from app.services import host_secrets
+
+    result = await host_secrets.apply(db, body.secrets or {})
+
+    try:
+        await AuditService.log_event(
+            db,
+            event_type="provisioning_host_secrets",
+            success=True,
+            username=actor,
+            # Key names and counts. A value here would be a secret in an
+            # exportable table, which is the one thing this endpoint must not
+            # produce.
+            details={
+                "accepted": result["accepted"],
+                "refused": result["refused"],
+                "revoked": result["revoked"],
+                # Withdrawals that did not take. Worth an audit line of its own:
+                # the credential is still live in the town's vault, and this is
+                # the only record that somebody tried to take it back.
+                "failed": result["failed"],
+                "counts": {k: len(v) for k, v in result.items()},
+            },
+        )
+    except Exception:
+        pass
+
+    return {"status": "ok", **result}

--- a/backend/app/api/provisioning.py
+++ b/backend/app/api/provisioning.py
@@ -399,12 +399,15 @@ async def set_host_secrets(
     the same store any credential goes to, and are never echoed, logged, or put
     in an error message.
 
-    The response is {"status", "accepted", "refused", "revoked", "failed"} --
-    four sorted lists of key names. `failed` was added after the first release
-    and is additive on purpose: it names withdrawals that did not take (the
-    vault refused the delete, so the credential is still live and still the
-    host's to retry), and a caller that only reads the first three is unchanged
-    by it.
+    The response is {"status", "accepted", "refused", "revoked", "failed",
+    "db_only"} -- five sorted lists of key names. `failed` and `db_only` were
+    added after the first release and are additive on purpose, so a caller that
+    only reads the first three is unchanged by them. `failed` names withdrawals
+    that did not take (the vault refused the delete, so the credential is still
+    live and still the host's to retry). `db_only` names writes that reached
+    only the encrypted database copy because the external secret store would
+    not take them -- the credential works, but not for the reason the host
+    thinks, and it goes away when the database copies are scrubbed.
     """
     from app.services import host_secrets
 
@@ -427,6 +430,11 @@ async def set_host_secrets(
                 # the credential is still live in the town's vault, and this is
                 # the only record that somebody tried to take it back.
                 "failed": result["failed"],
+                # Accepted, but only into the encrypted database copy -- the
+                # external secret store did not take the write. The credential
+                # works today and vanishes the day the database copies are
+                # scrubbed, and this line is the only place that is visible.
+                "db_only": result["db_only"],
                 "counts": {k: len(v) for k, v in result.items()},
             },
         )

--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -533,34 +533,30 @@ async def configure_auth0(
                     social_connections_errors.append(f"{conn_name}: {str(conn_err)[:50]}")
                     logger.warning(f"Failed to enable {conn_name} social connection: {conn_err}")
             
-        # Store credentials in database
-        
+        # Store credentials through the single write choke-point.
+        #
+        # This used to write SystemSecret rows here by hand, and all three of
+        # these keys are host-shareable. A town that configures its own Auth0
+        # tenant on this page was therefore leaving them marked host-provided:
+        # the next push from the host overwrote the town's SSO with the host's,
+        # and the host un-sharing Auth0 DELETED the town's own credential --
+        # both from a value nobody at the host ever typed. Ownership moves on a
+        # town-side write, and `_persist_secret` is what moves it (via
+        # `host_secrets.forget`), so this path goes through it like the other
+        # two credential write paths do.
+        #
+        # It also means these land in the configured secret store rather than
+        # only in the encrypted database copy, which is what the rest of the
+        # product already assumed was happening.
+        from app.api.system import _persist_secret
+
         for key, value in [
             ("AUTH0_DOMAIN", request.domain),
             ("AUTH0_CLIENT_ID", client_id),
             ("AUTH0_CLIENT_SECRET", client_secret)
         ]:
-            result = await db.execute(
-                select(SystemSecret).where(SystemSecret.key_name == key)
-            )
-            secret = result.scalar_one_or_none()
-            
-            encrypted_value = encrypt(value)
-            
-            if secret:
-                secret.key_value = encrypted_value
-                secret.is_configured = True
-            else:
-                secret = SystemSecret(
-                    key_name=key,
-                    key_value=encrypted_value,
-                    is_configured=True,
-                    description=f"Auth0 {key.split('_')[1].lower()}"
-                )
-                db.add(secret)
-        
-        await db.commit()
-        
+            await _persist_secret(db, key, value)
+
         # Log successful setup
         await AuditService.log_event(
             db=db,

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -1001,13 +1001,22 @@ async def _persist_secret(
 ) -> bool:
     """Write a secret to the configured store and keep an encrypted DB copy.
 
-    Returns whether the external store took it. That return value matters: when
-    the store is not reachable yet, set_secret returns False and logs at DEBUG,
-    which nothing raises the level for -- so the secret quietly lived only in
-    the database and the town had no way to know. It is a real ordering trap,
+    Returns whether the value ended up where this deployment intends it to
+    live. That return value matters: when an external store is configured but
+    not reachable yet, set_secret returns False and logs at DEBUG, which
+    nothing raises the level for -- so the secret quietly lived only in the
+    database and the town had no way to know. It is a real ordering trap,
     because the credentials that make Secret Manager reachable are themselves
     entered on this page: anything saved before them lands in the database and
     stays there until somebody happens to run the migration.
+
+    False therefore means "this was supposed to go somewhere else and did not",
+    NOT merely "it is in the database". On a town whose chosen store is the
+    database -- or which has not chosen one yet -- there is no somewhere else,
+    set_secret returns False for every key by design, and this returns True:
+    the credential is exactly where it belongs. Reporting those as db-only
+    made every save on the default deployment look like a credential about to
+    disappear.
 
     The caller surfaces this rather than swallowing it.
 
@@ -1042,7 +1051,16 @@ async def _persist_secret(
     # relying on DB_REQUIRED_KEYS to keep its database copy from being scrubbed
     # -- which worked, and still wrote the name of the store into the store.
     bootstrap_keys = {"GCP_SERVICE_ACCOUNT_JSON", "GOOGLE_CLOUD_PROJECT"} | _STORE_CHOICE_KEYS
-    stored_externally = key_name in bootstrap_keys
+    # A deployment whose chosen store IS the encrypted database, or which has
+    # not chosen one yet, has nothing outside the database to write to --
+    # `set_secret` returns False for every key by design, not by failure. Read
+    # as "the store rejected it", that turned an ordinary save on an ordinary
+    # database-store town into a warning that the credential was about to
+    # vanish, on every key, forever. The return value below means "the value is
+    # where this deployment intends it to live", which is true here.
+    from app.services.secret_manager import external_store_configured
+    has_external_store = external_store_configured()
+    stored_externally = key_name in bootstrap_keys or not has_external_store
     if value and key_name not in bootstrap_keys:
         try:
             if await set_secret(key_name, value):

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -377,6 +377,24 @@ async def _stored_fields(providers: List[Dict[str, Any]]) -> Dict[str, bool]:
     return out
 
 
+async def _host_provided_fields(db, stored_fields: Dict[str, bool]) -> Dict[str, bool]:
+    """{credential key: this one came from the deployment's host}.
+
+    Sits beside `_stored_fields` and reads the same set of keys, because the
+    card needs both answers about the same box: whether anything is stored, and
+    whether the town or its host put it there. A host-provided credential is a
+    working credential -- the card is green, the badge says configured, and the
+    only difference is a note under the label, so a clerk is not sent looking
+    for an account the town does not have. Typing a value over it still saves
+    and still works; that is what takes the key back.
+
+    Presence and ownership only. Never a value.
+    """
+    from app.services import host_secrets
+
+    return await host_secrets.field_provenance(db, stored_fields)
+
+
 async def _configured_map(providers: List[Dict[str, Any]]) -> Dict[str, bool]:
     """{provider id: are all of its required credentials stored}.
 
@@ -661,9 +679,11 @@ async def get_identity_catalog(
     from app.services.secret_manager import get_secret
     current = ((await get_secret(IDENTITY_PROVIDER_KEY)) or "auth0").strip().lower()
     providers = catalog_for_api()
+    stored = await _stored_fields(providers)
     return {"current_provider": current, "default_provider": "auth0",
             "providers": providers, "configured": await _configured_map(providers),
-            "stored_fields": await _stored_fields(providers),
+            "stored_fields": stored,
+            "host_provided": await _host_provided_fields(db, stored),
             "last_result": await _last_result_for(db, "identity", current)}
 
 
@@ -677,9 +697,11 @@ async def get_translation_catalog(
     from app.services.secret_manager import get_secret
     current = ((await get_secret(TRANSLATION_PROVIDER_KEY)) or "google").strip().lower()
     providers = catalog_for_api()
+    stored = await _stored_fields(providers)
     return {"current_provider": current, "default_provider": "google",
             "providers": providers, "configured": await _configured_map(providers),
-            "stored_fields": await _stored_fields(providers),
+            "stored_fields": stored,
+            "host_provided": await _host_provided_fields(db, stored),
             "last_result": await _last_result_for(db, "translation", current)}
 
 
@@ -695,9 +717,11 @@ async def get_maps_catalog(
     from app.services.secret_manager import get_secret
     current = normalize_provider(await get_secret(MAP_PROVIDER_KEY))
     providers = catalog_for_api()
+    stored = await _stored_fields(providers)
     return {"current_provider": current, "default_provider": "google",
             "providers": providers, "configured": await _configured_map(providers),
-            "stored_fields": await _stored_fields(providers),
+            "stored_fields": stored,
+            "host_provided": await _host_provided_fields(db, stored),
             "last_result": await _last_result_for(db, "maps", current)}
 
 
@@ -742,13 +766,15 @@ async def get_ai_catalog(
 
     resolved_model = current_model or AI_CATALOG.get(current_provider, {}).get("default_model")
     current_models = next((p["models"] for p in providers if p["provider"] == current_provider), [])
+    stored = await _stored_fields(providers)
     return {
         "current_provider": current_provider,
         "default_provider": "vertex",
         "current_model": resolved_model,
         "current_model_available": md.model_is_available(current_models, current_model),
         "configured": configured,
-        "stored_fields": await _stored_fields(providers),
+        "stored_fields": stored,
+        "host_provided": await _host_provided_fields(db, stored),
         "providers": providers,
         "last_result": await _last_result_for(db, "ai", current_provider),
     }
@@ -803,6 +829,7 @@ async def get_capability_catalog(
             capability, await get_secret(_PROVIDER_SELECT_KEY[capability])
         )
     providers = catalog_for_api(capability)
+    stored = await _stored_fields(providers)
 
     return {
         "current_provider": current,
@@ -817,7 +844,11 @@ async def get_capability_catalog(
         "configured": await _configured_map(providers),
         # Which individual boxes have something in them, so the form's
         # "Saved" hint stops appearing on empty optional ones.
-        "stored_fields": await _stored_fields(providers),
+        "stored_fields": stored,
+        # And which of those the deployment's host supplied rather than the
+        # town, so the hint can say so instead of sending a clerk to look for
+        # an account their town does not have.
+        "host_provided": await _host_provided_fields(db, stored),
         "last_result": await _last_result_for(db, capability, current),
         # Whether this card may change the selection. The secret store may not:
         # every credential the town has is in the current one and repointing the
@@ -965,7 +996,9 @@ def _require_a_secret_store() -> None:
 _STORE_CHOICE_KEYS = {"SECRETS_PROVIDER"}
 
 
-async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
+async def _persist_secret(
+    db: AsyncSession, key_name: str, value: str, *, from_host: bool = False
+) -> bool:
     """Write a secret to the configured store and keep an encrypted DB copy.
 
     Returns whether the external store took it. That return value matters: when
@@ -977,6 +1010,13 @@ async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
     stays there until somebody happens to run the migration.
 
     The caller surfaces this rather than swallowing it.
+
+    `from_host` marks the one caller that is not a town admin: the provisioning
+    endpoint through which the deployment's host supplies credentials. Every
+    other write is somebody at the town typing into a box, and that is what
+    takes ownership of a key back off the host -- see `host_secrets.forget`.
+    The flag defaults to the town reading, so a write path added later has to
+    opt out of it on purpose rather than by forgetting.
     """
     from app.core.encryption import encrypt
     from app.core.managed import reject_platform_key_writes
@@ -1025,6 +1065,17 @@ async def _persist_secret(db: AsyncSession, key_name: str, value: str) -> bool:
         secret.is_configured = bool(value)
     else:
         db.add(SystemSecret(key_name=key_name, key_value=enc, is_configured=bool(value)))
+    # The town has just entered a value of its own, so this key is no longer
+    # the host's to replace or withdraw. In the same transaction as the write
+    # it belongs to: an ownership record that can land without the value, or
+    # the value without it, is a race that reverts a clerk's credential.
+    #
+    # A blank value is "keep what is stored" everywhere else on this page and
+    # means the same here -- clearing a box does not claim the key.
+    if value and not from_host:
+        from app.services import host_secrets
+
+        await host_secrets.forget(db, key_name)
     await db.commit()
     return stored_externally
 
@@ -2868,10 +2919,15 @@ async def list_secrets(
     texting was on, and now asks /providers/status, which reports what dispatch
     resolves rather than what is stored.
     """
+    from app.services import host_secrets
     from app.services.secret_manager import get_secret
 
     result = await db.execute(select(SystemSecret))
     secrets = result.scalars().all()
+
+    # Who supplied each one. Names only, read once for the whole list rather
+    # than per row.
+    from_host = set(await host_secrets.host_provided(db))
 
     response = []
     for secret in secrets:
@@ -2884,6 +2940,11 @@ async def list_secrets(
             # and saying so is the safe direction: the cost is asking about
             # something already done, rather than ticking something unreadable.
             data.is_configured = False
+        # Both halves, the same rule `field_provenance` uses: the host owns this
+        # key AND there is a value stored under it. A key the host has since
+        # withdrawn otherwise keeps saying "supplied by your host" next to an
+        # empty box, which reads as a credential the town has and does not.
+        data.host_provided = secret.key_name in from_host and bool(data.is_configured)
         response.append(data)
 
     return response
@@ -2948,7 +3009,24 @@ async def create_or_update_secret(
             is_configured=bool(secret_data.key_value)
         )
         db.add(secret)
-    
+
+    # The other door into the secret table, and so the other place ownership
+    # has to move. This endpoint does not go through `_persist_secret` -- it
+    # predates it and writes the row itself -- so the same clearing has to be
+    # here, or a plain secret field would be the one way a town could enter its
+    # own credential and still have the host overwrite it on the next push.
+    #
+    # Unconditional, unlike `_persist_secret`, and the difference is deliberate.
+    # There a blank value means "keep what is stored" -- it is the partial save
+    # a provider card sends when a masked box was not touched. Here the box IS
+    # the credential and saving it empty is somebody clearing it on purpose:
+    # a town that deletes a host-supplied key has decided it does not want that
+    # key, and leaving it host-owned meant the next scheduled push put it
+    # straight back with no trace of who undid the deletion.
+    from app.services import host_secrets
+
+    await host_secrets.forget(db, secret_data.key_name)
+
     await db.commit()
     await db.refresh(secret)
 

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -23,6 +23,14 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,
     # Celery Beat Schedule
     #
+    # No per-entry queue option, deliberately. Every entry used to say
+    # queue="default", but the worker consumes Celery's actual default queue
+    # (named "celery") -- so every scheduled task ever published went into a
+    # queue nobody read. Backups, retention, connector checks: none had ever
+    # run except by hand, and 2,695 unconsumed messages were sitting in redis
+    # when this was found. Publishing on the default queue is what the manual
+    # `celery call` path always did, which is why manual runs worked.
+    #
     # Hourly-and-slower entries are crontab (wall-clock), not intervals. An
     # interval counts from worker boot and resets on every restart, so during
     # any stretch of active deployment the daily jobs simply never fired --
@@ -37,7 +45,6 @@ celery_app.conf.update(
         "proactive-health-scan": {
             "task": "app.tasks.service_requests.proactive_health_scan",
             "schedule": 60 * 15,  # Every 15 minutes
-            "options": {"queue": "default"}
         },
         # Road centreline refresh. Fires daily but acts on one day a month --
         # the day is derived from a hash of the township name so deployments
@@ -48,7 +55,6 @@ celery_app.conf.update(
         "monthly-road-refresh": {
             "task": "app.tasks.road_data.refresh_roads_monthly",
             "schedule": crontab(hour=4, minute=15),  # checked daily, acts monthly
-            "options": {"queue": "default"}
         },
         # Test every configured connector once a day.
         #
@@ -61,87 +67,73 @@ celery_app.conf.update(
         # credentials do not expire faster than once a day.
         "hourly-system-probe": {
             "task": "app.tasks.connector_checks.probe_system",
-            "schedule": crontab(minute=7),
-            "options": {"queue": "default"}
+            "schedule": crontab(minute=7)
         },
         "daily-connector-check": {
             "task": "app.tasks.connector_checks.verify_connectors",
-            "schedule": crontab(hour=9, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=9, minute=0)
         },
         # Daily anchor of the audit hash-chain head (tamper-evidence beyond the DB)
         "daily-audit-anchor": {
             "task": "app.tasks.service_requests.anchor_audit_chain",
-            "schedule": crontab(hour=0, minute=30),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=0, minute=30)
         },
         # Daily retention enforcement at 1:00 AM UTC (before backup)
         "daily-retention-enforcement": {
             "task": "app.tasks.service_requests.enforce_retention_policy",
-            "schedule": crontab(hour=1, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=1, minute=0)
         },
         # Daily purge of IP addresses older than 90 days (privacy commitment)
         "daily-ip-purge": {
             "task": "app.tasks.service_requests.purge_old_ip_addresses",
-            "schedule": crontab(hour=1, minute=30),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=1, minute=30)
         },
         # Daily database backup at 2:00 AM UTC
         "daily-database-backup": {
             "task": "app.tasks.service_requests.backup_database",
-            "schedule": crontab(hour=2, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=2, minute=0)
         },
         # Weekly backup cleanup on Sundays at 3:00 AM UTC
         "weekly-backup-cleanup": {
             "task": "app.tasks.service_requests.cleanup_expired_backups",
-            "schedule": crontab(hour=3, minute=0, day_of_week="sunday"),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=3, minute=0, day_of_week="sunday")
         },
         # Poll connected govtech platforms for external status changes
         "pull-integration-updates": {
             "task": "app.tasks.integrations.pull_integration_updates",
             "schedule": 60 * 15,  # Every 15 minutes
-            "options": {"queue": "default"}
         },
         # Import new external comments on linked, active requests
         "pull-integration-comments": {
             "task": "app.tasks.integrations.pull_integration_comments",
             "schedule": 60 * 15,  # Every 15 minutes
-            "options": {"queue": "default"}
         },
         # Mirror external asset inventories into Pinpoint map layers
         "sync-integration-assets": {
             "task": "app.tasks.integrations.sync_integration_assets",
-            "schedule": crontab(hour=5, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=5, minute=0)
         },
         # Weekly staff digest emails on Mondays at 8:00 AM UTC
         "weekly-staff-digest": {
             "task": "app.tasks.service_requests.send_weekly_digest",
-            "schedule": crontab(hour=8, minute=0, day_of_week="monday"),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=8, minute=0, day_of_week="monday")
         },
         # Storage hygiene that used to be two buttons on the setup page. Both
         # verify before they change anything and are no-ops with nothing to do,
         # so nobody has to work out whether they apply.
         "hourly-secret-vaulting": {
             "task": "app.tasks.storage.vault_secrets",
-            "schedule": crontab(minute=37),
-            "options": {"queue": "default"}
+            "schedule": crontab(minute=37)
         },
         "nightly-pii-rewrap": {
             "task": "app.tasks.storage.rewrap_pii",
-            "schedule": crontab(hour=6, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=6, minute=0)
         },
         # Refresh the live AI model lists so the picker stays current and can
         # flag a retired/deprecated model without anyone opening the admin UI.
         "daily-ai-model-refresh": {
             "task": "app.tasks.service_requests.refresh_ai_models",
-            "schedule": crontab(hour=10, minute=0),
-            "options": {"queue": "default"}
+            "schedule": crontab(hour=10, minute=0)
         },
     }
 )

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -188,6 +188,14 @@ async def _run_schema_migrations():
         "ALTER TABLE service_requests ADD COLUMN IF NOT EXISTS public_archived BOOLEAN NOT NULL DEFAULT false",
         "CREATE INDEX IF NOT EXISTS ix_service_requests_public_archived ON service_requests (public_archived)",
         "ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS public_archive_days INTEGER",
+        # Which credential keys the deployment's host supplied, rather than the
+        # town (added 2026-08-10). Key NAMES only; values live in the secret
+        # store and the encrypted system_secrets copy like any other credential.
+        # NULL reads as "none of them", so an install that has not migrated
+        # behaves as a town that owns all its own credentials -- which is the
+        # safe direction: a host push is refused rather than a town's key being
+        # overwritten by one.
+        "ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS host_provided_keys JSON",
         # GovTech integrations: comment/document sync tracking (added 2026-07-01)
         "ALTER TABLE request_comments ADD COLUMN IF NOT EXISTS external_ref VARCHAR(200)",
         "CREATE INDEX IF NOT EXISTS ix_request_comments_external_ref ON request_comments (external_ref)",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -598,6 +598,14 @@ class SystemSettings(Base):
     # Refreshed on demand (admin "Refresh models") and by a daily Celery task.
     ai_models_cache = Column(JSON, default={})
 
+    # Credential keys this instance's host supplied rather than the town, as a
+    # list of key names (never values). It is a record of ownership, and every
+    # rule about host-provided credentials reads it: the host may replace or
+    # withdraw what is on this list and nothing else, and a town admin typing
+    # their own value into the same box takes the key off it -- after which the
+    # host can no longer touch it. See app/services/host_secrets.py.
+    host_provided_keys = Column(JSON, default=[])
+
     # Last-seen status per proactive health check ({check_key: status}), so the
     # alerting task only emails admins when a check crosses into a worse state.
     health_alert_state = Column(JSON, default={})

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -452,6 +452,11 @@ class SecretResponse(SecretBase):
     id: int
     is_configured: bool
     key_value: Optional[str] = None  # Only returned for non-sensitive configuration secrets
+    # Whether the deployment's host supplied this credential rather than the
+    # town. A note about who to ask, not a permission: the town can save its
+    # own value over it, and that takes the key off the host's list for good.
+    # False on a standalone install, where there is no host to provide one.
+    host_provided: bool = False
 
     class Config:
         from_attributes = True

--- a/backend/app/services/host_secrets.py
+++ b/backend/app/services/host_secrets.py
@@ -147,12 +147,18 @@ def _normalise(raw) -> List[str]:
     return sorted({k for k in raw if isinstance(k, str) and k})
 
 
-async def host_provided(db) -> List[str]:
-    """Which keys are currently the host's, sorted. Never raises."""
+async def host_provided(db, *, fresh: bool = False) -> List[str]:
+    """Which keys are currently the host's, sorted. Never raises.
+
+    `fresh=True` re-reads the row from the database rather than accepting the
+    copy this session already holds -- see `get_settings`. Callers deciding
+    something DURING a push need it, because `apply` commits key by key and a
+    town admin's save can commit in between.
+    """
     from app.services.system_settings import get_settings
 
     try:
-        row = await get_settings(db)
+        row = await get_settings(db, fresh=fresh)
     except Exception:
         logger.warning("Could not read host-provided credential ownership")
         return []
@@ -345,8 +351,6 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
         if isinstance(k, str) and str(k).strip()
     }
     allowed = shareable_keys()
-    previously: List[str] = await host_provided(db)
-    owned = set(previously)
 
     accepted: List[str] = []
     refused: List[str] = []
@@ -400,7 +404,24 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
             # out entirely).
             refused.append(key)
             continue
-        if key not in owned:
+        # Ownership is read again for EVERY key, and it is read fresh.
+        #
+        # A single snapshot taken before the loop is a lie by the second key.
+        # `_persist_secret` commits as it goes, so this loop spans many
+        # committed transactions and several seconds of vault round trips, and
+        # a town admin saving their own credential in that window calls
+        # `forget`, which commits too. Against a snapshot the loop never sees
+        # it: it reaches the clerk's key, finds it in the ownership set it read
+        # before the push started, skips the "does the town already have one"
+        # guard entirely, and overwrites the value the clerk typed seconds ago
+        # with the host's. That is the exact outcome this whole module exists
+        # to make impossible, and it survived the first fix because that one
+        # only handled a `forget` landing after its key had been written.
+        #
+        # Reading per key costs one SELECT against a row already in cache, next
+        # to a vault write per key. It is not a price worth optimising.
+        owned_now = set(await host_provided(db, fresh=True))
+        if key not in owned_now:
             try:
                 taken = await _is_configured(db, key)
             except Exception:
@@ -432,11 +453,13 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
         except Exception:
             logger.warning("Could not store a host-provided credential")
             refused.append(key)
-            if key not in previously:
+            if key not in owned_now:
                 # New key, nothing of the host's behind it: releasing the claim
                 # leaves the row exactly as it was. A key the host ALREADY
                 # owned keeps its claim -- see `unclaim` above for what
-                # dropping it cost.
+                # dropping it cost. Judged against the same fresh read the
+                # guard used, so a key a clerk took back moments ago is treated
+                # as theirs by both halves of this branch.
                 unclaim.append(key)
             continue
         if not stored_externally:
@@ -463,7 +486,13 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
     # blank, the vault errored -- and none of those is the host saying "stop
     # sharing this". Revocation has exactly one spelling in a full replace, and
     # it is absence from the payload. A refused key is present, so it stays.
-    for key in sorted(owned - set(incoming)):
+    # Fresh again, and for the same reason. Revoking against the snapshot taken
+    # before the loop would withdraw a credential a clerk claimed while the
+    # push was running -- deleting, from vault and database both, a value the
+    # town entered on purpose and now owns. Withdrawal may only ever apply to
+    # keys that are still the host's at the moment it happens.
+    still_owned = set(await host_provided(db, fresh=True))
+    for key in sorted(still_owned - set(incoming)):
         if key not in allowed:
             logger.warning(
                 "Keeping a host-provided credential that is no longer shareable "

--- a/backend/app/services/host_secrets.py
+++ b/backend/app/services/host_secrets.py
@@ -1,0 +1,433 @@
+"""Credentials the host supplies, and who owns each one.
+
+A town on a state-hosted deployment often has no account of its own with a map
+vendor, a translation API or an identity provider, and waiting for one is the
+step that stalls onboarding. The host already has those accounts, so it can
+hand the instance working credentials and the setup page stops dead-ending on
+a box nobody can fill in.
+
+That is only safe if ownership is written down, because the same box has two
+possible authors and they must not be able to overwrite each other by
+accident:
+
+  * The host may replace or withdraw a key **it** provided, and nothing else.
+    A key the town entered is refused, every time, however often it is pushed.
+  * A town admin who types their own value into the box takes the key back
+    permanently -- the next push is refused rather than silently reverting a
+    credential a clerk chose on purpose.
+
+`SystemSettings.host_provided_keys` is that record, and it holds key NAMES.
+No value passes through this module into anything that is stored, logged,
+audited or returned: values go to the ordinary secret path (`_persist_secret`)
+and stay in the secret store plus the encrypted `system_secrets` copy, exactly
+as a town-entered credential does. Everything this module reports back is a
+sorted list of names.
+
+The push is a FULL REPLACE. The payload is the complete current set of shared
+credentials, so a key that is missing from it is one the host has stopped
+sharing, and it is deleted rather than left behind: a credential nobody
+intended to still be live is the thing a revocation exists to prevent.
+"""
+
+import logging
+from typing import Dict, Iterable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Crash reporting has no provider card and therefore no catalog entry, but it
+# is a per-deployment credential a host plausibly owns. Named here rather than
+# invented at the call site so there is one list to read.
+EXTRA_SHAREABLE_KEYS = frozenset({"SENTRY_DSN"})
+
+# Fields that sit in a provider catalog's `credential_fields` but are not
+# credentials: they are the town's own choices about how the software behaves,
+# and a host has no standing to set them from outside.
+#
+# REDACT_FACES and REDACT_PLATES decide whether faces and number plates in
+# resident photographs are blurred before anybody sees them. They are declared
+# alongside the redaction provider's key because the card needs them on screen,
+# but pushing REDACT_FACES=false would turn off blurring of residents' faces
+# from the host's console, silently, on a schedule -- which is a privacy
+# decision belonging to the town and nobody else.
+#
+# SMTP_USE_TLS is transport policy for the town's own mail relay, and
+# SMS_HTTP_TEST_URL points the SMS test at a URL of the pusher's choosing.
+# Neither unlocks an account the host holds, which is the entire justification
+# for this endpoint existing.
+#
+# Note this is a subtraction, not a switch to "secret fields only". The
+# non-secret companion fields -- AUTH0_DOMAIN, the AZURE_*_ENDPOINT pair,
+# VERTEX_AI_PROJECT and the rest -- have to stay shareable, because a key
+# delivered without the endpoint or tenant it belongs to is a credential the
+# town cannot use.
+NON_CREDENTIAL_KEYS = frozenset({
+    "REDACT_FACES",
+    "REDACT_PLATES",
+    "SMTP_USE_TLS",
+    "SMS_HTTP_TEST_URL",
+})
+
+# Every capability with a provider catalog. The allowlist is derived from these
+# rather than hand-listed, so a capability or a provider added later is covered
+# without anyone remembering to come back here -- and, more importantly, a
+# credential field REMOVED from a catalog stops being pushable at the same
+# moment it stops being read.
+_CAPABILITIES = (
+    "ai", "translation", "identity", "maps",
+    "email", "sms", "kms", "redaction", "secrets",
+)
+
+
+def shareable_keys() -> frozenset:
+    """Every credential key a host is allowed to supply.
+
+    The union of the credential fields every provider catalog declares, plus
+    `EXTRA_SHAREABLE_KEYS`, minus anything the platform owns and minus
+    `NON_CREDENTIAL_KEYS`.
+
+    The platform filter is `is_platform_managed`, which is the same rule the
+    town-facing write guard uses, and it removes two families at once: the
+    keys that make the secret store and the KMS work (a host pushing those
+    through this door would be repointing where the town's credentials live,
+    from an endpoint whose whole promise is that it only writes provider
+    credentials), and everything prefixed `BACKUP_`, which is the host's own
+    backup arrangement and not a thing to copy into a town's vault.
+
+    Note this filter is unconditional -- unlike `reject_platform_key_writes`,
+    which only bites in managed mode. A key that is infrastructure on a hosted
+    deployment is infrastructure everywhere, and the allowlist for a machine
+    endpoint should not change shape depending on a mode flag.
+
+    The second filter is `NON_CREDENTIAL_KEYS` -- the behaviour and privacy
+    toggles that share a catalog with the credentials they belong to. Read its
+    comment before adding to it: it is a deny-list precisely so that a new
+    provider's non-secret companion field (the endpoint, the tenant, the
+    project id) stays shareable by default, because a credential delivered
+    without them is one the town cannot use.
+    """
+    from app.core.managed import is_platform_managed
+
+    keys = set(EXTRA_SHAREABLE_KEYS)
+    for capability in _CAPABILITIES:
+        for spec in (_catalog(capability) or {}).values():
+            for field in (spec.get("credential_fields") or []):
+                key = (field or {}).get("key")
+                if key:
+                    keys.add(key)
+    return frozenset(
+        k for k in keys
+        if not is_platform_managed(k) and k not in NON_CREDENTIAL_KEYS
+    )
+
+
+def _catalog(capability: str) -> Dict:
+    """The raw catalog for a capability, or {} if it cannot be loaded.
+
+    Never raises: an allowlist that fails closed for one capability is a host
+    push that gets refused, which is recoverable and visible. An exception here
+    would take out the whole endpoint.
+    """
+    from app.api.system import _capability_catalog
+
+    try:
+        return _capability_catalog(capability) or {}
+    except Exception:  # pragma: no cover - a catalog that cannot import
+        logger.warning("Could not read the %s catalog for the host allowlist", capability)
+        return {}
+
+
+def _normalise(raw) -> List[str]:
+    """The stored column as a clean sorted list of key names.
+
+    Defensive because the column is JSON: NULL on every row that predates the
+    migration, and anything at all if something ever wrote the wrong shape.
+    """
+    if not isinstance(raw, (list, tuple, set)):
+        return []
+    return sorted({k for k in raw if isinstance(k, str) and k})
+
+
+async def host_provided(db) -> List[str]:
+    """Which keys are currently the host's, sorted. Never raises."""
+    from app.services.system_settings import get_settings
+
+    try:
+        row = await get_settings(db)
+    except Exception:
+        logger.warning("Could not read host-provided credential ownership")
+        return []
+    return _normalise(getattr(row, "host_provided_keys", None))
+
+
+async def _store(db, *, add: Iterable[str] = (), drop: Iterable[str] = ()) -> List[str]:
+    """Adjust the ownership record in place. The caller commits.
+
+    Reads the column FRESH and applies a delta, rather than writing back a set
+    computed earlier. `apply` takes several seconds -- a vault write per key --
+    and a town admin who saves their own credential during that window calls
+    `forget`, which removes the key. Writing back a snapshot taken before the
+    loop started put it straight back, and the next push then overwrote the
+    value the clerk had just typed. The delta only ever says what THIS push
+    decided; anything else the row says now is somebody else's decision and is
+    left alone.
+
+    Assigned as a new list rather than mutated: SQLAlchemy does not track
+    in-place changes to a plain JSON column, so `keys.remove(...)` would be a
+    change that never reached the database -- and a provenance record that
+    silently does not persist is the failure mode where a town's own credential
+    keeps being overwritten by the host.
+    """
+    from app.services.system_settings import get_settings
+
+    row = await get_settings(db, create=True)
+    fresh = set(_normalise(getattr(row, "host_provided_keys", None)))
+    keys = sorted((fresh - set(drop)) | {k for k in add if k})
+    row.host_provided_keys = keys
+    return keys
+
+
+async def forget(db, key_name: str) -> bool:
+    """The town has entered its own value for this key, so it is theirs now.
+
+    Called from the single write choke-point (`_persist_secret`) on every
+    town-admin save, so there is no door into the secret table that leaves the
+    ownership record stale. Returns whether anything changed; does not commit,
+    because the caller's own commit is what makes the write and the ownership
+    change land together.
+
+    Never raises. This runs inside a save, and failing to update a provenance
+    note must not fail the credential write that produced it -- the town still
+    gets the value it typed, and the worst case is a later host push that is
+    accepted when it should have been refused.
+    """
+    try:
+        if key_name not in shareable_keys():
+            # Selector keys, backup keys, bootstrap keys: never host-provided,
+            # so there is nothing to look up. Keeps the ordinary save path from
+            # taking an extra read for every key that could not be on the list.
+            return False
+        from app.services.system_settings import get_settings
+
+        row = await get_settings(db)
+        current = _normalise(getattr(row, "host_provided_keys", None))
+        if key_name not in current:
+            return False
+        row.host_provided_keys = [k for k in current if k != key_name]
+        return True
+    except Exception:
+        logger.warning("Could not clear host provenance for a saved credential")
+        return False
+
+
+async def _is_configured(db, key_name: str) -> bool:
+    """Is there a credential stored against this key right now.
+
+    Two questions, because one of them is not enough. `get_secret` answers what
+    can be READ, and it never raises: every backend falls through to the
+    encrypted database copy and returns None when it has nothing. So a town
+    credential that lives in a vault the instance cannot currently reach -- an
+    expired service account, a network partition, a Key Vault the town rotated
+    -- reads as None, which is indistinguishable from "nobody ever set this".
+    Trusting that answer alone means the host's value is written over a clerk's
+    credential precisely when nothing can see that it is there, which is the one
+    outcome this endpoint may never produce.
+
+    So the `system_secrets` row is asked too. `is_configured` on that row is the
+    town's own record that a value was saved, and it survives the vault sweep
+    that scrubs `key_value` to NULL. Either answer saying yes is yes.
+
+    Raises rather than guessing if the row cannot be read at all: `apply` turns
+    that into a refusal, which is the safe direction for the same reason.
+    """
+    from sqlalchemy import select
+
+    from app.models import SystemSecret
+    from app.services.secret_manager import get_secret
+
+    if bool((await get_secret(key_name) or "").strip()):
+        return True
+    result = await db.execute(
+        select(SystemSecret.is_configured).where(SystemSecret.key_name == key_name)
+    )
+    return bool(result.scalar_one_or_none())
+
+
+async def _revoke(db, key_name: str) -> bool:
+    """Take back a credential the host has stopped sharing.
+
+    Deleted rather than blanked. The row and the vault entry both go, because
+    "the host is no longer providing this" has to leave nothing behind that a
+    later read could still resolve -- `get_secret` falls back to the database
+    copy when the vault does not answer, so clearing only one of the two would
+    leave the credential live.
+
+    Returns whether the credential is actually gone, and that return value is
+    the point of this function. `delete_secret` deletes from the vault AND from
+    the database and returns True if EITHER worked, so an unreachable or
+    unconfigured vault produces a successful-looking call that removed the
+    database copy and left the real credential live in the vault. Reporting
+    that as revoked and dropping the key from the ownership record would be the
+    worst of the three possible outcomes: the credential still works, nobody
+    knows it does, and the host can no longer withdraw it because the next push
+    will refuse a key it no longer owns.
+
+    So the key is looked up again afterwards, cache dropped first so the answer
+    is not the one we are trying to invalidate. If it still resolves, the caller
+    keeps ownership and reports it as failed, and the next push tries again.
+    """
+    from app.services.secret_manager import clear_cache, delete_secret
+
+    try:
+        await delete_secret(key_name)
+    except Exception:
+        logger.warning("Could not fully withdraw a host-provided credential")
+    try:
+        clear_cache(key_name=key_name)
+        from app.api.system import _invalidate_process_caches
+
+        _invalidate_process_caches(key_name)
+    except Exception:
+        pass
+    try:
+        return not await _is_configured(db, key_name)
+    except Exception:
+        # Cannot confirm it is gone. Same direction as everywhere else on this
+        # page: assume the credential is still there, keep it on the host's
+        # books, and say so.
+        logger.warning("Could not confirm withdrawal of a host-provided credential")
+        return False
+
+
+async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
+    """Apply a host's complete current set of shared credentials.
+
+    Full replace: what arrives is everything the host is sharing, so anything
+    the host used to provide and did not send this time is withdrawn.
+
+    Returns {"accepted", "refused", "revoked", "failed"} -- sorted key names,
+    and only names. Nothing here returns, logs or records a value. `failed` is
+    the withdrawal that did not take: the credential is still live, it is still
+    the host's, and the next push will try again.
+    """
+    from app.api.system import _persist_secret
+
+    incoming = {
+        str(k).strip(): v
+        for k, v in (secrets or {}).items()
+        if isinstance(k, str) and str(k).strip()
+    }
+    allowed = shareable_keys()
+    previously: List[str] = await host_provided(db)
+    owned = set(previously)
+
+    accepted: List[str] = []
+    refused: List[str] = []
+    # Keys claimed for the host before their write, whose write then failed.
+    # Subtracted again at the end -- see the claim below for why they are
+    # claimed first at all.
+    unclaim: List[str] = []
+
+    for key in sorted(incoming):
+        raw = incoming[key]
+        if not isinstance(raw, str):
+            # The request model types this Dict[str, str], so this is a
+            # defensive second line rather than the expected path. It is here
+            # because the first line used to be `dict`: a number or a nested
+            # object reached `.strip()`, raised AttributeError halfway through
+            # the loop, and returned 500 -- after some keys had already been
+            # written and committed. Refused per key, like every other bad
+            # input on this endpoint, so the rest of the batch still lands.
+            refused.append(key)
+            continue
+        value = raw.strip()
+        if key not in allowed:
+            # Unknown, platform-owned or BACKUP_-prefixed. Refused in the body
+            # rather than by a 4xx: one bad key in a batch must not throw away
+            # the good ones, and the host needs to see which key it was.
+            refused.append(key)
+            continue
+        if not value:
+            # The contract says every shared key arrives with a value, so a
+            # blank one is a mistake at the other end. Refusing is the
+            # conservative reading: writing it would clear a live credential,
+            # and revocation already has an unambiguous spelling (leave the key
+            # out entirely).
+            refused.append(key)
+            continue
+        if key not in owned:
+            try:
+                taken = await _is_configured(db, key)
+            except Exception:
+                # Cannot tell whether the town has one. Refuse: overwriting a
+                # town's own credential is the one outcome this endpoint may
+                # never produce by accident.
+                logger.warning("Could not establish ownership of a pushed credential; refusing it")
+                refused.append(key)
+                continue
+            if taken:
+                refused.append(key)
+                continue
+        # Ownership BEFORE the value, in the transaction the value commits in.
+        # `_persist_secret` commits each key as it writes it, and the ownership
+        # record used to be written once at the end -- so a failure partway
+        # through the batch left keys written into the town's vault with no
+        # record that the host put them there. The host could then neither
+        # replace nor withdraw them, because the next push sees a key it does
+        # not own with a value against it and refuses it: permanently stuck
+        # credentials, and the more keys in the batch the likelier it got.
+        #
+        # Claiming first is the safe half of the race. A claim whose write then
+        # fails leaves a key marked host-provided with nothing stored, which
+        # the next push simply writes; the reverse leaves a live credential
+        # nobody can manage.
+        await _store(db, add=[key])
+        try:
+            await _persist_secret(db, key, value, from_host=True)
+        except Exception:
+            logger.warning("Could not store a host-provided credential")
+            refused.append(key)
+            unclaim.append(key)
+            continue
+        accepted.append(key)
+
+    withdrawn: List[str] = []
+    failed: List[str] = []
+    for key in sorted(owned - set(incoming)):
+        if await _revoke(db, key):
+            withdrawn.append(key)
+        else:
+            # Still resolves. Keep it on the host's books: an unmanageable live
+            # credential is worse than one that is still listed as shared.
+            failed.append(key)
+
+    await _store(db, add=accepted, drop=withdrawn + unclaim)
+    await db.commit()
+
+    return {
+        "accepted": sorted(accepted),
+        "refused": sorted(refused),
+        "revoked": withdrawn,
+        "failed": failed,
+    }
+
+
+async def field_provenance(db, stored_fields: Dict[str, bool]) -> Dict[str, bool]:
+    """{credential key: did the host supply this one}, for the admin UI.
+
+    True only when the key is the host's AND there is actually a value stored,
+    so a box the host once filled and has since withdrawn does not keep
+    claiming a provider it no longer has. Presence and ownership; no values.
+
+    Empty on failure, which reads on screen as an ordinary town-entered
+    credential -- the safe direction for a note that is only ever explanatory.
+    """
+    try:
+        owned = set(await host_provided(db))
+    except Exception:
+        return {}
+    return {key: (key in owned and bool(stored)) for key, stored in (stored_fields or {}).items()}
+
+
+def sorted_names(keys: Sequence[str]) -> List[str]:
+    """Names only, sorted -- the shape every response and audit entry uses."""
+    return sorted({k for k in keys if k})

--- a/backend/app/services/host_secrets.py
+++ b/backend/app/services/host_secrets.py
@@ -171,6 +171,21 @@ async def _store(db, *, add: Iterable[str] = (), drop: Iterable[str] = ()) -> Li
     decided; anything else the row says now is somebody else's decision and is
     left alone.
 
+    `fresh=True` is what makes that read actually fresh, and it is the whole
+    point of the call. An ordinary `get_settings` issues the SELECT but
+    SQLAlchemy's identity map hands back the instance this session already
+    holds, with the attribute values it was loaded with -- so the concurrent
+    `forget` this re-read exists to notice is invisible, and the clerk's key
+    goes straight back onto the host's books. `populate_existing` is what tells
+    the ORM to overwrite the loaded attributes with what the database now says.
+    (The tell that the old read was not fresh: the round-trip test in
+    test_host_provided_credentials.py needs `session.expire_all()` before it
+    can see its own committed write.)
+
+    Flushed before returning, so the claim is durable inside the transaction
+    before the caller goes off to do a multi-second vault write -- and so the
+    NEXT fresh read sees it rather than discarding it as a pending change.
+
     Assigned as a new list rather than mutated: SQLAlchemy does not track
     in-place changes to a plain JSON column, so `keys.remove(...)` would be a
     change that never reached the database -- and a provenance record that
@@ -179,10 +194,15 @@ async def _store(db, *, add: Iterable[str] = (), drop: Iterable[str] = ()) -> Li
     """
     from app.services.system_settings import get_settings
 
-    row = await get_settings(db, create=True)
+    row = await get_settings(db, create=True, fresh=True)
     fresh = set(_normalise(getattr(row, "host_provided_keys", None)))
     keys = sorted((fresh - set(drop)) | {k for k in add if k})
     row.host_provided_keys = keys
+    try:
+        await db.flush()
+    except Exception:  # pragma: no cover - a session that cannot flush
+        # The caller's commit is still ahead of us and will carry the change.
+        logger.warning("Could not flush host provenance mid-push")
     return keys
 
 
@@ -208,7 +228,12 @@ async def forget(db, key_name: str) -> bool:
             return False
         from app.services.system_settings import get_settings
 
-        row = await get_settings(db)
+        # Fresh for the same reason `_store` is: a push running right now has
+        # been committing claims key by key, and the identity map would hand
+        # this session the row as it looked before any of them. Deciding "the
+        # host does not own this key" against a stale copy is how a clerk's
+        # save fails to take the key back.
+        row = await get_settings(db, fresh=True)
         current = _normalise(getattr(row, "host_provided_keys", None))
         if key_name not in current:
             return False
@@ -304,10 +329,13 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
     Full replace: what arrives is everything the host is sharing, so anything
     the host used to provide and did not send this time is withdrawn.
 
-    Returns {"accepted", "refused", "revoked", "failed"} -- sorted key names,
-    and only names. Nothing here returns, logs or records a value. `failed` is
-    the withdrawal that did not take: the credential is still live, it is still
-    the host's, and the next push will try again.
+    Returns {"accepted", "refused", "revoked", "failed", "db_only"} -- sorted
+    key names, and only names. Nothing here returns, logs or records a value.
+    `failed` is the withdrawal that did not take: the credential is still live,
+    it is still the host's, and the next push will try again. `db_only` is the
+    write that landed in the encrypted database copy but not in the external
+    secret store, which is a working credential today and a surprise the day
+    the database copy is scrubbed.
     """
     from app.api.system import _persist_secret
 
@@ -322,10 +350,28 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
 
     accepted: List[str] = []
     refused: List[str] = []
-    # Keys claimed for the host before their write, whose write then failed.
-    # Subtracted again at the end -- see the claim below for why they are
-    # claimed first at all.
+    # Keys the host did NOT already own, claimed just before their write, whose
+    # write then failed. Subtracted again at the end -- see the claim below for
+    # why they are claimed first at all.
+    #
+    # Only keys that were new to the host go in here, and that restriction is
+    # the whole of the fix for a bug that stranded credentials permanently. A
+    # re-push of a key the host already owned used to land here too on any
+    # transient vault error, and the key was then dropped from the ownership
+    # record while the host's PREVIOUS value stayed live in the town's vault.
+    # Every push after that saw a key the host does not own with a value
+    # against it, refused it (the guard below), and the host could neither
+    # replace nor withdraw it -- one blip, stranded forever. A key already on
+    # the host's books stays on them when a re-write fails: the value that is
+    # live is still the host's, so the record still says so, and the next push
+    # simply tries the write again.
     unclaim: List[str] = []
+    # Keys whose value reached the encrypted database copy but NOT the external
+    # secret store -- `_persist_secret` returning False. Every other caller of
+    # it surfaces this, because it is the ordering trap where a credential
+    # saved before the store was reachable lives only in the database and
+    # nobody finds out. Reported so the host can see it and re-push.
+    db_only: List[str] = []
 
     for key in sorted(incoming):
         raw = incoming[key]
@@ -382,17 +428,48 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
         # nobody can manage.
         await _store(db, add=[key])
         try:
-            await _persist_secret(db, key, value, from_host=True)
+            stored_externally = await _persist_secret(db, key, value, from_host=True)
         except Exception:
             logger.warning("Could not store a host-provided credential")
             refused.append(key)
-            unclaim.append(key)
+            if key not in previously:
+                # New key, nothing of the host's behind it: releasing the claim
+                # leaves the row exactly as it was. A key the host ALREADY
+                # owned keeps its claim -- see `unclaim` above for what
+                # dropping it cost.
+                unclaim.append(key)
             continue
+        if not stored_externally:
+            db_only.append(key)
         accepted.append(key)
 
     withdrawn: List[str] = []
     failed: List[str] = []
+    # The same allowlist the write path uses, applied to the revoke path. It was
+    # missing here, and the asymmetry is not academic: `allowed` is derived from
+    # the provider catalogs, so a provider leaving a catalog or a key becoming
+    # platform-managed shrinks it between one push and the next. A key stranded
+    # on the wrong side of that change was deleted -- vault and database both --
+    # because it looked like a withdrawal, when nothing had been withdrawn and
+    # the town was simply running a build whose catalogs no longer name the key.
+    # Deleting a live credential on the strength of a catalog edit is the one
+    # direction that cannot be undone from here, so a key the host owns but may
+    # no longer be given is left alone AND left on the host's books: the claim
+    # is what lets the host withdraw it deliberately if the key ever comes back.
+    #
+    # Note what is deliberately NOT revoked on the other side of the same
+    # asymmetry: a key that arrived in this payload and was REFUSED. Refusal
+    # says the write could not happen -- the town owns the key, the value was
+    # blank, the vault errored -- and none of those is the host saying "stop
+    # sharing this". Revocation has exactly one spelling in a full replace, and
+    # it is absence from the payload. A refused key is present, so it stays.
     for key in sorted(owned - set(incoming)):
+        if key not in allowed:
+            logger.warning(
+                "Keeping a host-provided credential that is no longer shareable "
+                "rather than deleting it"
+            )
+            continue
         if await _revoke(db, key):
             withdrawn.append(key)
         else:
@@ -400,7 +477,13 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
             # credential is worse than one that is still listed as shared.
             failed.append(key)
 
-    await _store(db, add=accepted, drop=withdrawn + unclaim)
+    # Drops only. Every accepted key claimed itself at the moment it was
+    # written, so re-adding the batch here added nothing except a race: a key a
+    # town admin claimed with `forget` partway through this loop was handed
+    # straight back to the host by this line, and the next push overwrote the
+    # value the clerk had just typed. What this call is for is the two
+    # subtractions, which nothing else has applied yet.
+    await _store(db, drop=withdrawn + unclaim)
     await db.commit()
 
     return {
@@ -408,6 +491,10 @@ async def apply(db, secrets: Optional[Dict[str, str]]) -> Dict[str, List[str]]:
         "refused": sorted(refused),
         "revoked": withdrawn,
         "failed": failed,
+        # Written, but only to the encrypted database copy -- the external
+        # store did not take it. Additive, like `failed` before it: a caller
+        # reading only the older keys is unaffected.
+        "db_only": sorted(db_only),
     }
 
 

--- a/backend/app/services/secret_manager.py
+++ b/backend/app/services/secret_manager.py
@@ -178,6 +178,26 @@ def store_chosen() -> bool:
     return _secrets_provider() in SECRET_STORES
 
 
+def external_store_configured() -> bool:
+    """Is there a store OUTSIDE the encrypted database for secrets to go to.
+
+    Not the same question as `store_chosen`, and the difference is the whole
+    reason this exists. "database" is a real answer to "where do the keys
+    live" -- a supported, deliberate choice -- so `store_chosen()` is True for
+    it. But there is then nothing external to write to, and `set_secret`
+    returns False for every key by design rather than by failure.
+
+    Callers that read that False as "the external store would not take it"
+    need this to tell the two apart. Without it, every credential saved on a
+    database-store deployment is reported as a write that only reached the
+    database and is about to disappear -- which is alarming, wrong, and
+    describes the deployment working exactly as configured. An unanswered
+    store ("") is external-less too: a value saved before the town has chosen
+    lands in the database on purpose and `vault_secrets` sweeps it in later.
+    """
+    return _secrets_provider() in ("google", "azure", "aws")
+
+
 def _is_gcp_available() -> bool:
     """Check if Google Cloud Secret Manager is available."""
     if _config["use_gcp"] is not None:

--- a/backend/app/services/system_settings.py
+++ b/backend/app/services/system_settings.py
@@ -69,20 +69,34 @@ def merge_into_canonical(rows: Sequence[Row], columns: Iterable[str]) -> tuple[O
     return canonical, others
 
 
-async def get_settings(db: Any, *, create: bool = False) -> Optional[Any]:
+async def get_settings(
+    db: Any, *, create: bool = False, fresh: bool = False
+) -> Optional[Any]:
     """Read the settings row deterministically.
 
     Ordered by id, so this returns the same row on every call regardless of how
     many exist or what the planner feels like doing. `create=True` inserts one
     when the table is empty, for the write paths.
+
+    `fresh=True` re-reads the row's columns from the database instead of
+    accepting the copy this session already has. The default is off because
+    almost every caller wants the cheap read, but it is not merely an
+    optimisation to skip: the SELECT below runs either way, and without
+    `populate_existing` the ORM discards the result and returns the identity
+    map's instance with whatever values it was first loaded with. A caller that
+    re-reads specifically to notice somebody else's committed change -- see
+    `host_secrets._store`, which re-reads mid-push to catch a town admin taking
+    a key back -- gets a stale answer and silently reverts them. Anything
+    checking for a concurrent write needs this flag.
     """
     from sqlalchemy import select
 
     from app.models import SystemSettings
 
-    row = (
-        await db.execute(select(SystemSettings).order_by(SystemSettings.id).limit(1))
-    ).scalar_one_or_none()
+    query = select(SystemSettings).order_by(SystemSettings.id).limit(1)
+    if fresh:
+        query = query.execution_options(populate_existing=True)
+    row = (await db.execute(query)).scalar_one_or_none()
     if row is None and create:
         row = SystemSettings()
         db.add(row)

--- a/backend/tests/test_every_route_states_its_audience.py
+++ b/backend/tests/test_every_route_states_its_audience.py
@@ -73,6 +73,7 @@ PUBLIC_WRITES = {
     ("provisioning.py", "post", "/lifecycle"),                       # provisioning token
     ("provisioning.py", "post", "/break-glass"),                     # signed break-glass token
     ("provisioning.py", "post", "/managed-settings"),                # provisioning token
+    ("provisioning.py", "post", "/host-secrets"),                    # provisioning token
 }
 
 

--- a/backend/tests/test_host_provided_credentials.py
+++ b/backend/tests/test_host_provided_credentials.py
@@ -1,0 +1,924 @@
+"""Credentials the host supplies, and the town's right to overrule them.
+
+A hosted town often has no account of its own with a map vendor or a
+translation API, so its host can push working credentials in and the setup page
+stops dead-ending on a box nobody can fill. That trade is only acceptable while
+three properties hold, and each of them fails silently, which is why they are
+pinned here rather than left to review:
+
+  * A credential the TOWN entered is never overwritten. The failure mode is a
+    clerk pasting a working key, a machine reverting it minutes later, and
+    nobody able to say why the connector broke.
+  * The push is a full replace, so a key the host stopped sharing is actually
+    deleted -- vault and encrypted database copy both, because `get_secret`
+    falls back to the second when the first does not answer. A half-revoked
+    credential is a live credential nobody thinks is live.
+  * The allowlist cannot reach the platform's own keys. `SECRETS_PROVIDER` or
+    `AWS_KMS_KEY_ID` arriving through this door would repoint where the town's
+    credentials live, from an endpoint whose entire promise is that it writes
+    provider credentials only.
+
+And the flat rule underneath all three: no key VALUE is returned, logged or
+audited. The response and the audit entry are key names and counts.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+# A submodule, not the top-level package. `pytest.importorskip("fastapi")` can
+# succeed against a partial install and then explode on the first real import;
+# see the header of test_migrate.py for the version of this that hid a whole
+# file from CI for months.
+pytest.importorskip("fastapi.routing")
+pytest.importorskip("sqlalchemy.orm")
+
+from fastapi import HTTPException
+
+from app.api import provisioning, system
+from app.services import host_secrets
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# Captured before any fixture replaces it, so the end-to-end test can put the
+# genuine write path back and exercise it.
+_REAL_PERSIST_SECRET = system._persist_secret
+
+
+# ---------------------------------------------------------------------------
+# Doubles. The suite has no database, so the settings row and the secret store
+# are stood in for -- but `apply` itself is the real thing under test, and so is
+# every ownership decision it makes.
+# ---------------------------------------------------------------------------
+
+class FakeRow:
+    """The singleton settings row, as far as this feature is concerned."""
+
+    def __init__(self, keys=None):
+        self.id = 1
+        self.host_provided_keys = keys
+
+
+class FakeDB:
+    def __init__(self):
+        self.commits = 0
+
+    async def commit(self):
+        self.commits += 1
+
+
+class Store:
+    """A secret store that records writes and deletions by key."""
+
+    def __init__(self, existing=None):
+        self.values = dict(existing or {})
+        self.writes = []
+        self.deleted = []
+        self.host_writes = []
+        # Keys whose vault delete does not take. `delete_secret` returns True
+        # when EITHER half of the delete worked, so this is the shape of a real
+        # failure: the database copy goes, the vault entry stays, and the
+        # credential is still live.
+        self.undeletable = set()
+        # Called on every persist, so a test can act in the middle of a batch.
+        self.on_persist = None
+
+    async def persist(self, db, key_name, value, *, from_host=False):
+        if self.on_persist:
+            await self.on_persist(key_name)
+        self.values[key_name] = value
+        self.writes.append(key_name)
+        if from_host:
+            self.host_writes.append(key_name)
+        return True
+
+    async def configured(self, _db, key_name):
+        return bool((self.values.get(key_name) or "").strip())
+
+    async def revoke(self, db, key_name):
+        """Stands in for `_revoke`: delete, then answer whether it is gone."""
+        self.deleted.append(key_name)
+        if key_name in self.undeletable:
+            return False
+        self.values.pop(key_name, None)
+        return True
+
+
+@pytest.fixture
+def town(monkeypatch):
+    """A town whose settings row and secret store we can inspect."""
+    row = FakeRow()
+    store = Store()
+    db = FakeDB()
+
+    async def get_settings(_db, *, create=False):
+        return row
+
+    monkeypatch.setattr("app.services.system_settings.get_settings", get_settings)
+    monkeypatch.setattr(system, "_persist_secret", store.persist)
+    monkeypatch.setattr(host_secrets, "_is_configured", store.configured)
+    monkeypatch.setattr(host_secrets, "_revoke", store.revoke)
+
+    class Town:
+        pass
+
+    t = Town()
+    t.row, t.store, t.db = row, store, db
+    return t
+
+
+A_KEY = "GOOGLE_MAPS_API_KEY"
+ANOTHER = "AZURE_TRANSLATOR_KEY"
+VALUE = "AIza-not-a-real-key-0001"
+
+
+# ---------------------------------------------------------------------------
+# The allowlist
+# ---------------------------------------------------------------------------
+
+def test_the_allowlist_is_derived_from_the_catalogs():
+    """Not hand-listed. A credential field removed from a catalog stops being
+    pushable at the same moment it stops being read, and a provider added later
+    is covered without anyone remembering to come back here."""
+    keys = host_secrets.shareable_keys()
+    assert A_KEY in keys
+    assert "TWILIO_AUTH_TOKEN" in keys
+    assert "AUTH0_CLIENT_SECRET" in keys
+    # No provider card declares it, but it is still a per-deployment credential
+    # a host plausibly owns.
+    assert "SENTRY_DSN" in keys
+
+
+@pytest.mark.parametrize("key", [
+    # The storage arrangement. Pushing these would repoint where every other
+    # credential lives, which is not a provider credential by any reading.
+    "SECRETS_PROVIDER", "KMS_PROVIDER", "AWS_KMS_KEY_ID", "GCP_SERVICE_ACCOUNT_JSON",
+    # The host's own backups, not something to copy into a town's vault.
+    "BACKUP_ENCRYPTION_KEY", "BACKUP_S3_BUCKET",
+    # The instance's identity and database.
+    "SECRET_KEY", "DATABASE_URL", "PROVISIONING_TOKEN",
+])
+def test_the_platform_keys_are_not_shareable(key):
+    assert key not in host_secrets.shareable_keys(), key
+
+
+@pytest.mark.parametrize("key", sorted(host_secrets.NON_CREDENTIAL_KEYS))
+def test_the_behaviour_toggles_are_not_shareable(key):
+    """They sit in a provider catalog's credential_fields because the card has
+    to show them, but they are not credentials and a host has no standing to
+    set them.
+
+    REDACT_FACES and REDACT_PLATES are the ones that matter: they decide
+    whether faces and number plates in residents' photographs are blurred
+    before anybody sees them. A host that could push REDACT_FACES=false would
+    be turning off the blurring of residents' faces from its own console,
+    silently, on whatever schedule it pushes on. That is the town's decision
+    and there is no version of "the host has an account for it" that applies.
+    """
+    assert key not in host_secrets.shareable_keys(), key
+
+
+def test_the_non_secret_companion_fields_stay_shareable():
+    """The deny-list is a subtraction, not a switch to "secret fields only".
+
+    A key arrives with the things it needs to be used: Auth0's domain, the
+    endpoint an Azure key is scoped to, the project a Vertex credential names.
+    Filtering on `secret: true` would have removed every one of them, and the
+    town would have been handed credentials that cannot connect to anything --
+    which is worse than not being handed them, because the card reports
+    configured."""
+    keys = host_secrets.shareable_keys()
+    for companion in ("AUTH0_DOMAIN", "AZURE_TRANSLATOR_ENDPOINT", "VERTEX_AI_PROJECT"):
+        assert companion in keys, companion
+
+
+@pytest.mark.parametrize("key", [
+    "SECRETS_PROVIDER", "BACKUP_ENCRYPTION_KEY", "NOT_A_REAL_SETTING", "",
+])
+def test_a_key_off_the_allowlist_is_refused_not_written(town, key):
+    """Refused in the body rather than by a 4xx: one bad key in a batch must
+    not throw away the good ones, and the host has to be told which key."""
+    result = _run(host_secrets.apply(town.db, {key: "x", A_KEY: VALUE}))
+
+    assert result["accepted"] == [A_KEY]
+    assert town.store.writes == [A_KEY]
+    if key:
+        assert result["refused"] == [key]
+
+
+# ---------------------------------------------------------------------------
+# Accept, then revoke -- the full-replace round trip
+# ---------------------------------------------------------------------------
+
+def test_a_pushed_credential_is_stored_and_recorded_as_the_hosts(town):
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result == {"accepted": [A_KEY], "refused": [], "revoked": [], "failed": []}
+    assert town.store.values[A_KEY] == VALUE
+    assert town.row.host_provided_keys == [A_KEY]
+    # Written through the host door, so the write does not take ownership away
+    # from the host it just gave it to.
+    assert town.store.host_writes == [A_KEY]
+
+
+def test_pushing_the_same_value_again_changes_nothing(town):
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result["accepted"] == [A_KEY]
+    assert result["revoked"] == []
+    assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_a_key_left_out_of_the_next_push_is_withdrawn(town):
+    """Full replace. The host's console has no other way to say "stop sharing
+    this", so absence has to mean it -- and it has to mean deleted, not merely
+    unlisted, or the credential stays live in the town's vault."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result["revoked"] == [ANOTHER]
+    assert town.store.deleted == [ANOTHER]
+    assert ANOTHER not in town.store.values
+    assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_an_empty_push_withdraws_everything(town):
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    result = _run(host_secrets.apply(town.db, {}))
+
+    assert result["revoked"] == [ANOTHER, A_KEY]
+    assert town.row.host_provided_keys == []
+
+
+# ---------------------------------------------------------------------------
+# The town wins
+# ---------------------------------------------------------------------------
+
+def test_a_credential_the_town_configured_is_refused(town):
+    """The town's own key wins. Not a 4xx and not a partial write: the host is
+    told which key it may not have, and the key keeps the value a clerk
+    entered."""
+    town.store.values[A_KEY] = "the-towns-own-key"
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result == {"accepted": [], "refused": [A_KEY], "revoked": [], "failed": []}
+    assert town.store.values[A_KEY] == "the-towns-own-key"
+    assert town.store.writes == []
+    assert town.row.host_provided_keys == []
+
+
+def test_a_town_save_flips_ownership_and_the_next_push_is_refused(town):
+    """The whole override contract, end to end: the host supplies a key, a
+    clerk types their own value over it, and the host can no longer touch it.
+
+    The flip happens in `_persist_secret`, which every town-admin write goes
+    through, so this is the property that makes it safe for the host to keep
+    pushing on a schedule."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+    assert town.row.host_provided_keys == [A_KEY]
+
+    # What a town-admin save does: the value lands, and ownership moves.
+    town.store.values[A_KEY] = "typed-by-the-clerk"
+    _run(host_secrets.forget(town.db, A_KEY))
+    assert town.row.host_provided_keys == []
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+    assert result["refused"] == [A_KEY]
+    assert town.store.values[A_KEY] == "typed-by-the-clerk"
+
+
+def test_a_save_during_the_push_is_not_undone_when_it_finishes(town):
+    """The race. A push is a vault write per key and takes seconds; a clerk who
+    saves their own credential inside that window calls `forget`, which takes
+    the key off the host.
+
+    The ownership record used to be written back at the end from a snapshot
+    taken before the loop started, which put the key straight back -- and the
+    next scheduled push then overwrote the value the clerk had just typed, with
+    nothing anywhere saying why. So the record is re-read fresh and only the
+    keys this push actually decided about are changed."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    assert town.row.host_provided_keys == [ANOTHER, A_KEY]
+
+    async def the_clerk_saves_their_own(key_name):
+        if key_name == A_KEY:
+            town.store.values[ANOTHER] = "typed-by-the-clerk"
+            await host_secrets.forget(town.db, ANOTHER)
+
+    town.store.on_persist = the_clerk_saves_their_own
+
+    # ANOTHER is in the push but blank, so it is refused -- the case where the
+    # old code kept it purely because the stale snapshot said it was the host's.
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "   "}))
+
+    assert result["refused"] == [ANOTHER]
+    assert town.row.host_provided_keys == [A_KEY]
+    assert town.store.values[ANOTHER] == "typed-by-the-clerk"
+
+
+def test_ownership_is_not_taken_for_a_key_nobody_shared(town):
+    assert _run(host_secrets.forget(town.db, A_KEY)) is False
+    assert host_secrets._normalise(town.row.host_provided_keys) == []
+
+
+def test_a_configured_but_unreadable_credential_is_refused(monkeypatch):
+    """The one the fake store cannot show you, so it is tested against the real
+    `_is_configured`.
+
+    `get_secret` does not raise when the vault is unreachable. Every backend
+    falls through to the encrypted database copy and returns None -- and the
+    vault sweep has already scrubbed that copy to NULL for any key that
+    migrated. So a town credential sitting in a Key Vault the instance cannot
+    currently reach reads back as None, exactly like a key nobody ever set.
+
+    The `system_secrets` row still says `is_configured = True`. That is the
+    town's own record that a clerk saved something, and it is why the check
+    asks the row as well as the store: reading the value is not the only way to
+    know a credential is there, and overwriting one because we could not read
+    it is the failure this endpoint exists to avoid."""
+    class Result:
+        """The system_secrets row: saved, and scrubbed by the vault sweep."""
+
+        def scalar_one_or_none(self):
+            return True
+
+    class DB:
+        def __init__(self):
+            self.commits = 0
+
+        async def execute(self, _stmt):
+            return Result()
+
+        async def commit(self):
+            self.commits += 1
+
+    row = FakeRow()
+    store = Store()
+
+    async def get_settings(_db, *, create=False):
+        return row
+
+    async def unreadable(_key):
+        # What an unreachable vault actually does: None, and no exception.
+        return None
+
+    monkeypatch.setattr("app.services.system_settings.get_settings", get_settings)
+    monkeypatch.setattr("app.services.secret_manager.get_secret", unreadable)
+    monkeypatch.setattr(system, "_persist_secret", store.persist)
+
+    result = _run(host_secrets.apply(DB(), {A_KEY: VALUE}))
+
+    assert result["refused"] == [A_KEY]
+    assert result["accepted"] == []
+    assert store.writes == []
+    assert host_secrets._normalise(row.host_provided_keys) == []
+
+
+def test_a_store_that_cannot_be_asked_at_all_refuses(town, monkeypatch):
+    """The pessimistic answer everywhere else on this page is "not configured",
+    and here that would mean writing over a town credential nobody could read.
+    So this one refuses instead of guessing."""
+    async def boom(_db, _key):
+        raise RuntimeError("settings row unreadable")
+
+    monkeypatch.setattr(host_secrets, "_is_configured", boom)
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result["refused"] == [A_KEY]
+    assert town.store.writes == []
+
+
+def test_a_blank_value_is_refused_rather_than_clearing_a_credential(town):
+    """Revocation has an unambiguous spelling -- leave the key out. A blank
+    value is a mistake at the other end, and writing it would clear a live
+    credential."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+    result = _run(host_secrets.apply(town.db, {A_KEY: "   "}))
+
+    assert result["refused"] == [A_KEY]
+    assert result["revoked"] == []
+    assert town.store.values[A_KEY] == VALUE
+
+
+# ---------------------------------------------------------------------------
+# A malformed push must not half-land
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", [1234, None, {"nested": "object"}, ["a"], True])
+def test_a_value_that_is_not_a_string_is_refused_not_raised(town, value):
+    """It used to be an AttributeError on `.strip()`, which is a 500 -- and a
+    500 halfway through a batch, after earlier keys had already been written
+    and committed by `_persist_secret`. Refused per key, like every other bad
+    input here, so one malformed entry costs that entry and the rest of the
+    push still lands."""
+    result = _run(host_secrets.apply(town.db, {ANOTHER: value, A_KEY: VALUE}))
+
+    assert result["refused"] == [ANOTHER]
+    assert result["accepted"] == [A_KEY]
+    assert town.store.writes == [A_KEY]
+    assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_the_request_model_rejects_a_non_string_value():
+    """The first line of the same defence, at the door. `secrets: dict` took
+    anything at all; `Dict[str, str]` is what makes the loop's check a second
+    line rather than the only one."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        provisioning.HostSecretsRequest(secrets={A_KEY: {"not": "a string"}})
+
+
+def test_a_write_that_fails_midway_leaves_no_unowned_credential(town):
+    """The orphan. `_persist_secret` commits each key as it goes, and ownership
+    used to be written once at the end -- so a failure partway through left
+    keys sitting in the town's vault with nothing recording that the host put
+    them there.
+
+    That is not a cosmetic gap. The next push sees a key it does not own with a
+    value against it, refuses it, and the host can then neither replace nor
+    withdraw the credential it just installed: permanently stuck, and the more
+    keys in the batch the likelier it got. So ownership is claimed in the same
+    transaction as the write."""
+    seen = []
+
+    async def blow_up_on_the_second(key_name):
+        seen.append(key_name)
+        if len(seen) == 2:
+            raise RuntimeError("vault write failed")
+
+    town.store.on_persist = blow_up_on_the_second
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    # ANOTHER sorts first, so A_KEY is the one that blew up.
+    assert result["accepted"] == [ANOTHER]
+    assert result["refused"] == [A_KEY]
+    # Everything written is owned, and nothing unwritten is.
+    assert town.row.host_provided_keys == [ANOTHER]
+    assert set(town.store.values) == {ANOTHER}
+
+
+def test_every_committed_key_is_owned_at_the_moment_it_is_written(town):
+    """The property underneath the test above, checked where it matters: at the
+    instant `_persist_secret` commits a value, the ownership record already
+    names that key. Anything weaker is a window in which a crash strands a
+    credential."""
+    owned_at_write = {}
+
+    async def look(key_name):
+        owned_at_write[key_name] = list(
+            host_secrets._normalise(town.row.host_provided_keys)
+        )
+
+    town.store.on_persist = look
+
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    assert A_KEY in owned_at_write[A_KEY]
+    assert ANOTHER in owned_at_write[ANOTHER]
+
+
+# ---------------------------------------------------------------------------
+# A withdrawal that does not take
+# ---------------------------------------------------------------------------
+
+def test_a_failed_withdrawal_keeps_the_key_and_says_so(town):
+    """`delete_secret` returns True when EITHER the vault delete or the database
+    delete worked. An unreachable vault therefore produces a successful-looking
+    call that removed the database copy and left the real credential live.
+
+    Dropping the key from the ownership record on that basis is the worst
+    available outcome: the credential still works, nothing on screen says it is
+    the host's, and the host cannot withdraw it on a later push because it no
+    longer owns it. So a withdrawal that cannot be confirmed keeps the key and
+    is reported in `failed`."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    town.store.undeletable.add(ANOTHER)
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result["revoked"] == []
+    assert result["failed"] == [ANOTHER]
+    # Still live, and still the host's to take back.
+    assert town.store.values[ANOTHER] == "translator-0002"
+    assert town.row.host_provided_keys == [ANOTHER, A_KEY]
+
+
+def test_a_later_push_can_still_withdraw_what_failed_before(town):
+    """Which is the point of keeping it. The retry is the next ordinary push --
+    the host's console has nothing else to say, and nothing has to be
+    reconciled by hand."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    town.store.undeletable.add(ANOTHER)
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    town.store.undeletable.clear()
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+
+    assert result["revoked"] == [ANOTHER]
+    assert result["failed"] == []
+    assert ANOTHER not in town.store.values
+    assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_a_revoke_reports_failure_when_the_credential_still_resolves(monkeypatch):
+    """The real `_revoke`, not the stand-in: the delete is called, it answers
+    the cheerful True that a half-delete answers, and the key still reads back.
+    """
+    from app.services import secret_manager
+
+    async def delete_secret(_key):
+        return True  # The database copy went; the vault entry did not.
+
+    monkeypatch.setattr(secret_manager, "delete_secret", delete_secret)
+    monkeypatch.setattr(secret_manager, "clear_cache", lambda **kw: None)
+
+    async def still_there(_key):
+        return "the-value-that-would-not-die"
+
+    monkeypatch.setattr(secret_manager, "get_secret", still_there)
+
+    assert _run(host_secrets._revoke(FakeDB(), A_KEY)) is False
+
+
+# ---------------------------------------------------------------------------
+# The write choke-point
+# ---------------------------------------------------------------------------
+
+def test_the_town_reading_is_the_default_for_persist_secret():
+    """`from_host` has to be opted into. A write path added later that forgets
+    the flag takes ownership for the town, which is the safe direction: the
+    host stops being able to overwrite something, rather than starting to."""
+    import inspect
+
+    sig = inspect.signature(system._persist_secret)
+    assert sig.parameters["from_host"].default is False
+    assert sig.parameters["from_host"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_every_town_write_path_clears_provenance():
+    """Two doors into the secret table, and both have to move ownership. The
+    plain-secrets endpoint does not go through `_persist_secret` -- it predates
+    it and writes the row itself -- so a check that only looked at the choke
+    point would miss the one way a town could enter its own credential and
+    still be overwritten."""
+    import inspect
+
+    for fn in (system._persist_secret, system.create_or_update_secret):
+        src = inspect.getsource(fn)
+        assert "host_secrets.forget" in src, fn.__name__
+
+
+# ---------------------------------------------------------------------------
+# The endpoint
+# ---------------------------------------------------------------------------
+
+def test_the_route_exists_on_the_provisioning_router():
+    paths = {r.path for r in provisioning.router.routes}
+    assert "/host-secrets" in paths
+
+
+def test_the_endpoint_is_inert_until_a_provisioning_token_is_set(monkeypatch):
+    """404, not 401. A standalone install exposes no provisioning surface at
+    all -- the endpoint does not merely refuse, it does not exist."""
+    class NoToken:
+        provisioning_token = ""
+
+    monkeypatch.setattr(provisioning, "get_settings", lambda: NoToken())
+    with pytest.raises(HTTPException) as exc:
+        provisioning.require_provisioning_token("anything")
+    assert exc.value.status_code == 404
+
+
+def test_a_wrong_token_is_rejected(monkeypatch):
+    class Token:
+        provisioning_token = "the-real-token"
+
+    monkeypatch.setattr(provisioning, "get_settings", lambda: Token())
+    with pytest.raises(HTTPException) as exc:
+        provisioning.require_provisioning_token("not-the-token")
+    assert exc.value.status_code == 401
+
+    assert provisioning.require_provisioning_token("the-real-token") == "orchestrator"
+
+
+def test_the_endpoint_answers_with_names_and_audits_no_values(town, monkeypatch):
+    recorded = {}
+
+    async def log_event(db, **kw):
+        recorded.update(kw)
+
+    monkeypatch.setattr(provisioning.AuditService, "log_event", log_event)
+
+    body = provisioning.HostSecretsRequest(secrets={A_KEY: VALUE, "SECRETS_PROVIDER": "aws"})
+    response = _run(provisioning.set_host_secrets(body, db=town.db, actor="orchestrator"))
+
+    assert response == {
+        "status": "ok",
+        "accepted": [A_KEY],
+        "refused": ["SECRETS_PROVIDER"],
+        "revoked": [],
+        "failed": [],
+    }
+    assert recorded["event_type"] == "provisioning_host_secrets"
+    assert recorded["details"]["counts"] == {
+        "accepted": 1, "refused": 1, "revoked": 0, "failed": 0,
+    }
+
+    # The flat rule: a value never reaches the audit table, which is exported.
+    assert VALUE not in json.dumps(recorded["details"])
+    assert VALUE not in json.dumps(response)
+
+
+# ---------------------------------------------------------------------------
+# What the admin console is told
+# ---------------------------------------------------------------------------
+
+def test_provenance_is_reported_per_field_and_only_where_stored(town):
+    """True needs both halves. A box the host once filled and has since
+    withdrawn must not keep claiming a provider the town no longer has."""
+    town.row.host_provided_keys = [A_KEY, ANOTHER]
+
+    provenance = _run(host_secrets.field_provenance(
+        town.db, {A_KEY: True, ANOTHER: False, "SMTP_PASSWORD": True}
+    ))
+
+    assert provenance == {A_KEY: True, ANOTHER: False, "SMTP_PASSWORD": False}
+
+
+def test_provenance_reads_as_town_owned_when_it_cannot_be_read(town, monkeypatch):
+    """The note is explanatory, so the safe failure is an ordinary "Saved"."""
+    async def boom(_db, *, create=False):
+        raise RuntimeError("no settings row")
+
+    monkeypatch.setattr("app.services.system_settings.get_settings", boom)
+    assert _run(host_secrets.field_provenance(town.db, {A_KEY: True})) == {A_KEY: False}
+
+
+def test_every_catalog_route_reports_provenance():
+    """All five of them. The generic route serves five capabilities and the four
+    hand-written ones came first, so a change made in one place and not the
+    others is the standing failure mode on this endpoint family."""
+    import inspect
+
+    routes = (
+        system.get_identity_catalog,
+        system.get_translation_catalog,
+        system.get_maps_catalog,
+        system.get_ai_catalog,
+        system.get_capability_catalog,
+    )
+    for fn in routes:
+        src = inspect.getsource(fn)
+        assert '"host_provided"' in src, fn.__name__
+        assert "_host_provided_fields" in src, fn.__name__
+
+
+def test_the_secrets_list_says_who_supplied_each_key(town, monkeypatch):
+    class FakeSecret:
+        def __init__(self, key_name):
+            self.id = 1
+            self.key_name = key_name
+            self.key_value = None
+            self.description = None
+            self.is_configured = True
+
+    rows = [FakeSecret(A_KEY), FakeSecret("SMTP_PASSWORD")]
+
+    class Result:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return rows
+
+    class DB:
+        async def execute(self, _stmt):
+            return Result()
+
+    async def get_secret(_key):
+        return "something"
+
+    monkeypatch.setattr("app.services.secret_manager.get_secret", get_secret)
+
+    async def host_provided(_db):
+        return [A_KEY]
+
+    monkeypatch.setattr(host_secrets, "host_provided", host_provided)
+
+    listed = _run(system.list_secrets(db=DB(), _=None))
+
+    by_key = {row.key_name: row for row in listed}
+    assert by_key[A_KEY].host_provided is True
+    assert by_key["SMTP_PASSWORD"].host_provided is False
+    # Still no values, for any key.
+    assert all(row.key_value is None for row in listed)
+
+
+def test_the_secrets_list_drops_the_host_note_when_nothing_is_stored(town, monkeypatch):
+    """Both halves, the same rule the catalog routes use. A key the host has
+    since withdrawn kept saying "supplied by your host" next to an empty box,
+    which reads as a credential the town has and does not -- and the row
+    survives the withdrawal, because `is_configured` on the list is computed
+    from what can actually be read."""
+    class FakeSecret:
+        def __init__(self, key_name):
+            self.id = 1
+            self.key_name = key_name
+            self.key_value = None
+            self.description = None
+            self.is_configured = True
+
+    rows = [FakeSecret(A_KEY)]
+
+    class Result:
+        def scalars(self):
+            return self
+
+        def all(self):
+            return rows
+
+    class DB:
+        async def execute(self, _stmt):
+            return Result()
+
+    async def get_secret(_key):
+        return None  # Withdrawn, or never readable.
+
+    monkeypatch.setattr("app.services.secret_manager.get_secret", get_secret)
+
+    async def host_provided(_db):
+        return [A_KEY]
+
+    monkeypatch.setattr(host_secrets, "host_provided", host_provided)
+
+    listed = _run(system.list_secrets(db=DB(), _=None))
+
+    assert listed[0].is_configured is False
+    assert listed[0].host_provided is False
+
+
+def test_clearing_a_host_provided_key_takes_it_off_the_host(town, monkeypatch):
+    """A blank save on the plain secrets endpoint is a deliberate clear -- the
+    box IS the credential there, unlike the provider cards where an untouched
+    masked field posts empty and means "keep what is stored".
+
+    The `forget` call used to be inside `if secret_data.key_value:`, so
+    clearing a host-supplied key left it host-owned and the next scheduled push
+    put it straight back. A town that deletes a credential has decided it does
+    not want that credential, and a machine undoing that decision minutes later
+    is indistinguishable from the clear not having worked."""
+    from app.schemas import SecretCreate
+
+    town.row.host_provided_keys = [A_KEY]
+
+    class Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class DB:
+        def __init__(self):
+            self.added = []
+
+        async def execute(self, _stmt):
+            return Result()
+
+        def add(self, obj):
+            self.added.append(obj)
+
+        async def commit(self):
+            pass
+
+        async def refresh(self, _obj):
+            pass
+
+    class Background:
+        def add_task(self, *a, **kw):
+            pass
+
+    async def noop(*a, **kw):
+        pass
+
+    monkeypatch.setattr(system, "_require_a_secret_store", lambda: None)
+    monkeypatch.setattr("app.services.secret_manager.set_secret", noop)
+    monkeypatch.setattr("app.services.admin_audit.record_admin_action", noop)
+
+    _run(system.create_or_update_secret(
+        SecretCreate(key_name=A_KEY, key_value=""),
+        background=Background(),
+        db=DB(),
+        _=None,
+    ))
+
+    assert town.row.host_provided_keys == []
+
+
+# ---------------------------------------------------------------------------
+# The real write path
+# ---------------------------------------------------------------------------
+
+def test_a_push_lands_before_the_town_has_chosen_a_secret_store(town, monkeypatch):
+    """End to end through the REAL `_persist_secret`, with no store chosen.
+
+    This is the state a town is in the moment it is provisioned, and it is the
+    whole reason the endpoint has no store gate: the admin pages refuse a
+    credential until somebody says where credentials go, which protects a
+    person from an unmade decision, but refusing the host's push would leave a
+    fresh town with no credentials and no way to be given any until an admin
+    logged in.
+
+    So: no 409, an encrypted row written to the database (never plaintext, even
+    in this pre-decision window), and the key recorded as the host's."""
+    from app.core.encryption import decrypt
+    from app.services import secret_manager
+
+    monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+    # No project, no client: the "not available" answer, without asking the
+    # network for it.
+    monkeypatch.setitem(secret_manager._config, "use_gcp", False)
+
+    class Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class DB:
+        def __init__(self):
+            self.added = []
+            self.commits = 0
+
+        async def execute(self, _stmt):
+            return Result()
+
+        def add(self, obj):
+            self.added.append(obj)
+
+        async def commit(self):
+            self.commits += 1
+
+    db = DB()
+    # The real thing, not the fixture's recorder.
+    monkeypatch.setattr(system, "_persist_secret", _REAL_PERSIST_SECRET)
+
+    result = _run(host_secrets.apply(db, {A_KEY: VALUE}))
+
+    assert result["accepted"] == [A_KEY]
+    assert result["refused"] == []
+    assert len(db.added) == 1
+    written = db.added[0]
+    assert written.key_name == A_KEY
+    assert written.is_configured is True
+    # Encrypted at rest, and it really is the value we pushed.
+    assert written.key_value != VALUE
+    assert decrypt(written.key_value) == VALUE
+    assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_the_ownership_column_survives_a_real_round_trip():
+    """A real SQLAlchemy JSON column, not a plain attribute on a stand-in.
+
+    The suite has no async database (no aiosqlite), so this uses a synchronous
+    SQLite session against the actual `SystemSettings` model -- which is enough,
+    because what is being checked is ORM change tracking, not the driver.
+
+    SQLAlchemy does not see in-place mutation of a plain JSON column: a
+    `keys.remove(...)` or `keys.append(...)` is a change that flushes as
+    nothing. `_store` therefore assigns a new list, and this is the test that
+    fails if somebody ever tidies that into a mutation -- a provenance record
+    that silently does not persist is exactly the bug where a town's own
+    credential keeps being overwritten by the host."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from app.models import SystemSettings
+
+    engine = create_engine("sqlite://")
+    SystemSettings.__table__.create(engine)
+
+    with Session(engine) as session:
+        row = SystemSettings(host_provided_keys=[A_KEY, ANOTHER])
+        session.add(row)
+        session.commit()
+
+        # What `_store` does: fresh set, assigned.
+        row.host_provided_keys = sorted(
+            set(host_secrets._normalise(row.host_provided_keys)) - {ANOTHER}
+        )
+        session.commit()
+        session.expire_all()
+
+        reloaded = session.query(SystemSettings).one()
+        assert reloaded.host_provided_keys == [A_KEY]
+
+        # And empty is stored as empty, not as NULL-that-reads-as-unknown.
+        reloaded.host_provided_keys = []
+        session.commit()
+        session.expire_all()
+        assert session.query(SystemSettings).one().host_provided_keys == []

--- a/backend/tests/test_host_provided_credentials.py
+++ b/backend/tests/test_host_provided_credentials.py
@@ -66,9 +66,15 @@ class FakeRow:
 class FakeDB:
     def __init__(self):
         self.commits = 0
+        self.flushes = 0
 
     async def commit(self):
         self.commits += 1
+
+    async def flush(self):
+        # `_store` flushes so a claim is durable inside the transaction before
+        # the caller goes off to do a multi-second vault write.
+        self.flushes += 1
 
 
 class Store:
@@ -87,6 +93,11 @@ class Store:
         # Called on every persist, so a test can act in the middle of a batch.
         self.on_persist = None
 
+        # Keys whose write lands in the encrypted database copy but which the
+        # external store will not take -- what `_persist_secret` reports by
+        # returning False.
+        self.db_only = set()
+
     async def persist(self, db, key_name, value, *, from_host=False):
         if self.on_persist:
             await self.on_persist(key_name)
@@ -94,7 +105,7 @@ class Store:
         self.writes.append(key_name)
         if from_host:
             self.host_writes.append(key_name)
-        return True
+        return key_name not in self.db_only
 
     async def configured(self, _db, key_name):
         return bool((self.values.get(key_name) or "").strip())
@@ -115,7 +126,11 @@ def town(monkeypatch):
     store = Store()
     db = FakeDB()
 
-    async def get_settings(_db, *, create=False):
+    async def get_settings(_db, *, create=False, fresh=False):
+        # `fresh` is the real helper's populate_existing re-read. There is one
+        # row object here and every read already sees the latest state, so the
+        # flag only has to be accepted -- a test that needs to simulate a
+        # concurrent write mutates `row` directly.
         return row
 
     monkeypatch.setattr("app.services.system_settings.get_settings", get_settings)
@@ -217,7 +232,8 @@ def test_a_key_off_the_allowlist_is_refused_not_written(town, key):
 def test_a_pushed_credential_is_stored_and_recorded_as_the_hosts(town):
     result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
 
-    assert result == {"accepted": [A_KEY], "refused": [], "revoked": [], "failed": []}
+    assert result == {"accepted": [A_KEY], "refused": [], "revoked": [], "failed": [],
+                      "db_only": []}
     assert town.store.values[A_KEY] == VALUE
     assert town.row.host_provided_keys == [A_KEY]
     # Written through the host door, so the write does not take ownership away
@@ -267,7 +283,8 @@ def test_a_credential_the_town_configured_is_refused(town):
 
     result = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
 
-    assert result == {"accepted": [], "refused": [A_KEY], "revoked": [], "failed": []}
+    assert result == {"accepted": [], "refused": [A_KEY], "revoked": [], "failed": [],
+                      "db_only": []}
     assert town.store.values[A_KEY] == "the-towns-own-key"
     assert town.store.writes == []
     assert town.row.host_provided_keys == []
@@ -361,7 +378,11 @@ def test_a_configured_but_unreadable_credential_is_refused(monkeypatch):
     row = FakeRow()
     store = Store()
 
-    async def get_settings(_db, *, create=False):
+    async def get_settings(_db, *, create=False, fresh=False):
+        # `fresh` is the real helper's populate_existing re-read. There is one
+        # row object here and every read already sees the latest state, so the
+        # flag only has to be accepted -- a test that needs to simulate a
+        # concurrent write mutates `row` directly.
         return row
 
     async def unreadable(_key):
@@ -486,6 +507,151 @@ def test_every_committed_key_is_owned_at_the_moment_it_is_written(town):
     assert ANOTHER in owned_at_write[ANOTHER]
 
 
+def test_a_failed_rewrite_does_not_strand_a_key_the_host_already_owned(town):
+    """The permanent strand, and the reason the release of a claim is gated on
+    whether the key was new.
+
+    Releasing the claim is right for a key the host has never written: nothing
+    of the host's is behind it, so the row goes back to how it was. It is
+    catastrophic for a RE-push. The host's previous value is still live in the
+    town's vault, and dropping the ownership record leaves a key that is not
+    owned but does have a value -- which is exactly the shape the guard above
+    refuses. Every push after that transient blip is refused, forever, and the
+    host can neither replace the credential nor withdraw it. One failed vault
+    write, and the key is unmanageable for the life of the deployment.
+
+    Three pushes, which is the smallest sequence that shows it: accept, fail,
+    and then the recovery that used to be impossible."""
+    first = _run(host_secrets.apply(town.db, {A_KEY: VALUE}))
+    assert first["accepted"] == [A_KEY]
+    assert town.row.host_provided_keys == [A_KEY]
+
+    async def blow_up(_key_name):
+        raise RuntimeError("vault write failed")
+
+    town.store.on_persist = blow_up
+    second = _run(host_secrets.apply(town.db, {A_KEY: "AIza-not-a-real-key-0002"}))
+
+    # Refused, because the write did not happen -- but the key the host already
+    # owned is still the host's, because the value behind it is still the
+    # host's.
+    assert second["refused"] == [A_KEY]
+    assert second["accepted"] == []
+    assert town.row.host_provided_keys == [A_KEY]
+    assert town.store.values[A_KEY] == VALUE
+
+    # And that is what makes the blip recoverable: the vault comes back, the
+    # host re-pushes, and the key is replaced rather than refused.
+    town.store.on_persist = None
+    third = _run(host_secrets.apply(town.db, {A_KEY: "AIza-not-a-real-key-0003"}))
+
+    assert third["accepted"] == [A_KEY]
+    assert third["refused"] == []
+    assert town.store.values[A_KEY] == "AIza-not-a-real-key-0003"
+
+    # The withdrawal the host could no longer reach still works too.
+    fourth = _run(host_secrets.apply(town.db, {}))
+    assert fourth["revoked"] == [A_KEY]
+    assert A_KEY not in town.store.values
+
+
+def test_a_key_claimed_by_the_town_mid_push_is_not_handed_back(town):
+    """`apply` takes seconds -- a vault write per key -- and a clerk who saves
+    their own credential during that window calls `forget`, which takes the key
+    off the host.
+
+    The final ownership write used to re-add the whole accepted batch, which
+    put the clerk's key straight back on the host's books and let the next push
+    overwrite the value they had just typed. Every accepted key already claimed
+    itself at the moment it was written, so the last write has nothing to add
+    and only subtracts."""
+    async def the_clerk_saves_their_own(key_name):
+        if key_name == A_KEY:
+            # Mid-write, after the host has claimed the key: what `forget` does
+            # to the row from the clerk's own session.
+            town.row.host_provided_keys = [
+                k for k in host_secrets._normalise(town.row.host_provided_keys)
+                if k != A_KEY
+            ]
+
+    town.store.on_persist = the_clerk_saves_their_own
+
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    # The clerk's save is the last word on that key.
+    assert A_KEY not in host_secrets._normalise(town.row.host_provided_keys)
+    # And the key the host really did provide is untouched by the correction.
+    assert ANOTHER in host_secrets._normalise(town.row.host_provided_keys)
+
+
+def test_a_write_the_external_store_would_not_take_is_reported(town):
+    """`_persist_secret` returns whether the EXTERNAL store took the value.
+    False means it landed only in the encrypted database copy, which is a
+    working credential right up until the sweep that scrubs those copies.
+
+    Every other caller surfaces that. This one dropped it on the floor, so the
+    host was told "accepted" for a credential that is not where it thinks it
+    is. Accepted is still the right answer -- the town can use the key -- but
+    not the only answer."""
+    town.store.db_only.add(ANOTHER)
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    assert sorted(result["accepted"]) == sorted([A_KEY, ANOTHER])
+    assert result["db_only"] == [ANOTHER]
+    # Names only, here as everywhere else on this endpoint.
+    assert VALUE not in json.dumps(result)
+
+
+def test_a_key_that_is_no_longer_shareable_is_kept_rather_than_deleted(town, monkeypatch):
+    """The revoke loop had no allowlist, and the write path does.
+
+    That asymmetry deletes credentials nobody withdrew. `shareable_keys` is
+    derived from the provider catalogs, so it shrinks whenever a provider
+    leaves one or a key becomes platform-managed -- and a key stranded by that
+    change looks exactly like a key the host stopped sending. Vault and
+    database copy both go, on the strength of a catalog edit, and there is no
+    way back from here.
+
+    So a key the host owns but may no longer be given is left alone, and left
+    on the host's books: the claim is what lets the host withdraw it on purpose
+    if it ever becomes shareable again."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    assert town.row.host_provided_keys == [ANOTHER, A_KEY]
+
+    # The catalogs stop naming A_KEY, exactly as a provider removal would.
+    shrunk = host_secrets.shareable_keys() - {A_KEY}
+    monkeypatch.setattr(host_secrets, "shareable_keys", lambda: shrunk)
+
+    result = _run(host_secrets.apply(town.db, {ANOTHER: "translator-0002"}))
+
+    assert result["revoked"] == []
+    assert town.store.deleted == []
+    # Still live, and still recorded as the host's so it can be withdrawn
+    # deliberately later.
+    assert town.store.values[A_KEY] == VALUE
+    assert A_KEY in host_secrets._normalise(town.row.host_provided_keys)
+
+
+def test_a_refused_key_in_the_payload_is_not_revoked(town):
+    """The other half of the same decision, written down because it is a choice
+    rather than an accident.
+
+    A key that arrived and was refused is a key the host is still sharing --
+    the write just could not happen. Revocation has exactly one spelling in a
+    full replace, and it is absence from the payload. Treating refusal as
+    withdrawal would delete a live credential every time a vault hiccuped."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    # Blank is refused, and the key is present in the payload.
+    result = _run(host_secrets.apply(town.db, {A_KEY: "   ", ANOTHER: "translator-0002"}))
+
+    assert result["refused"] == [A_KEY]
+    assert result["revoked"] == []
+    assert town.store.values[A_KEY] == VALUE
+    assert A_KEY in host_secrets._normalise(town.row.host_provided_keys)
+
+
 # ---------------------------------------------------------------------------
 # A withdrawal that does not take
 # ---------------------------------------------------------------------------
@@ -577,6 +743,29 @@ def test_every_town_write_path_clears_provenance():
         assert "host_secrets.forget" in src, fn.__name__
 
 
+def test_the_auth0_wizard_is_a_town_write_like_any_other():
+    """A third door, and the one that was still open.
+
+    `configure_auth0` builds the town's own Auth0 application and then stored
+    AUTH0_DOMAIN, AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET by writing
+    SystemSecret rows itself. All three are host-shareable, so a town that set
+    up its OWN identity provider on that page kept them marked host-provided:
+    the next push replaced the town's SSO with the host's, and the host
+    un-sharing Auth0 deleted a credential the host never supplied. Losing sign
+    -in for a whole town, from a wizard whose entire purpose is the town's own
+    tenant.
+
+    It goes through the choke point now, which is what moves ownership."""
+    import inspect
+
+    from app.api import setup
+
+    src = inspect.getsource(setup.configure_auth0)
+    assert "_persist_secret" in src
+    # And no longer writes the rows by hand around that call.
+    assert "SystemSecret(" not in src.split("AUTH0_CLIENT_SECRET")[-1]
+
+
 # ---------------------------------------------------------------------------
 # The endpoint
 # ---------------------------------------------------------------------------
@@ -627,10 +816,11 @@ def test_the_endpoint_answers_with_names_and_audits_no_values(town, monkeypatch)
         "refused": ["SECRETS_PROVIDER"],
         "revoked": [],
         "failed": [],
+        "db_only": [],
     }
     assert recorded["event_type"] == "provisioning_host_secrets"
     assert recorded["details"]["counts"] == {
-        "accepted": 1, "refused": 1, "revoked": 0, "failed": 0,
+        "accepted": 1, "refused": 1, "revoked": 0, "failed": 0, "db_only": 0,
     }
 
     # The flat rule: a value never reaches the audit table, which is exported.
@@ -879,6 +1069,111 @@ def test_a_push_lands_before_the_town_has_chosen_a_secret_store(town, monkeypatc
     assert written.key_value != VALUE
     assert decrypt(written.key_value) == VALUE
     assert town.row.host_provided_keys == [A_KEY]
+
+
+def test_the_column_has_the_belt_and_braces_guard_too():
+    """Every recent column is added twice: once by its Alembic revision, and
+    once by init_db's idempotent ADD COLUMN IF NOT EXISTS.
+
+    That is not redundancy for its own sake. init_db is what catches an install
+    whose migration history is ahead of its actual schema -- a restored dump, a
+    stamped-not-migrated database, a town brought up from a snapshot. Without
+    the guard, `host_provided_keys` is missing on exactly those deployments and
+    every read of the settings row raises: not a degraded credential feature, a
+    500 on any page that reads settings at all."""
+    from pathlib import Path
+
+    from app.db import init_db
+
+    source = Path(init_db.__file__).read_text()
+    assert (
+        "ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS host_provided_keys"
+        in source
+    )
+
+
+def test_the_declared_schema_floor_matches_the_migration_it_ships():
+    """MIN_DB_REVISION is the oldest schema this image can start against, and
+    the orchestrator refuses an upgrade outside [min .. head].
+
+    The rule in the file is: additive migration, leave it at the PREVIOUS head.
+    The host-provided-keys migration is a single nullable ADD COLUMN, so the
+    floor is the revision immediately before it. It had been left fourteen
+    revisions back, across several contract migrations this build genuinely
+    cannot run against, which is the unsafe direction: it lets an image reach a
+    town whose schema it cannot serve, rather than merely blocking a rollout."""
+    pytest.importorskip("alembic.script")
+    from pathlib import Path
+
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    root = Path(__file__).resolve().parents[1]
+
+    # The same parse the CI job does: comments out, whitespace stripped.
+    declared = ""
+    for line in (root / "MIN_DB_REVISION").read_text().splitlines():
+        if line.strip() and not line.strip().startswith("#"):
+            declared = line.strip()
+    assert declared
+
+    cfg = Config(str(root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(root / "alembic"))
+    script = ScriptDirectory.from_config(cfg)
+    heads = script.get_heads()
+    assert len(heads) == 1, f"expected one head, got {sorted(heads)}"
+
+    previous = script.get_revision(heads[0]).down_revision
+    assert declared == previous, (
+        f"MIN_DB_REVISION says {declared}, but the revision before head is {previous}"
+    )
+
+
+def test_the_guard_read_asks_the_database_rather_than_the_identity_map():
+    """The "fresh read" in `_store` has to actually be fresh.
+
+    It exists to notice a `forget` that another session committed while this
+    push was in its multi-second vault write. But an ordinary `get_settings`
+    issues the SELECT and then throws the result away: SQLAlchemy's identity
+    map already holds this row, so the attributes handed back are the ones it
+    was first loaded with, and the clerk's save is invisible. The push then
+    writes the key back onto the host's books and the next push overwrites the
+    value they typed -- the exact bug the re-read was added to prevent.
+
+    `populate_existing` is what makes the ORM overwrite the loaded attributes
+    with what the database now says, so this pins that the flag is on the
+    statement and that `_store` is the caller asking for it.
+    """
+    from app.services import system_settings
+
+    seen = []
+
+    class RecordingDB:
+        async def execute(self, statement):
+            seen.append(statement)
+
+            class Result:
+                def scalar_one_or_none(self_inner):
+                    return FakeRow()
+
+            return Result()
+
+        async def flush(self):
+            pass
+
+    def populate_existing(statement) -> bool:
+        return bool(statement.get_execution_options().get("populate_existing"))
+
+    # The default stays cheap: almost every caller wants the identity map.
+    _run(system_settings.get_settings(RecordingDB()))
+    assert not populate_existing(seen[-1])
+
+    _run(system_settings.get_settings(RecordingDB(), fresh=True))
+    assert populate_existing(seen[-1])
+
+    # And this is the caller that must not get a stale answer.
+    _run(host_secrets._store(RecordingDB(), add=[A_KEY]))
+    assert populate_existing(seen[-1])
 
 
 def test_the_ownership_column_survives_a_real_round_trip():

--- a/backend/tests/test_host_provided_credentials.py
+++ b/backend/tests/test_host_provided_credentials.py
@@ -584,6 +584,47 @@ def test_a_key_claimed_by_the_town_mid_push_is_not_handed_back(town):
     assert ANOTHER in host_secrets._normalise(town.row.host_provided_keys)
 
 
+def test_a_key_the_town_claims_before_its_turn_is_refused_not_overwritten(town):
+    """The other ordering, and the one a single pre-loop snapshot cannot see.
+
+    `apply` commits key by key, so the loop spans several committed
+    transactions. A clerk who saves their own credential during the FIRST key's
+    vault write has already committed `forget` by the time the loop reaches the
+    second -- and against a snapshot taken before the push started, the second
+    key still looks like the host's. The ownership guard is skipped on that
+    basis, and the host's value is written over a credential a clerk typed
+    seconds earlier.
+
+    ANOTHER sorts first, so the clerk's save lands during ANOTHER's write and
+    A_KEY's turn comes afterwards. That is the reviewer's reproduction, and it
+    is why ownership is re-read for every key rather than once."""
+    _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+    assert town.row.host_provided_keys == [ANOTHER, A_KEY]
+
+    async def the_clerk_saves_their_own(key_name):
+        if key_name != ANOTHER:
+            return
+        # Exactly what a town-side save does, from the clerk's own session:
+        # the value goes in, and `forget` takes the key off the host.
+        town.store.values[A_KEY] = "the-towns-own-key"
+        town.row.host_provided_keys = [
+            k for k in host_secrets._normalise(town.row.host_provided_keys)
+            if k != A_KEY
+        ]
+
+    town.store.on_persist = the_clerk_saves_their_own
+
+    result = _run(host_secrets.apply(town.db, {A_KEY: VALUE, ANOTHER: "translator-0002"}))
+
+    # The town's own credential wins, however the timing falls.
+    assert result["refused"] == [A_KEY]
+    assert town.store.values[A_KEY] == "the-towns-own-key"
+    assert A_KEY not in host_secrets._normalise(town.row.host_provided_keys)
+    # And it is not revoked either: it is the town's now, not a withdrawal.
+    assert result["revoked"] == []
+    assert A_KEY not in town.store.deleted
+
+
 def test_a_write_the_external_store_would_not_take_is_reported(town):
     """`_persist_secret` returns whether the EXTERNAL store took the value.
     False means it landed only in the encrypted database copy, which is a
@@ -1069,6 +1110,104 @@ def test_a_push_lands_before_the_town_has_chosen_a_secret_store(town, monkeypatc
     assert written.key_value != VALUE
     assert decrypt(written.key_value) == VALUE
     assert town.row.host_provided_keys == [A_KEY]
+    # And NOT flagged as a write that only reached the database. There is no
+    # external store to have rejected it -- see the test below.
+    assert result["db_only"] == []
+
+
+@pytest.mark.parametrize("provider", ["database", ""])
+def test_a_town_with_no_external_store_is_not_told_its_keys_are_db_only(
+    town, monkeypatch, provider
+):
+    """`db_only` has to mean something, and on the default deployment it did not.
+
+    `set_secret` returns False for every key when the chosen store IS the
+    encrypted database, by design rather than by failure -- there is nothing
+    outside the database to write to. Reported as db-only, that made an
+    ordinary save on an ordinary town look like a credential about to vanish,
+    on every key, forever; and the endpoint's own documentation told the host
+    exactly that. An alarm that fires on the default configuration is one
+    nobody can act on, which costs the real signal it was added to carry.
+
+    Both external-less states are the same answer: "database" is a deliberate
+    choice, "" is a town that has not chosen yet and whose values land in the
+    database on purpose until it does."""
+    from app.services import secret_manager
+
+    if provider:
+        monkeypatch.setenv("SECRETS_PROVIDER", provider)
+    else:
+        monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+    monkeypatch.setitem(secret_manager._config, "use_gcp", False)
+
+    class Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class DB:
+        def __init__(self):
+            self.added = []
+
+        async def execute(self, _stmt):
+            return Result()
+
+        def add(self, obj):
+            self.added.append(obj)
+
+        async def commit(self):
+            pass
+
+    monkeypatch.setattr(system, "_persist_secret", _REAL_PERSIST_SECRET)
+
+    result = _run(host_secrets.apply(DB(), {A_KEY: VALUE}))
+
+    assert result["accepted"] == [A_KEY]
+    assert result["db_only"] == []
+    assert secret_manager.external_store_configured() is False
+
+
+def test_an_external_store_that_refuses_the_write_is_still_reported(town, monkeypatch):
+    """The other side of the same coin: the signal must survive the fix.
+
+    With a real external store configured, a False from `set_secret` is what it
+    always was -- the store would not take it, the credential is living in the
+    database copy alone, and it goes away when that copy is swept. That is the
+    ordering trap the flag exists for, and narrowing db_only must not have
+    silenced it."""
+    from app.services import secret_manager
+
+    monkeypatch.setenv("SECRETS_PROVIDER", "azure")
+
+    async def refuse(_key, _value):
+        return False
+
+    monkeypatch.setattr(secret_manager, "set_secret", refuse)
+    monkeypatch.setattr("app.services.secret_manager.set_secret", refuse)
+
+    class Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class DB:
+        def __init__(self):
+            self.added = []
+
+        async def execute(self, _stmt):
+            return Result()
+
+        def add(self, obj):
+            self.added.append(obj)
+
+        async def commit(self):
+            pass
+
+    monkeypatch.setattr(system, "_persist_secret", _REAL_PERSIST_SECRET)
+
+    result = _run(host_secrets.apply(DB(), {A_KEY: VALUE}))
+
+    assert secret_manager.external_store_configured() is True
+    assert result["accepted"] == [A_KEY]
+    assert result["db_only"] == [A_KEY]
 
 
 def test_the_column_has_the_belt_and_braces_guard_too():
@@ -1096,12 +1235,27 @@ def test_the_declared_schema_floor_matches_the_migration_it_ships():
     """MIN_DB_REVISION is the oldest schema this image can start against, and
     the orchestrator refuses an upgrade outside [min .. head].
 
-    The rule in the file is: additive migration, leave it at the PREVIOUS head.
-    The host-provided-keys migration is a single nullable ADD COLUMN, so the
-    floor is the revision immediately before it. It had been left fourteen
-    revisions back, across several contract migrations this build genuinely
-    cannot run against, which is the unsafe direction: it lets an image reach a
-    town whose schema it cannot serve, rather than merely blocking a rollout."""
+    The consuming gate is SET MEMBERSHIP, not a range: centralizedhosting's
+    rollout._precheck_compatibility refuses unless the town's observed revision
+    is exactly `min_db_revision` or exactly `db_revision`. So there are only
+    ever two legal declarations, and which one is correct depends on the head
+    migration:
+
+      * ADDITIVE (expand) -- the previous head. The new build still runs on the
+        old schema, so a town can be started on the new image and migrated
+        after, with no window where code and schema disagree.
+      * DESTRUCTIVE (contract) -- head itself. The new build cannot run on the
+        old schema, so the orchestrator has to see the town already migrated.
+
+    This asserts the rule rather than one side of it. An earlier version
+    demanded the previous head unconditionally, which is right for the
+    migration shipping today and would have pressured whoever writes the next
+    contract migration into declaring a floor their build cannot honour.
+
+    The value had been left fourteen revisions back, across several contract
+    migrations this build genuinely cannot start against -- the unsafe
+    direction, since it lets an image reach a town whose schema it cannot
+    serve, where naming a too-new revision merely blocks a rollout."""
     pytest.importorskip("alembic.script")
     from pathlib import Path
 
@@ -1123,10 +1277,30 @@ def test_the_declared_schema_floor_matches_the_migration_it_ships():
     heads = script.get_heads()
     assert len(heads) == 1, f"expected one head, got {sorted(heads)}"
 
-    previous = script.get_revision(heads[0]).down_revision
-    assert declared == previous, (
-        f"MIN_DB_REVISION says {declared}, but the revision before head is {previous}"
+    head = heads[0]
+    previous = script.get_revision(head).down_revision
+
+    # The gate only ever accepts one of these two.
+    assert declared in {head, previous}, (
+        f"MIN_DB_REVISION says {declared}, which is neither head ({head}) nor "
+        f"the revision before it ({previous}). The orchestrator's compatibility "
+        f"check is set membership on exactly those two."
     )
+
+    # And which of the two, by the head migration's own shape.
+    from app.db.migrate import ADDITIVE, classify_source, revision_sources
+
+    _path, head_source = revision_sources()[head]
+    if classify_source(head_source) == ADDITIVE:
+        assert declared == previous, (
+            f"head {head} is additive, so the build runs on the old schema and "
+            f"MIN_DB_REVISION should be {previous}, not {declared}"
+        )
+    else:
+        assert declared == head, (
+            f"head {head} is destructive, so the build cannot run on the old "
+            f"schema and MIN_DB_REVISION must be {head}, not {declared}"
+        )
 
 
 def test_the_guard_read_asks_the_database_rather_than_the_identity_map():

--- a/backend/tests/test_settings_round_trip.py
+++ b/backend/tests/test_settings_round_trip.py
@@ -70,6 +70,14 @@ INTERNAL = {
     "ai_models_cache",     # discovery cache, refreshed by the model picker
     "health_alert_state",  # what the alerting layer has already said
     "managed_policy",      # set by the hosting orchestrator, not the town
+    # Which credential keys the host supplied. Same reasoning as
+    # managed_policy: written only by the orchestrator (POST
+    # /provisioning/host-secrets) and by the write choke-point clearing a key a
+    # town has taken over, never by anybody filling in a form. It surfaces to
+    # the console read-only, as the `host_provided` note on the catalog and
+    # secrets responses, so there is nothing here for a settings form to round
+    # trip.
+    "host_provided_keys",
     "updated_at",          # the ORM writes it
 }
 

--- a/frontend/src/components/InlineProviderSetup.tsx
+++ b/frontend/src/components/InlineProviderSetup.tsx
@@ -224,6 +224,7 @@ export default function InlineProviderSetup({
                 ctx={ctx}
                 identity={identity}
                 storedFields={catalog.stored_fields}
+                hostProvided={catalog.host_provided}
                 alreadySet={alreadySet && isCurrent}
                 compact
             />

--- a/frontend/src/components/ProviderCredentialSteps.hostprovided.test.tsx
+++ b/frontend/src/components/ProviderCredentialSteps.hostprovided.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * A credential the deployment's host supplied says so, and behaves like any
+ * other saved credential.
+ *
+ * A hosted town frequently has no account of its own with a map or translation
+ * vendor, so its host can hand the instance working credentials. That is only
+ * an improvement if the card reads honestly. The failure it replaces is a box
+ * marked plainly "Saved" against a key the town never entered: a clerk goes
+ * looking for a vendor account nobody at the town has, finds nothing, and
+ * concludes the page is lying.
+ *
+ * The rest of the card must not change. Host-provided is not read-only, not a
+ * lock, and not a different colour -- the badge stays green, the box still
+ * accepts a value, and typing one is exactly how a town takes the key back. So
+ * this asserts the wording changed and that nothing else did.
+ */
+
+let InlineProviderSetup: typeof import('./InlineProviderSetup').default;
+
+const AUTH0 = {
+    current_provider: 'auth0',
+    configured: { auth0: true },
+    stored_fields: { AUTH0_DOMAIN: true, AUTH0_CLIENT_ID: true, AUTH0_CLIENT_SECRET: true },
+    providers: [{
+        provider: 'auth0',
+        name: 'Auth0',
+        credential_fields: [
+            { key: 'AUTH0_DOMAIN', label: 'Auth0 Domain', secret: false },
+            { key: 'AUTH0_CLIENT_ID', label: 'Client ID', secret: false },
+            { key: 'AUTH0_CLIENT_SECRET', label: 'Client Secret', secret: true },
+        ],
+    }],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+const getCloudIdentity = vi.fn();
+const getProviderCatalog = vi.fn();
+const saveProvider = vi.fn();
+const testProvider = vi.fn();
+
+vi.mock('../services/api', () => ({
+    api: {
+        getProviderCatalog: (...a: unknown[]) => getProviderCatalog(...a),
+        getCloudIdentity: (...a: unknown[]) => getCloudIdentity(...a),
+        saveProvider: (...a: unknown[]) => saveProvider(...a),
+        testProvider: (...a: unknown[]) => testProvider(...a),
+    },
+}));
+
+async function mount(ui: React.ReactElement) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(ui); });
+    await act(async () => { await Promise.resolve(); });
+}
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    // setupStepsContent fills a module-scoped registry as an import side
+    // effect, so after a reset it has to be re-imported before anything reads
+    // the walk. Same ordering as InlineProviderSetup.test.tsx.
+    await import('./setupStepsContent');
+    InlineProviderSetup = (await import('./InlineProviderSetup')).default;
+    getProviderCatalog.mockResolvedValue(AUTH0);
+    getCloudIdentity.mockResolvedValue({ attached: false, provider: null, identity: null, skippable_keys: [] });
+    saveProvider.mockResolvedValue({ ok: true, provider: 'auth0', warnings: [] });
+    testProvider.mockResolvedValue({ ok: true, detail: 'Signed a test token.' });
+});
+
+afterEach(async () => {
+    await act(async () => { root?.unmount(); });
+    container?.remove();
+});
+
+const labelText = () => Array.from(container.querySelectorAll('label')).map(l => l.textContent || '');
+
+describe('a credential the host provided', () => {
+    it('says so instead of a bare "Saved"', async () => {
+        getProviderCatalog.mockResolvedValue({
+            ...AUTH0,
+            host_provided: { AUTH0_CLIENT_SECRET: true },
+        });
+
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        const hinted = labelText().filter(t => t.includes('Saved'));
+        expect(hinted.some(t => t.includes('provided by your host'))).toBe(true);
+        // Only the field the backend named. The other two are the town's, and
+        // saying otherwise would send a clerk to the wrong place for those too.
+        expect(hinted.filter(t => t.includes('provided by your host'))).toHaveLength(1);
+    });
+
+    it('leaves the box editable, so the town can take the key back', async () => {
+        getProviderCatalog.mockResolvedValue({
+            ...AUTH0,
+            host_provided: { AUTH0_CLIENT_SECRET: true },
+        });
+
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        const inputs = Array.from(container.querySelectorAll('input'));
+        expect(inputs).toHaveLength(3);
+        expect(inputs.some(i => i.disabled || i.readOnly)).toBe(false);
+    });
+
+    it('reads as an ordinary saved credential when the backend says nothing', async () => {
+        // Standalone installs have no host, and older backends do not send the
+        // field at all. Either way the hint is the one it has always been.
+        await mount(<InlineProviderSetup cap="identity" provider="auth0" />);
+
+        const text = labelText().join(' | ');
+        expect(text).toContain('Saved');
+        expect(text).not.toContain('provided by your host');
+    });
+});

--- a/frontend/src/components/ProviderCredentialSteps.tsx
+++ b/frontend/src/components/ProviderCredentialSteps.tsx
@@ -27,7 +27,8 @@ import type { Capability, CloudIdentity, ProviderInfo } from '../services/api';
  * town already chose in the questionnaire.
  */
 export default function ProviderCredentialSteps({
-    cap, provider, active, values, onChange, ctx, identity, storedFields, alreadySet = false, compact = false,
+    cap, provider, active, values, onChange, ctx, identity, storedFields, hostProvided,
+    alreadySet = false, compact = false,
 }: {
     cap: Capability;
     /** Which provider's walk to render. Not read off the catalog: the guide
@@ -47,6 +48,15 @@ export default function ProviderCredentialSteps({
      *  and applying it per provider made that promise about optional boxes
      *  nobody had ever filled in -- where it is false. */
     storedFields?: Record<string, boolean>;
+    /** Which of those boxes hold a credential the deployment's host supplied
+     *  rather than the town.
+     *
+     *  Only the wording of the hint changes. The box is saved, the card is
+     *  green, and typing a value here still saves -- which is the point, and
+     *  the moment the key becomes the town's. What it prevents is a clerk
+     *  reading "Saved" and going to look for a vendor account their town has
+     *  never had. Absent on a standalone install, where there is no host. */
+    hostProvided?: Record<string, boolean>;
     /** Credentials for this provider are already stored, so an empty box means
      *  "keep what is there" rather than "not done yet". Used for the
      *  requirements block; the per-box hint reads `storedFields`. */
@@ -103,6 +113,7 @@ export default function ProviderCredentialSteps({
                 placeholder={`Enter ${f.label.toLowerCase()}`}
                 help={active.field_help?.[f.key]}
                 savedHint={storedFields?.[f.key] ?? false}
+                savedLabel={hostProvided?.[f.key] ? 'Saved · provided by your host' : undefined}
             />
         );
     };

--- a/frontend/src/components/SecretField.tsx
+++ b/frontend/src/components/SecretField.tsx
@@ -126,7 +126,7 @@ export function looksLikePlaceholder(raw: string): boolean {
  */
 export default function SecretField({
     label, value, onChange, secret = false, placeholder, help,
-    savedHint = false, required = false, autoFocus = false, kind = 'auto',
+    savedHint = false, savedLabel, required = false, autoFocus = false, kind = 'auto',
 }: {
     label: string;
     value: string;
@@ -135,6 +135,12 @@ export default function SecretField({
     placeholder?: string;
     help?: string;
     savedHint?: boolean;
+    /** What the "Saved" badge says, when plain "Saved" is not the whole story.
+     *  Used for a credential the deployment's host supplied, which is saved and
+     *  working -- the badge stays green and the box still accepts a value of
+     *  the town's own -- but which a clerk would otherwise go looking for in an
+     *  account their town does not have. Absent means "Saved". */
+    savedLabel?: string;
     required?: boolean;
     autoFocus?: boolean;
     kind?: FieldKind;
@@ -153,7 +159,7 @@ export default function SecretField({
                 {required && !savedHint && <span className="normal-case tracking-normal text-amber-300 font-medium">(required)</span>}
                 {savedHint && (
                     <span className="ml-auto normal-case tracking-normal text-[10px] font-medium text-emerald-300/80 inline-flex items-center gap-1">
-                        <CheckCircle className="w-3 h-3" aria-hidden="true" /> Saved
+                        <CheckCircle className="w-3 h-3" aria-hidden="true" /> {savedLabel || 'Saved'}
                     </span>
                 )}
             </label>

--- a/frontend/src/components/ServiceProviders.tsx
+++ b/frontend/src/components/ServiceProviders.tsx
@@ -1133,6 +1133,7 @@ function CapabilityCard({ cap, title, blurb, icon: Icon, delay, recheckToken, re
                                 ctx={stepCtx}
                                 identity={identity}
                                 storedFields={catalog.stored_fields}
+                                hostProvided={catalog.host_provided}
                                 alreadySet={alreadySet}
                             />
                         </div>

--- a/frontend/src/components/SetupIntegrationsPage.tsx
+++ b/frontend/src/components/SetupIntegrationsPage.tsx
@@ -327,14 +327,32 @@ onWantAi: () => Promise<void>;
                 {/* Pasting is still allowed -- some towns get the key by
                     email from whoever administers the project -- but the
                     file picker is first, because a downloaded file is what
-                    step 4 actually leaves you holding. */}
-                <textarea
-                    placeholder="…or paste the contents"
-                    value={secretValues[jsonKey] || ''}
-                    onChange={(e) => setSecretValues(p => ({ ...p, [jsonKey]: e.target.value }))}
-                    rows={2}
-                    className="mt-2 w-full text-xs bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-white placeholder-white/30 focus:outline-none focus:border-primary-400/50 resize-none font-mono"
-                />
+                    step 4 actually leaves you holding.
+
+                    Masked, through the same field every other credential on
+                    this page uses. This was a bare <textarea>, and it was the
+                    one place a private key sat in plain text on screen: the
+                    file picker above writes into the very same state, so
+                    choosing the .json file printed the whole service-account
+                    key -- private_key included -- into a box that stayed
+                    visible while a clerk carried on scrolling, screen-sharing
+                    with whoever was helping them, or walking away from the
+                    desk. The reveal toggle is still there for eyeballing a
+                    truncated paste, which is the only reason the value ever
+                    needs to be on screen at all.
+
+                    kind="json" rather than inferred, so the advisory line says
+                    whether what was pasted or read parses -- the one check
+                    worth having here, since the value is now dots. */}
+                <div className="mt-2">
+                    <SecretField
+                        label="…or paste the contents"
+                        value={secretValues[jsonKey] || ''}
+                        onChange={(v: string) => setSecretValues(p => ({ ...p, [jsonKey]: v }))}
+                        secret
+                        kind="json"
+                    />
+                </div>
             </div>
 
             <SecretField

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -62,6 +62,12 @@ export default function SetupWizard(props: SetupWizardProps) {
     const tasks = useMemo(() => buildPlan(props), [
         props.cloud, props.idp, props.maps, props.aiProvider,
         props.emailProvider, props.smsProvider, props.redactionProvider, props.wanted,
+        // Nothing in this application passes `exclude` (see PlanInput), but a
+        // console that does would otherwise keep the plan it built before the
+        // exclusion changed -- the memo would hold, and the walk would go on
+        // offering a task for a credential that had just stopped being that
+        // console's to enter.
+        props.exclude,
     ]);
 
     /* Finished means finished *for the provider currently chosen*.
@@ -115,7 +121,14 @@ export default function SetupWizard(props: SetupWizardProps) {
      * away from since. */
     const openTask = tasks.find(t => t.id === openId) ?? null;
     useEffect(() => {
-        if (openTask && !taskDone(openTask)) return;
+        // Guarded on `status` for the same reason the landing effect above is.
+        // This effect runs on mount too, and before the status arrives every
+        // task reads as unfinished and nothing is open yet -- so it fell
+        // straight through to tasks[0] and opened it, which is how a clerk who
+        // had already finished the Google task landed on it anyway. Not in the
+        // dependency list on purpose: re-running when the status refreshes
+        // would reopen a task the clerk had deliberately navigated away from.
+        if (!status || (openTask && !taskDone(openTask))) return;
         const next = tasks.find(t => !taskDone(t));
         if (next && next.id !== openId) setOpenId(next.id);
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -116,10 +116,12 @@ export interface PlanInput {
      * its towns bring their own map key has no map credential to enter and no
      * task to be shown.
      *
-     * Optional, and absent everywhere in this application: nothing here passes
-     * it, so every plan built by a town's own console is unchanged. It is a
-     * hole left deliberately rather than a feature in use, so that the console
-     * with the extra question does not have to fork this arithmetic to ask it.
+     * Optional, and never passed by a TOWN's own console: sign-in and maps are
+     * unconditional there, so every plan the app builds is unchanged by this
+     * field existing. The host panel is the caller that does pass it, from its
+     * payer matrix. The hole is here rather than in a fork so that the console
+     * with the extra question does not have to copy this arithmetic to ask it,
+     * and so both copies of this file stay byte-identical.
      */
     exclude?: ReadonlySet<string>;
 }

--- a/frontend/src/components/setupPlan.ts
+++ b/frontend/src/components/setupPlan.ts
@@ -106,6 +106,22 @@ export interface PlanInput {
     redactionProvider: string;
     /** Feature ids ticked in the questionnaire. */
     wanted: ReadonlySet<string>;
+    /* Item ids to leave out even though the questionnaire cannot hide them.
+     *
+     * Sign-in and maps are added unconditionally below, because no town can
+     * take a report without both -- there is no tick for either, and there
+     * should not be. That is a statement about a town, and it is not true of
+     * every console that renders this plan: a hosting panel walks an operator
+     * through the credentials the HOST pays for, and a host that has decided
+     * its towns bring their own map key has no map credential to enter and no
+     * task to be shown.
+     *
+     * Optional, and absent everywhere in this application: nothing here passes
+     * it, so every plan built by a town's own console is unchanged. It is a
+     * hole left deliberately rather than a feature in use, so that the console
+     * with the extra question does not have to fork this arithmetic to ask it.
+     */
+    exclude?: ReadonlySet<string>;
 }
 
 /* Order is the order a town should work in, not the order the code was
@@ -144,7 +160,13 @@ export function buildPlan(input: PlanInput): PlanTask[] {
     const { cloud, idp, maps, wanted } = input;
     const want = (f: string) => wanted.has(f);
     const byVendor = new Map<Vendor, PlanItem[]>();
+    /* Filtered on the way in rather than on the way out, so a task whose only
+     * item was excluded is never assembled at all. Dropping items afterwards
+     * would leave an empty vendor task with a title and a foundation walk and
+     * nothing to do inside it -- which is exactly the dead end the exclusion
+     * exists to remove. */
     const add = (vendor: Vendor, item: PlanItem) => {
+        if (input.exclude?.has(item.id)) return;
         const list = byVendor.get(vendor) ?? [];
         list.push(item);
         byVendor.set(vendor, list);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -227,6 +227,17 @@ export interface ProviderCatalog {
      *  configured every one of its boxes claimed to be saved -- including an
      *  optional one nobody had filled in. Presence only; no values. */
     stored_fields?: Record<string, boolean>;
+    /** Which of those boxes hold a credential the deployment's host supplied
+     *  rather than the town -- true only where a value is actually stored.
+     *
+     *  A hosted town frequently has no account of its own with a map or
+     *  translation vendor, so its host can supply working credentials and the
+     *  card is configured like any other. This only changes the wording of the
+     *  per-box "Saved" hint, so a clerk is not sent looking for an account
+     *  their town does not have. The town can still save its own value over
+     *  it, and that takes the key off the host's list. Absent on a standalone
+     *  install, where there is no host to provide one. */
+    host_provided?: Record<string, boolean>;
     /** Whether this card may change the provider. False for the secret store:
      *  every credential the town has is in the current one and repointing the
      *  setting does not move them, so the switch belongs to the cloud-profile

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -337,6 +337,10 @@ export interface SystemSecret {
     key_value?: string;  // Only returned for some secrets (not sensitive ones)
     description: string | null;
     is_configured: boolean;
+    /** The deployment's host supplied this credential rather than the town.
+     *  The town can still save its own value over it, which takes the key off
+     *  the host's list. Absent/false on a standalone install. */
+    host_provided?: boolean;
 }
 
 // Statistics types


### PR DESCRIPTION
## Commits

- `202fc5c` feat(provisioning): accept host-provided credentials from the orchestrator
- `17d20fe` fix(host-secrets): stop a vault blip stranding a credential for good
- `c3b1779` fix(setup): mask the service-account key, and stop the walk jumping ahead
- `783649f` fix(host-secrets): read ownership fresh for every key, not once per push
- `dfe956a` docs(setup-plan): the exclude hole is used now, so stop saying it is not

Includes the beat fix (31ba187) already on main as base.