### PR TITLE
CI: guard minimal-env imports so backend-tests can go green

### DIFF
--- a/backend/tests/test_a_changed_setting_reaches_the_process.py
+++ b/backend/tests/test_a_changed_setting_reaches_the_process.py
@@ -60,7 +60,7 @@ def test_rotating_the_key_drops_the_path_as_well_as_the_key():
 
 
 def test_saving_a_kms_setting_clears_the_path(monkeypatch):
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api import system
     from app.core import encryption
 
@@ -74,7 +74,7 @@ def test_saving_an_identity_setting_clears_the_discovery_document():
     """The OIDC discovery document is cached per issuer with no expiry. A town
     correcting a mistyped issuer, or a provider moving its endpoints, kept being
     sent to the old ones for the life of the process."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api import system
     from app.services import identity
 
@@ -86,7 +86,7 @@ def test_saving_an_identity_setting_clears_the_discovery_document():
 def test_saving_something_unrelated_clears_nothing(monkeypatch):
     """Clearing everything on every save would refetch each capability's
     credentials on a page that saves several times."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api import system
     from app.core import encryption
 
@@ -98,7 +98,7 @@ def test_saving_something_unrelated_clears_nothing(monkeypatch):
 def test_clearing_a_cache_never_fails_the_save(monkeypatch):
     """This runs inside the write. Failing to drop a cache must not lose the
     credential that was being saved."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api import system
     from app.core import encryption
 
@@ -119,6 +119,10 @@ def test_clearing_a_cache_never_fails_the_save(monkeypatch):
 
 def _config_source():
     import inspect
+
+    # Reading the source of a Celery task module still executes its imports,
+    # and app.tasks.service_requests builds the Celery app at import time.
+    pytest.importorskip("celery.app")
 
     from app.tasks import service_requests
 

--- a/backend/tests/test_accela_oauth.py
+++ b/backend/tests/test_accela_oauth.py
@@ -37,6 +37,15 @@ from app.integrations.connectors.accela import AccelaConnector, _clear_token_cac
 from app.integrations.registry import PLATFORM_CATALOG, build_connector
 
 
+
+def _needs_fastapi():
+    """The connector itself is plain httpx, so most of this file runs anywhere.
+    Only the handful of tests that reach into the API layer need the web stack;
+    they guard here rather than at module scope, which would take the OAuth and
+    scope assertions down with them."""
+    pytest.importorskip("fastapi.routing")
+
+
 CONFIG = {"agency_name": "SPRINGFIELD", "environment": "PROD", "record_type": "SR/General/Complaint/NA"}
 
 
@@ -179,6 +188,7 @@ async def test_the_redirect_uri_comes_from_the_configured_public_origin(monkeypa
     """Behind the TLS-terminating proxy, request.base_url is http://backend:8000/ —
     a URL Accela can neither match nor redirect to. The deployment's configured
     public origin is what the callback must be built on."""
+    _needs_fastapi()
     import app.api.system as system_mod
 
     monkeypatch.delenv(accela_oauth.REDIRECT_URI_KEY, raising=False)
@@ -194,6 +204,7 @@ async def test_the_redirect_uri_comes_from_the_configured_public_origin(monkeypa
 
 
 async def test_with_nothing_configured_the_request_url_is_a_logged_last_resort(monkeypatch, caplog):
+    _needs_fastapi()
     import app.api.system as system_mod
 
     monkeypatch.delenv(accela_oauth.REDIRECT_URI_KEY, raising=False)
@@ -500,6 +511,7 @@ async def test_a_dead_refresh_token_surfaces_as_a_refresh_failure(monkeypatch):
     with pytest.raises(ConnectorError) as exc:
         await AccelaConnector(CONFIG, {"refresh_token": "revoked"})._get_token()
 
+    _needs_fastapi()
     from app.api.integrations import _friendly_test_error
     assert "sign in again" in _friendly_test_error(str(exc.value)).lower()
 

--- a/backend/tests/test_connector_health.py
+++ b/backend/tests/test_connector_health.py
@@ -171,6 +171,10 @@ def test_a_normal_error_passes_through_readable():
 async def test_a_success_detail_is_scrubbed_before_it_is_stored():
     """record_success stores what the check found, and what a check found is a
     vendor string like any other -- same column, same cards, same emails."""
+    # record_success never raises -- it logs and swallows. Without the ORM stack
+    # it therefore "succeeds" having written nothing, so this has to skip rather
+    # than assert against a row the code never touched.
+    pytest.importorskip("geoalchemy2.types")   # via app.models -> ConnectorHealth
     stored = Row()
 
     class Result:
@@ -272,7 +276,7 @@ def test_a_success_goes_stale_within_a_few_sweeps():
 
 def test_the_sweep_really_does_run_daily():
     """The bound above is only meaningful if the schedule is what it claims."""
-    pytest.importorskip("celery")
+    pytest.importorskip("celery.app")
     from app.core.celery_app import celery_app
 
     entry = celery_app.conf.beat_schedule["daily-connector-check"]

--- a/backend/tests/test_health_classification.py
+++ b/backend/tests/test_health_classification.py
@@ -8,7 +8,16 @@ import importlib
 
 import pytest
 
-pytest.importorskip("sqlalchemy")  # health.py imports the DB stack
+# classify_health is pure policy, but it lives in a router module, so importing
+# it drags in the whole web stack. Each of these has to be named: sqlalchemy
+# alone was guarded here before, and the file went from "skipped in CI" to
+# "collection error in CI" the day health.py grew its `from fastapi import` --
+# a collection error makes pytest exit 2, which reads as a broken run rather
+# than a missing dependency. Skip on the specific third-party imports, so a
+# genuine breakage of health.py still surfaces as an error in the full image.
+pytest.importorskip("fastapi.routing")           # the router decorators
+pytest.importorskip("sqlalchemy")        # health.py queries the DB directly
+pytest.importorskip("geoalchemy2.types")       # via app.models -> Geometry columns
 
 health = importlib.import_module("app.api.health")
 

--- a/backend/tests/test_integration_data_integrity.py
+++ b/backend/tests/test_integration_data_integrity.py
@@ -32,7 +32,7 @@ NOW = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
 def tasks():
     """The sync tasks module. Needs the ORM and Celery, which CI does not have."""
     pytest.importorskip("sqlalchemy")
-    pytest.importorskip("celery")
+    pytest.importorskip("celery.app")
     import app.tasks.integrations as module
     return module
 
@@ -65,6 +65,7 @@ def test_documents_pushed_count_is_in_a_migration_not_only_in_init_db():
 
 def test_the_model_and_the_migrations_agree_on_the_integration_link_columns():
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("geoalchemy2.types")   # app.models declares Geometry columns
     from app.models import IntegrationLink
 
     columns = {c.name for c in IntegrationLink.__table__.columns}
@@ -311,7 +312,7 @@ def test_deleting_clears_the_database_copy_too():
     ("config_fields", "agency_name"),
 ])
 def test_declared_fields_are_accepted(field_list, key):
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api.integrations import _allowed_keys, _reject_unknown_keys
 
     assert key in _allowed_keys("accela", field_list)
@@ -326,7 +327,7 @@ def test_an_undeclared_credential_field_cannot_name_a_vault_key():
     """`credentials` keys become Secret Manager key names
     (INTEGRATION_<PLATFORM>_<FIELD>), so an unvalidated dict let an admin write
     arbitrary entries into the namespace the platform itself reads from."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from fastapi import HTTPException
 
     from app.api.integrations import _reject_unknown_keys
@@ -340,7 +341,7 @@ def test_an_undeclared_credential_field_cannot_name_a_vault_key():
 def test_an_undeclared_setting_is_refused_rather_than_silently_ignored():
     """Config is a JSON blob the connectors read by key, so an unrecognised key
     is a setting the admin believes they set and nothing will ever read."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from fastapi import HTTPException
 
     from app.api.integrations import _reject_unknown_keys
@@ -352,7 +353,7 @@ def test_an_undeclared_setting_is_refused_rather_than_silently_ignored():
 def test_the_per_vendor_mapping_keys_the_connectors_read_are_still_accepted():
     """These are real settings an integrator sets deliberately; they are just
     not wizard fields. Rejecting them would break a working install."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api.integrations import _reject_unknown_keys
 
     _reject_unknown_keys("generic_rest", None, {
@@ -365,7 +366,7 @@ def test_vaulted_is_all_or_nothing_not_any():
     """A vault write that failed for one field falls back to keeping that value
     encrypted in this database. `any` reported the whole set as vaulted on the
     strength of the fields that succeeded -- a trust signal rounding up."""
-    pytest.importorskip("fastapi")
+    pytest.importorskip("fastapi.routing")
     from app.api.integrations import _vaulted_state
 
     assert _vaulted_state({}) == "none"

--- a/backend/tests/test_migrate.py
+++ b/backend/tests/test_migrate.py
@@ -35,6 +35,10 @@ import pytest
 # guard misses.
 def _needs_alembic():
     pytest.importorskip("alembic.script")
+    # Reading the chain executes every revision file, and the road-geometry
+    # revision imports geoalchemy2 at module level -- so alembic being present
+    # is not on its own enough to load the versions directory.
+    pytest.importorskip("geoalchemy2.types")
 
 from app.db.migrate import (
     ADDITIVE,

--- a/backend/tests/test_redaction_fallback.py
+++ b/backend/tests/test_redaction_fallback.py
@@ -127,6 +127,10 @@ def _rejecting():
 
 
 def _probe_png() -> bytes:
+    # The one-pixel probe lives in the API module next to the button that uses
+    # it, so getting hold of it drags in the web stack. The redaction logic
+    # under test does not need fastapi; only this fixture does.
+    pytest.importorskip("fastapi.routing")
     from app.api.system import _one_pixel_probe_image
     return _one_pixel_probe_image()
 
@@ -194,6 +198,7 @@ def test_the_test_button_asks_the_detector_rather_than_the_credential_store():
     make a real detection call, or it reports green on a lapsed subscription."""
     import inspect
 
+    pytest.importorskip("fastapi.routing")
     from app.api import system
 
     source = inspect.getsource(system._test_redaction)

--- a/backend/tests/test_secret_versions_do_not_accumulate.py
+++ b/backend/tests/test_secret_versions_do_not_accumulate.py
@@ -43,7 +43,21 @@ class _Client:
 PATH = "projects/p/secrets/secret-x"
 
 
+def _needs_google():
+    """`_prune_versions` imports google.api_core for the two exception types it
+    treats as success. With the client library absent that import fails inside
+    the function's own try/except, which logs and returns 0 -- so every test
+    below would pass while destroying nothing and proving nothing.
+
+    Guard on the submodule: google-* packages install into a `google/` namespace
+    package, so a bare importorskip("google") can succeed with none of the
+    libraries present.
+    """
+    pytest.importorskip("google.api_core")
+
+
 def test_it_keeps_the_newest_three_and_destroys_the_rest():
+    _needs_google()
     client = _Client(range(1, 44))          # v1..v43, like the real bundle
     sm._prune_versions(client, PATH)
     assert sorted(client.destroyed) == list(range(1, 41))
@@ -53,12 +67,14 @@ def test_it_keeps_the_newest_three_and_destroys_the_rest():
 def test_it_never_destroys_what_latest_points_to():
     """The one mistake here costs a live credential, so it is checked explicitly
     rather than inferred from the ordering."""
+    _needs_google()
     client = _Client(range(1, 10), latest=4)
     sm._prune_versions(client, PATH)
     assert 4 not in client.destroyed
 
 
 def test_nothing_to_do_when_there_are_only_a_few():
+    _needs_google()
     client = _Client([1, 2, 3])
     assert sm._prune_versions(client, PATH) == 0
     assert client.destroyed == []
@@ -66,6 +82,7 @@ def test_nothing_to_do_when_there_are_only_a_few():
 
 def test_a_version_already_gone_is_not_an_error():
     """Two writers pruning the same bundle is expected, not a failure."""
+    _needs_google()
     from google.api_core import exceptions as gexc
 
     client = _Client(range(1, 10))
@@ -80,6 +97,8 @@ def test_a_version_already_gone_is_not_an_error():
 def test_pruning_failure_never_fails_the_write():
     """The credential is already stored by the time this runs. Reporting failure
     because cleanup stumbled would turn a billing tidy-up into a lost secret."""
+    _needs_google()
+
     class _Broken:
         def list_secret_versions(self, request):
             raise RuntimeError("permission denied")


### PR DESCRIPTION
## Commits

- `3705a9d` test(ci): guard the minimal-env imports so backend-tests can go green